### PR TITLE
(#4) add .travis.yml using mac os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+os: osx
+language: c
+
+install:
+  - mkdir bin
+  - mkdir rgl
+  - curl http://www.grammaticalframework.org/download/gf-3.9-bin-intel-mac.tar.gz > gf.tar.gz
+  - tar -C bin -zxf gf.tar.gz
+
+script:
+  - sh Make.sh --gf=./bin/gf --dest=./rgl


### PR DESCRIPTION
closes #4.

as an ubuntu user, I'm ashamed that I had to use macOS for the build, because travis' ubuntu version is only 14.04, which does not have the appropriate version of `libtinfo5` (not even in backports!).