### PR TITLE
use docker for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - mkdir rgl
 
 script:
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; sh Make.sh --dest=rgl ;"
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build --langs=-Mon --dest=rgl ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; runghc Make.hs build --langs=-Mon --dest=rgl ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl ;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - mkdir rgl
 
 script:
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build all --verbose ;"
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl --verbose ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl ; runghc Make.hs build all --verbose ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl --verbose ;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - mkdir rgl
 
 script:
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl ; runghc Make.hs build all --verbose ;"
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl --verbose ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl ; runghc Make.hs build prelude all --verbose ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/bash -c "cd /home/; export GF_LIB_PATH=/home/rgl; bash Make.sh --dest=rgl --verbose ;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-os: osx
+sudo: required
+
 language: c
 
-install:
-  - mkdir bin
+services:
+  - docker
+
+before_install:
+  - docker pull odanoburu/haskell-gf:3.9
   - mkdir rgl
-  - curl http://www.grammaticalframework.org/download/gf-3.9-bin-intel-mac.tar.gz > gf.tar.gz
-  - tar -C bin -zxf gf.tar.gz
 
 script:
-  - sh Make.sh --gf=./bin/gf --dest=./rgl
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build --langs=-Mon --dest=rgl ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; sh Make.sh --dest=rgl ;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - mkdir rgl
 
 script:
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build --langs=-Mon --dest=rgl ;"
   - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; sh Make.sh --dest=rgl ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build --langs=-Mon --dest=rgl ;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - mkdir rgl
 
 script:
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; runghc Make.hs build --langs=-Mon --dest=rgl ;"
-  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; runghc Make.hs build all --verbose ;"
+  - docker run --mount src="$(pwd)",target=/home,type=bind odanoburu/haskell-gf:3.9 /bin/sh -c "cd /home/; export GF_LIB_PATH=/home/rgl; sh Make.sh --dest=rgl --verbose ;"


### PR DESCRIPTION
using dockerfile in https://github.com/odanoburu/docker-gf/blob/master/haskell-gf/Dockerfile

basically, this takes the standard haskell docker image, installs gf using the .deb file, and then runs the `Make.sh` and `Make.hs` scripts.

1. there seems to exist a missing file in the mongolian language, which is why I excluded it.
2. I've tested it again, and `Make.hs` will fail the build when there are errors, but `Make.sh` won't; apparently we have to change it to exit with non-zero codes when its calls to gf go awry.
3. two days ago I've helped someone build GF on their computer, and the haskell script failed, while the shell one worked fine. the same happens in docker, unless I build with shell script first. I suspect it is a problem in the script: running `GF_LIB_PATH=/home/rgl runghc Make.hs build --langs=-Mon --dest=rgl` with a clean gf-rgl directory (removing the dist/ directory) throws an error, while using the usual GF_LIB_PATH works fine.

I don't think this should be merged until we figure out what seems to be a problem in Make.hs. can you reproduce the error in 3.? 