### PR TITLE
(Ger) fix old spellings of irregular verbs

### DIFF
--- a/src/german/IrregGer.gf
+++ b/src/german/IrregGer.gf
@@ -13,9 +13,9 @@ in {
 
   lin backen_V =  irregV "backen" "bäckt" "backt" "backt" "gebacken" ;
   lin backen_u_V =  irregV "backen" "bäckt" "buk" "buke" "gebacken" ;
-  lin befehlen_V =  irregV "befehlen" "befiehlt" "befahl" "beföhle" "befähle)" ;
-  lin beginnen_V =  irregV "beginnen" "beginnt" "begann" "begönne" "begänne)" ;
-  lin beißen_V =  irregV "beißen" "beißt" "biß" "bisse" "gebissen" ;
+  lin befehlen_V =  irregV "befehlen" "befiehlt" "befahl" "beföhle" "befähle" ;
+  lin beginnen_V =  irregV "beginnen" "beginnt" "begann" "begönne" "begänne" ;
+  lin beißen_V =  irregV "beißen" "beißt" "biss" "bisse" "gebissen" ;
   lin bergen_V =  irregV "bergen" "birgt" "barg" "bärge" "geborgen" ;
   lin bersten_V =  irregV "bersten" "birst" "barst" "bärste" "geborsten" ;
   lin bewegen_V =  irregV "bewegen" "bewegt" "bewog" "bewöge" "bewogen" ;
@@ -23,7 +23,7 @@ in {
   lin bieten_V =  irregV "bieten" "bietet" "bot" "böte" "geboten" ;
   lin binden_V =  irregV "binden" "bindet" "band" "bände" "gebunden" ;
   lin bitten_V =  irregV "bitten" "bittet" "bat" "bäte" "gebeten" ;
-  lin blasen_V =  irregV "blasen" "bläst" "blies" "bliese" "geblasen" ;
+  lin blasen_V =  irregV "blasen" "bläst" "blies" "bliese" "geblasen" ; 
   lin bleiben_V =  irregV "bleiben" "bleibt" "blieb" "bliebe" "geblieben" ;
   lin braten_V =  irregV "braten" "brät" "briet" "briete" "gebraten" ;
   lin brechen_V =  irregV "brechen" "bricht" "brach" "bräche" "gebrochen" ;
@@ -52,8 +52,8 @@ in {
   lin flechten_V =  irregV "flechten" "flicht" "flocht" "flöchte" "geflochten" ;
   lin fliegen_V =  irregV "fliegen" "fliegt" "flog" "flöge" "geflogen" ;
   lin fliehen_V =  irregV "fliehen" "flieht" "floh" "flöhe" "geflohen" ;
-  lin fließen_V =  irregV "fließen" "fließt" "floß" "flösse" "geflossen" ;
-  lin fressen_V =  irregV "fressen" "frißt" "fraß" "fräße" "gefressen" ;
+  lin fließen_V =  irregV "fließen" "fließt" "floss" "flösse" "geflossen" ;
+  lin fressen_V =  irregV "fressen" "frisst" "fraß" "fräße" "gefressen" ;
   lin frieren_V =  irregV "frieren" "friert" "fror" "fröre" "gefroren" ;
   lin gären_V =  irregV "gären" "gärt" "gärte" "göre" "gegoren" ;
   lin gären_o_V =  irregV "gären" "gärt" "gor" "göre" "gegoren" ;
@@ -65,11 +65,11 @@ in {
   lin gelten_V =  irregV "gelten" "gilt" "galt" "galte" "gegolten" ;
   lin gelten_o_V =  irregV "gelten" "gilt" "galt" "golte" "gegolten" ;
   lin genesen_V =  irregV "genesen" "genest" "genas" "genäse" "genesen" ;
-  lin genießen_V =  irregV "genießen" "genießt" "genoß" "genösse" "genossen" ;
+  lin genießen_V =  irregV "genießen" "genießt" "genoss" "genösse" "genossen" ;
   lin geschehen_V =  irregV "geschehen" "geschieht" "geschah" "geschehen" "geschähe" ;
   lin gewinnen_V =  irregV "gewinnen" "gewinnt" "gewann" "gewänne" "gewonnen" ;
   lin gewinnen_o_V =  irregV "gewinnen" "gewinnt" "gewann" "gewönne" "gewonnen" ;
-  lin gießen_V =  irregV "gießen" "gießt" "goß" "gösse" "gegossen" ;
+  lin gießen_V =  irregV "gießen" "gießt" "goss" "gösse" "gegossen" ;
   lin gleichen_V =  irregV "gleichen" "gleicht" "glich" "gliche" "geglichen" ;
   lin gleiten_V =  irregV "gleiten" "gleitet" "glitt" "glitte" "geglitten" ;
   lin glimmen_V =  irregV "glimmen" "glimmt" "glomm" "glimmte" "glömme" ;
@@ -94,7 +94,7 @@ in {
   lin kriechen_V =  irregV "kriechen" "kriecht" "kroch" "kröche" "gekrochen" ;
   lin küren_V =  irregV "küren" "kürt" "kürte" "kor" "gekürt" ;
   lin laden_V =  irregV "laden" "lädt" "lud" "lüde" "geladen" ;
-  lin lassen_V =  irregV "lassen" "läßt" "ließ" "ließe" "gelassen" ;
+  lin lassen_V =  irregV "lassen" "lässt" "ließ" "ließe" "gelassen" ;
   lin laufen_V =  irregV "laufen" "läuft" "lief" "liefe" "gelaufen" ;
   lin leiden_V =  irregV "leiden" "leidt" "litt" "litte" "gelitten" ;
   lin leihen_V =  irregV "leihen" "leiht" "lieh" "liehe" "geliehen" ;
@@ -104,14 +104,15 @@ in {
   lin mahlen_V =  irregV "mahlen" "mahlt" "mahlte" "mahlte" "gemahlen" ;
   lin meiden_V =  irregV "meiden" "meidt" "mied" "miede" "gemieden" ;
   lin melken_V =  irregV "melken" "milkt" "molk" "mölke" "gemolken" ;
-  lin messen_V =  irregV "messen" "mißt" "maß" "mäße" "gemessen" ;
-  lin mißlingen_V =  irregV "mißlingen" "mißlingt" "mißlang" "mißlungen" "mißlänge" ;
+  lin messen_V =  irregV "messen" "misst" "maß" "mäße" "gemessen" ;
+  lin mißlingen_V =  irregV "misslingen" "misslingt" "misslang" "misslungen" "misslänge" ;  -- old spelling
+  lin misslingen_V =  irregV "misslingen" "misslingt" "misslang" "misslungen" "misslänge" ;
   lin mögen_V =  lin V (M.mkV "mögen" "mag" "magst" "mag" "mögt" "mög" 
                           "mochte" "mochtest" "mochten" "mochtet"
                           "möchte" "gemocht" [] M.VHaben) ;
-  lin müssen_V = lin V (M.mkV "müssen" "muß" "mußt" "muß" "müßt" "müß" 
-                          "mußte" "mußtest" "mußten" "mußtet"
-                          "müßte" "gemußt" [] M.VHaben) ;
+  lin müssen_V = lin V (M.mkV "müssen" "muss" "musst" "muss" "müsst" "müss" 
+                          "musste" "musstest" "mussten" "musstet"
+                          "müsste" "gemusst" [] M.VHaben) ;
   lin nehmen_V = mk6V "nehmen" "nimmt" "nimm" "nahm" "nähme" "genommen" ;
   lin nennen_V =  irregV "nennen" "nennt" "nannte" "nennte" "genannt" ;
   lin pfeifen_V =  irregV "pfeifen" "pfeift" "pfiff" "pfiffe" "gepfiffen" ;
@@ -119,7 +120,7 @@ in {
   lin quellen_V =  irregV "quellen" "quillt" "quoll" "quölle" "gequollen" ;
   lin raten_V =  irregV "raten" "rät" "riet" "riete" "geraten" ;
   lin reiben_V =  irregV "reiben" "reibt" "rieb" "riebe" "gerieben" ;
-  lin reißen_V =  irregV "reißen" "reißt" "riß" "riße" "gerissen" ;
+  lin reißen_V =  irregV "reißen" "reißt" "riss" "risse" "gerissen" ;
   lin reiten_V =  irregV "reiten" "reitet" "ritt" "ritte" "geritten" ;
   lin rennen_V =  irregV "rennen" "rennt" "rannte" "rennte" "gerannt" ;
   lin riechen_V =  irregV "riechen" "riecht" "roch" "röche" "gerochen" ;
@@ -132,20 +133,20 @@ in {
   lin schaffen_V =  irregV "schaffen" "schafft" "schuf" "schüfe" "geschaffen" ;
   lin scheiden_V =  irregV "scheiden" "scheidt" "schied" "schiede" "geschieden" ;
   lin scheinen_V =  irregV "scheinen" "scheint" "schien" "schiene" "geschienen" ;
-  lin scheißen_V =  irregV "scheißen" "scheißt" "schiß" "schiße" "geschissen" ;
+  lin scheißen_V =  irregV "scheißen" "scheißt" "schiss" "schisse" "geschissen" ;
   lin schelten_V =  irregV "schelten" "schilt" "schalt" "schölte" "gescholten" ;
   lin scheren_V =  irregV "scheren" "schert" "schor" "schöre" "geschoren" ;
   lin schieben_V =  irregV "schieben" "schiebt" "schob" "schöbe" "geschoben" ;
-  lin schießen_V =  irregV "schießen" "schießt" "schoß" "schösse" "geschossen" ;
+  lin schießen_V =  irregV "schießen" "schießt" "schoss" "schösse" "geschossen" ;
   lin schinden_V =  irregV "schinden" "schindt" "schund" "schunde" "geschunden" ;
   lin schlafen_V =  irregV "schlafen" "schläft" "schlief" "schliefe" "geschlafen" ;
   lin schlagen_V =  irregV "schlagen" "schlägt" "schlug" "schlüge" "geschlagen" ;
   lin schleichen_V =  irregV "schleichen" "schleicht" "schlich" "schliche" "geschlichen" ;
   lin schleifen_V =  irregV "schleifen" "schleift" "schliff" "schliffe" "geschliffen" ;
-  lin schleißen_V =  irregV "schleißen" "schleißt" "schliß" "schliß" "geschlissen" ;
-  lin schließen_V =  irregV "schließen" "schließt" "schloß" "schlösse" "geschlossen" ;
+  lin schleißen_V =  irregV "schleißen" "schleißt" "schliss" "schliss" "geschlissen" ;
+  lin schließen_V =  irregV "schließen" "schließt" "schloss" "schlösse" "geschlossen" ;
   lin schlingen_V =  irregV "schlingen" "schlingt" "schlang" "schlünge" "geschlungen" ;
-  lin schmeißen_V =  irregV "schmeißen" "schmeißt" "schmiß" "schmiße" "geschmissen" ;
+  lin schmeißen_V =  irregV "schmeißen" "schmeißt" "schmiss" "schmisse" "geschmissen" ;
   lin schmelzen_V =  irregV "schmelzen" "schmilzt" "schmolz" "schmölze" "geschmolzen" ;
   lin schneiden_V =  irregV "schneiden" "schneidet" "schnitt" "schnitte" "geschnitten" ;
   lin schreiben_V =  irregV "schreiben" "schreibt" "schrieb" "schriebe" "geschrieben" ;
@@ -173,9 +174,9 @@ in {
   lin speien_V =  irregV "speien" "speit" "spie" "spie" "gespien" ;
   lin spinnen_V =  irregV "spinnen" "spinnt" "spann" "spänne" "gesponnen" ;
   lin spinnen_o_V =  irregV "spinnen" "spinnt" "spann" "spönne" "gesponnen" ;
-  lin spleißen_V =  irregV "spleißen" "spleißt" "spliß" "spliße" "gesplissen" ;
+  lin spleißen_V =  irregV "spleißen" "spleißt" "spliss" "splisse" "gesplissen" ;
   lin sprechen_V =  irregV "sprechen" "spricht" "sprach" "spräche" "gesprochen" ;
-  lin sprießen_V =  irregV "sprießen" "sprießt" "sproß" "sprösse" "gesprossen" ;
+  lin sprießen_V =  irregV "sprießen" "sprießt" "spross" "sprösse" "gesprossen" ;
   lin springen_V =  irregV "springen" "springt" "sprang" "spränge" "gesprungen" ;
   lin stechen_V =  irregV "stechen" "sticht" "stach" "stäche" "gestochen" ;
   lin stehen_V =  irregV "stehen" "steht" "stand" "stände" "gestanden" ;
@@ -200,7 +201,7 @@ in {
                        "tat" "tatest" "taten" "tatet"
                        "täte" "getan" [] M.VHaben) ;
   lin verderben_V =  irregV "verderben" "verdirbt" "verdarb" "verdarbe" "verdorben" ;
-  lin vergessen_V =  irregV "vergessen" "vergißt" "vergaß" "vergäße" "vergessen" ;
+  lin vergessen_V =  irregV "vergessen" "vergisst" "vergaß" "vergäße" "vergessen" ;
   lin verlieren_V =  irregV "verlieren" "verliert" "verlor" "verlöre" "verloren" ;
   lin wachsen_V =  irregV "wachsen" "wächst" "wuchs" "wüchse" "gewachsen" ;
   lin wägen_V =  irregV "wägen" "wägt" "wog" "woge" "gewogen" ;
@@ -229,4 +230,28 @@ in {
   lin ziehen_V =  irregV "ziehen" "zieht" "zog" "zöge" "gezogen" ;
   lin zwingen_V =  irregV "zwingen" "zwingt" "zwang" "zwänge" "gezwungen" ;
 
+
+-- old spellings, before the German orthography reform
+-- see https://en.wikipedia.org/wiki/German_orthography_reform_of_1996
+
+  lin beißen_old_V =  irregV "beißen" "beißt" "biß" "bisse" "gebissen" ;
+  lin fließen_old_V =  irregV "fließen" "fließt" "floß" "flösse" "geflossen" ;
+  lin fressen_old_V =  irregV "fressen" "frißt" "fraß" "fräße" "gefressen" ;
+  lin genießen_old_V =  irregV "genießen" "genießt" "genoß" "genösse" "genossen" ;
+  lin gießen_old_V =  irregV "gießen" "gießt" "goß" "gösse" "gegossen" ;
+  lin lassen_old_V =  irregV "lassen" "läßt" "ließ" "ließe" "gelassen" ;
+  lin messen_old_V =  irregV "messen" "mißt" "maß" "mäße" "gemessen" ;
+  lin mißlingen_old_V =  irregV "mißlingen" "mißlingt" "mißlang" "mißlungen" "mißlänge" ;
+  lin müssen_old_V = lin V (M.mkV "müssen" "muß" "mußt" "muß" "müßt" "müß" 
+                          "mußte" "mußtest" "mußten" "mußtet"
+                          "müßte" "gemußt" [] M.VHaben) ;
+  lin reißen_old_V =  irregV "reißen" "reißt" "riß" "riße" "gerissen" ;
+  lin scheißen_old_V =  irregV "scheißen" "scheißt" "schiß" "schiße" "geschissen" ;
+  lin schießen_old_V =  irregV "schießen" "schießt" "schoß" "schösse" "geschossen" ;
+  lin schleißen_old_V =  irregV "schleißen" "schleißt" "schliß" "schliß" "geschlissen" ;
+  lin schließen_old_V =  irregV "schließen" "schließt" "schloß" "schlösse" "geschlossen" ;
+  lin schmeißen_old_V =  irregV "schmeißen" "schmeißt" "schmiß" "schmiße" "geschmissen" ;
+  lin spleißen_old_V =  irregV "spleißen" "spleißt" "spliß" "spliße" "gesplissen" ;
+  lin sprießen_old_V =  irregV "sprießen" "sprießt" "sproß" "sprösse" "gesprossen" ;
+  lin vergessen_old_V =  irregV "vergessen" "vergißt" "vergaß" "vergäße" "vergessen" ;
 }

--- a/src/german/IrregGerAbs.gf
+++ b/src/german/IrregGerAbs.gf
@@ -89,7 +89,8 @@ abstract IrregGerAbs = Cat ** {
   fun meiden_V : V ;
   fun melken_V : V ;
   fun messen_V : V ;
-  fun mißlingen_V : V ;
+  fun mißlingen_V : V ;  -- old spelling
+  fun misslingen_V : V ;
   fun mögen_V : V ;
   fun müssen_V : V ;
   fun nehmen_V : V ;
@@ -193,4 +194,27 @@ abstract IrregGerAbs = Cat ** {
   fun zeihen_V : V ;
   fun ziehen_V : V ;
   fun zwingen_V : V ;
+
+
+-- old spellings, before the German orthography reform
+-- see https://en.wikipedia.org/wiki/German_orthography_reform_of_1996
+
+  fun beißen_old_V : V ;
+  fun fließen_old_V : V ;
+  fun fressen_old_V : V ;
+  fun genießen_old_V : V ;
+  fun gießen_old_V : V ;
+  fun lassen_old_V : V ;
+  fun messen_old_V : V ;
+  fun mißlingen_old_V : V ;
+  fun müssen_old_V : V ;
+  fun reißen_old_V : V ;
+  fun scheißen_old_V : V ;
+  fun schießen_old_V : V ;
+  fun schleißen_old_V : V ;
+  fun schließen_old_V : V ;
+  fun schmeißen_old_V : V ;
+  fun spleißen_old_V : V ;
+  fun sprießen_old_V : V ;
+  fun vergessen_old_V : V ;
 }


### PR DESCRIPTION
Updated the spelling of irregular German verbs (the rules have changed, see [https://en.wikipedia.org/wiki/German_orthography_reform_of_1996](https://en.wikipedia.org/wiki/German_orthography_reform_of_1996)).

The old spellings are kept at the end of the file.