### PR TITLE
(Romance) add copTyp to adjectives

### DIFF
--- a/src/catalan/LexiconCat.gf
+++ b/src/catalan/LexiconCat.gf
@@ -1,7 +1,7 @@
 --# -path=.:../romance:../common:../abstract:../../prelude
 
 concrete LexiconCat of Lexicon = CatCat ** open
-  (M=MorphoCat), ParadigmsCat, BeschCat in {
+  (M=MorphoCat), ParadigmsCat, BeschCat, (D = DiffCat) in {
 
 flags
   coding=utf8 ;
@@ -361,7 +361,7 @@ lin
   language_N = mkN "llengua" ; -- llengües
   rule_N = regFN "regla" ;
   question_N = regFN "pregunta" ;
-  ready_A = regA "preparat" ;
+  ready_A = adjCopula (regA "preparat") D.estarCopula ;
   reason_N = regFN "raó" ;
   uncertain_A = regA "incert" ;
 

--- a/src/catalan/ParadigmsCat.gf
+++ b/src/catalan/ParadigmsCat.gf
@@ -154,7 +154,10 @@ oper
 -- In the worst case, two separate adjectives are given:
 -- the positive ("bo"), and the comparative ("millor").
 
-    mkA : (bo : A) -> (millor : A) -> A -- special comparison (default with "mas")
+    mkA : (bo : A) -> (millor : A) -> A ; -- special comparison (default with "mas")
+
+    mkA : A -> CopulaType -> A -- force copula type
+      
     } ;
 
 -- The functions above create postfix adjectives. To switch
@@ -164,6 +167,7 @@ oper
 -- JS: What about vi bo -> bon vi ?
 
   prefixA : A -> A ; -- adjective before noun (default: after)
+  adjCopula : A -> CopulaType -> A ; -- force copula type
 
 
 --3 Two-place adjectives
@@ -324,23 +328,23 @@ oper
   makeNP x g n = {s = (pn2np (mk2PN x g)).s; a = agrP3 g n ; hasClit = False ; isPol = False ; isNeg = False} ** {lock_NP = <>} ;
 
   mk5A a b c d e =
-   compADeg {s = \\_ => (mkAdj a b c d e).s ; isPre = False ; lock_A = <>} ;
-  mk2A a b = compADeg {s = \\_ => (mkAdj2Reg a b).s ; isPre = False ; lock_A = <>} ;
-  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; lock_A = <>} ;
+    compADeg {s = \\_ => (mkAdj a b c d e).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  mk2A a b = compADeg {s = \\_ => (mkAdj2Reg a b).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
   prefA = overload {
     prefA : A -> A = \a -> a ** {isPre = True} ;
     prefA : Str -> Str -> A = \bo,bon ->
-        compADeg (lin A {s = \\_ => (adjBo bo bon).s ; isPre = True}) ;
+        compADeg (lin A {s = \\_ => (adjBo bo bon).s ; isPre = True ; copTyp = serCopula}) ;
   } ;
 
   mkA2 a p = a ** {c2 = p ; lock_A2 = <>} ;
 
   mkADeg a b =
    {s = table {Posit => a.s ! Posit ; _ => b.s ! Posit} ;
-    isPre = a.isPre ; lock_A = <>} ;
+    isPre = a.isPre ; copTyp = serCopula ; lock_A = <>} ;
   compADeg a =
     {s = table {Posit => a.s ! Posit ; _ => \\f => "més" ++ a.s ! Posit ! f} ;
-     isPre = a.isPre ;
+     isPre = a.isPre ; copTyp = a.copTyp ; 
      lock_A = <>} ;
   regADeg a = compADeg (regA a) ;
 
@@ -500,6 +504,7 @@ oper
     mkA : (lleig,lletja : Str) -> A = mk2A ;
     mkA : (fort,forta,forts,fortes,fortament : Str) -> A = mk5A ;
     mkA : (bo : A) -> (millor : A) -> A = mkADeg ;
+    mkA : A -> CopulaType -> A = adjCopula ;
     } ;
 
   mk5A : (fort,forta,forts,fortes,fortament : Str) -> A ;
@@ -513,6 +518,7 @@ oper
     prefA : (bo,bon : Str) -> A -- predicative masc, attributive masc
     } ;
   prefixA = prefA ;
+  adjCopula a cop = a ** {copTyp = cop} ;
 
   mkV = overload {
     mkV : (cantar : Str) -> V            = \x -> verbV (regV x) ;

--- a/src/french/ParadigmsFre.gf
+++ b/src/french/ParadigmsFre.gf
@@ -171,7 +171,10 @@ oper
 -- "bon-meilleur"), the positive and comparative can be given as separate
 -- adjectives.
 
-    mkA : A -> A -> A -- irregular comparison, e.g. bon-meilleur
+    mkA : A -> A -> A ; -- irregular comparison, e.g. bon-meilleur
+
+    mkA : A -> CopulaType -> A -- force copula type
+      
   } ;
 
 -- The functions create by default postfix adjectives. To switch
@@ -391,9 +394,10 @@ oper
     } ;
 
   mk4A a b c d = mk5A a a b c d ;
-  mk5A a b c d e = compADeg {s = \\_ => (mkAdj' a b c d e).s ; isPre = False ; lock_A = <>} ;
-  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; lock_A = <>} ;
-  prefA a = {s = a.s ; isPre = True ; lock_A = <>} ;
+  mk5A a b c d e = compADeg {s = \\_ => (mkAdj' a b c d e).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  prefA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
+  adjCopula a cop = a ** {copTyp = cop} ;
 
   mkA2 a p = a ** {c2 = p ; lock_A2 = <>} ;
 
@@ -403,10 +407,11 @@ oper
     mkA : (banal,banale,banaux : Str) -> A = \sec,seche,secs -> mk4A sec seche secs (seche + "ment") ; 
     mkA : (banal,banale,banaux,banalement : Str) -> A = mk4A ;
     mkA : (vieux,vieil,vieille,vieuxs,vieuxment : Str) -> A = mk5A ;
-    mkA : A -> A -> A = mkADeg
+    mkA : A -> A -> A = mkADeg ;
+    mkA : A -> CopulaType -> A = adjCopula ;
   };
 
-  prefixA a = {s = a.s ; isPre = True ; lock_A = <>} ;
+  prefixA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
 
   mkAdv x = ss x ** {lock_Adv = <>} ;
   mkAdV x = ss x ** {lock_AdV = <>} ;
@@ -479,14 +484,15 @@ oper
   mk5A : (vieux,vieil,vieille,vieuxs,vieuxment : Str) -> A ; -- worst-case adjetive
 
   prefA : A -> A ;
+  adjCopula : A -> CopulaType -> A ;
 
   mkADeg a b = 
-    {s = table {Posit => a.s ! Posit ; _ => b.s ! Posit} ; isPre = a.isPre ; lock_A = <>} ;
+    {s = table {Posit => a.s ! Posit ; _ => b.s ! Posit} ; isPre = a.isPre ; copTyp = a.copTyp ; lock_A = <>} ;
   compADeg a = 
     {s = table {Posit => a.s ! Posit ; _ => \\f => "plus" ++ a.s ! Posit ! f} ; 
      isPre = a.isPre ;
+     copTyp = a.copTyp ;
      lock_A = <>} ;
-  prefA a = {s = a.s ; isPre = True ; lock_A = <>} ;
 
   mkV = overload {
     mkV : Str -> V = regV ;

--- a/src/italian/ParadigmsIta.gf
+++ b/src/italian/ParadigmsIta.gf
@@ -165,7 +165,9 @@ oper
 -- With irregular comparison, there are as it were two adjectives:
 -- the positive ("buono") and the comparative ("migliore"). 
 
-    mkA : A -> A -> A -- special comparison, e.g. buono - migliore
+    mkA : A -> A -> A ; -- special comparison, e.g. buono - migliore
+
+    mkA : A -> CopulaType -> A -- force copula type
     } ;
 
 -- All the functions above create postfix adjectives. To switch
@@ -367,18 +369,19 @@ oper
   makeNP x g n = {s = (pn2np (mk2PN x g)).s; a = agrP3 g n ; hasClit = False ; isPol = False ; isNeg = False} ** {lock_NP = <>} ;
 
   mk5A a b c d e = 
-   compADeg {s = \\_ => (mkAdj a b c d e).s ; isPre = False ; lock_A = <>} ;
-  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; lock_A = <>} ;
-  prefA a = {s = a.s ; isPre = True ; lock_A = <>} ;
+   compADeg {s = \\_ => (mkAdj a b c d e).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  prefA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
+  adjCopula a cop = a ** {copTyp = cop} ;
 
   mkA2 a p = a ** {c2 = p ; lock_A2 = <>} ;
 
   mkADeg a b = 
    {s = table {Posit => a.s ! Posit ; _ => b.s ! Posit} ; 
-    isPre = a.isPre ; lock_A = <>} ;
+    isPre = a.isPre ; copTyp = serCopula ; lock_A = <>} ;
   compADeg a = 
     {s = table {Posit => a.s ! Posit ; _ => \\f => "più" ++ a.s ! Posit ! f} ; 
-     isPre = a.isPre ;
+     isPre = a.isPre ; copTyp = a.copTyp ;
      lock_A = <>} ;
   regADeg a = compADeg (regA a) ;
 
@@ -510,11 +513,13 @@ oper
   mkA = overload {
     mkA : (bianco : Str) -> A = regA ;
     mkA : (solo,sola,soli,sole, solamente : Str) -> A = mk5A ;
-    mkA : A -> A -> A = mkADeg
+    mkA : A -> A -> A = mkADeg ;
+    mkA : A -> CopulaType -> A = adjCopula ;
     } ;
   mk5A : (solo,sola,soli,sole, solamente : Str) -> A ;
   regA : Str -> A ;
   prefA : A -> A ;
+  adjCopula : A -> CopulaType -> A ;
   mkADeg : A -> A -> A ;
   compADeg : A -> A ;
   regADeg : Str -> A ;

--- a/src/portuguese/ExtendPor.gf
+++ b/src/portuguese/ExtendPor.gf
@@ -142,7 +142,8 @@ concrete ExtendPor of Extend =
   lin
     PresPartAP vp = {
       s = \\af => gerVP vp (aform2aagr af ** {p = P3}) ;
-      isPre = False
+      isPre = False ;
+      copTyp = serCopula
       } ;
 
     PastPartAP vps = pastPartAP vps [] ;
@@ -178,7 +179,8 @@ concrete ExtendPor of Extend =
     pastPartAP : VPSlash -> Str -> AP ;
     pastPartAP vps agent = lin AP {
       s = \\af => vps.comp ! (aform2aagr af ** {p = P3}) ++ vps.s.s ! VPart (aform2gender af) (aform2number af) ++ agent ;
-      isPre = False
+      isPre = False ;
+      copTyp = serCopula
       } ;
 
     passVPSlash : VPSlash -> Str -> VP ;
@@ -203,7 +205,8 @@ concrete ExtendPor of Extend =
       s = \\af => case (aform2aagr af) of {
         {n = n} => adj.s ! Posit ! (genNum2Aform noun.g n) ++ "de" ++ noun.s ! n
         } ;
-      isPre = adj.isPre
+      isPre = adj.isPre ;
+      copTyp = adj.copTyp
       } ;
 
     GerundCN vp = {

--- a/src/portuguese/LexiconPor.gf
+++ b/src/portuguese/LexiconPor.gf
@@ -1,7 +1,7 @@
 --# -path=.:../romance:../common:../abstract:../../prelude
 
 concrete LexiconPor of Lexicon = CatPor ** open
-  (M=MorphoPor), ParadigmsPor, BeschPor, Prelude in {
+  (M=MorphoPor), ParadigmsPor, BeschPor, Prelude, (D = DiffPor) in {
 
 flags
   optimize=values ;
@@ -39,7 +39,7 @@ lin
    near_A      = mkA "perto" ;
    new_A       = prefA (mkA "novo") ;
    old_A       = prefA (mkA "velho") ;
-   ready_A     = mkA "pronto" ;
+   ready_A     = adjCopula (mkA "pronto") D.estarCopula ;
    red_A       = mkA "vermelho" ;
    rotten_A    = mkA "podre" ;
    round_A     = mkA "redondo" ;

--- a/src/portuguese/ParadigmsPor.gf
+++ b/src/portuguese/ParadigmsPor.gf
@@ -184,10 +184,14 @@ oper
 
 --2 Adjectives
   compADeg : A -> A ;
-  compADeg a = {s = table {Posit => a.s ! Posit ;
-                           _ => \\f => "mais" ++
-                             a.s ! Posit ! f} ;
-                isPre = a.isPre ; lock_A = <>} ;
+  compADeg a = lin A {
+    s = table {
+      Posit => a.s ! Posit ;
+      _ => \\f => "mais" ++  a.s ! Posit ! f
+      } ;
+    isPre = a.isPre ;
+    copTyp = a.copTyp
+    } ;
 
 {-  superlADeg : A -> A ;
   superlADeg a = {s = table {Posit => a.s ! Posit ;
@@ -200,24 +204,32 @@ oper
 --  regADeg a = compADeg (regA a) ;
 
   regA : Str -> A ;
-  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ;
-                     lock_A = <>} ;
+  regA a = compADeg (lin A {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula}) ;
 
   mk2A : (único,unicamente : Str) -> A ;
   mk2A adj adv = compADeg {s = \\_ => (mkAdj2 adj adv).s ; isPre = False ;
+                           copTyp = serCopula ;
                            lock_A = <>} ;
 
   mk5A : (preto,preta,pretos,pretas,pretamente : Str) -> A ;
   mk5A a b c d e = compADeg {s = \\_ => (mkAdj a b c d e).s ;
-                             isPre = False ; lock_A = <>} ;
+                             isPre = False ; copTyp = serCopula ;
+                             lock_A = <>} ;
+
+  adjCopula : A -> CopulaType -> A ;
+  adjCopula a cop = a ** {copTyp = cop} ;
 
   mkADeg : A -> A -> A ;
-  mkADeg a b = {s = table {Posit => a.s ! Posit ;
-                           _ => b.s ! Posit
---                          Compar => b.s ! Posit ;
---                           Superl => "o" ++ b.s ! Posit ;
-                  } ;
-                isPre = a.isPre ; lock_A = <>} ;
+  mkADeg a b = lin A {
+    s = table {
+      Posit => a.s ! Posit ;
+      _ => b.s ! Posit
+        -- Compar => b.s ! Posit ;
+        -- Superl => "o" ++ b.s ! Posit ;
+      } ;
+    isPre = a.isPre ;
+    copTyp = a.copTyp
+    } ;
 
   mkNonInflectA : A -> Str -> A ;
   mkNonInflectA = \blanco,hueso -> blanco ** {s = \\x,y => blanco.s ! x ! y ++ hueso } ;
@@ -245,7 +257,10 @@ oper
       = mkADeg ;
 
     mkA : (blanco : A) -> (hueso : Str) -> A  -- noninflecting component after the adjective
-    = mkNonInflectA ;
+      = mkNonInflectA ;
+
+    mkA : A -> CopulaType -> A -- force copula type
+      = adjCopula ;
     } ;
 
 -- The functions above create postfix adjectives. To switch them to
@@ -256,7 +271,7 @@ oper
     prefixA = prefA ;
 
     prefA : A -> A ;
-    prefA a = {s = a.s ; isPre = True ; lock_A = <>} ;
+    prefA a = lin A {s = a.s ; isPre = True ; copTyp = a.copTyp} ;
 
 --3 Two-place adjectives
 --
@@ -320,7 +335,7 @@ oper
         "or" | "ôr" => pôr_Besch ;
         _ => comprar_Besch -- hole
         }
-    in verboV (paradigm v) ;
+    in lin V (verboV (paradigm v)) ;
 
   mkV = overload {
 --- [ ] update
@@ -345,8 +360,8 @@ oper
 -- "Bescherelle" book. To use them in the category $V$, wrap them with
 -- the function
 
-    mkV : Verbum -> V = -- import verb constructed with BeschPor
-      verboV ;
+    mkV : Verbum -> V = \v -> -- import verb constructed with BeschPor
+      lin V (verboV v) ;
 
     -- particle verb
     mkV : V -> Str -> V =
@@ -516,6 +531,6 @@ oper
                   isPol = False ;
                   isNeg = False} ** {lock_NP = <>} ;
 
-  reflVerboV : Verbum -> V = \ve -> reflV (verboV ve) ;
+  reflVerboV : Verbum -> V = \ve -> reflV (lin V (verboV ve)) ;
 
 } ;

--- a/src/romance/AdjectiveRomance.gf
+++ b/src/romance/AdjectiveRomance.gf
@@ -3,59 +3,70 @@ incomplete concrete AdjectiveRomance of Adjective =
   flags coding=utf8;
   lin
 
-    PositA  a = {
+    PositA a = {
       s = a.s ! Posit ;
-      isPre = a.isPre
+      isPre = a.isPre ;
+      copTyp = a.copTyp        
       } ;
     ComparA a np = {
       s = \\af => a.s ! Compar ! af ++ conjThan ++ (np.s ! Nom).ton ;
-      isPre = False
+      isPre = False ;
+      copTyp = a.copTyp
       } ;
     CAdvAP ad ap np = {
       s = \\af => ad.s ++ ap.s ! af ++ ad.p ++ (np.s ! Nom).ton ;
-      isPre = False
+      isPre = False ;
+      copTyp = ap.copTyp
       } ;
     UseComparA a = {
       s = \\af => a.s ! Compar ! af ;
-      isPre = a.isPre
+      isPre = a.isPre ;
+      copTyp = a.copTyp
       } ;
     AdjOrd ord = {
       s = \\af => ord.s ! aform2aagr af ; ----
-      isPre = False ----
+      isPre = False ; ----
+      copTyp = serCopula
       } ;
 
 -- $SuperlA$ belongs to determiner syntax in $Noun$.
 
     ComplA2 adj np = {
       s = \\af => adj.s ! Posit ! af ++ appCompl adj.c2 np ;
-      isPre = False
+      isPre = False ;
+      copTyp = serCopula
       } ;
 
     ReflA2 adj = {
       s = \\af =>
              adj.s ! Posit ! af ++
              adj.c2.s ++ prepCase adj.c2.c ++ reflPron Sg P3 Nom ; --- agr
-      isPre = False
+      isPre = False ;
+      copTyp = serCopula
       } ;
 
     SentAP ap sc = {
       s = \\a => ap.s ! a ++ sc.s ! dative ; -- prête à dormir --- mood
-      isPre = False
+      isPre = False ;
+      copTyp = ap.copTyp
       } ;
 
     AdAP ada ap = {
       s = \\a => ada.s ++ ap.s ! a ;
-      isPre = ap.isPre
+      isPre = ap.isPre ;
+      copTyp = ap.copTyp
       } ;
 
     UseA2 a = {
       s = a.s ! Posit ;
-      isPre = False ---- A2 has no isPre
+      isPre = False ; ---- A2 has no isPre
+      copTyp = serCopula ---- A2 has no copTyp (yet)
       } ;
 
     AdvAP ap adv = {
       s = \\a => ap.s ! a ++ adv.s ;
-      isPre = False
+      isPre = False ;
+      copTyp = ap.copTyp
       } ;
 
 

--- a/src/romance/CatRomance.gf
+++ b/src/romance/CatRomance.gf
@@ -55,7 +55,7 @@ incomplete concrete CatRomance of Cat = CommonX - [SC,Pol]
 
 -- Adjective
 
-    AP = {s : AForm => Str ; isPre : Bool} ;
+    AP = {s : AForm => Str ; isPre : Bool ; copTyp : CopulaType} ;
 
 -- Noun
 
@@ -105,7 +105,7 @@ incomplete concrete CatRomance of Cat = CommonX - [SC,Pol]
     V3, V2A, V2V = Verb ** {c2,c3 : Compl} ;
     VS = Verb ** {m : RPolarity => Mood} ;
 
-    A  = {s : Degree => AForm => Str ; isPre : Bool} ;
+    A  = {s : Degree => AForm => Str ; isPre : Bool ; copTyp : CopulaType} ;
     A2 = {s : Degree => AForm => Str ; c2 : Compl} ;
 
     N  = Noun ;

--- a/src/romance/ConjunctionRomance.gf
+++ b/src/romance/ConjunctionRomance.gf
@@ -14,7 +14,8 @@ incomplete concrete ConjunctionRomance of Conjunction =
       hasClit = False ; isNeg = ss.isNeg
       }) ;
     ConjAP conj ss = conjunctDistrTable AForm conj ss ** {
-      isPre = ss.isPre
+      isPre = ss.isPre ;
+      copTyp = ss.copTyp
       } ;
     ConjRS conj ss = conjunctDistrTable2 Mood Agr conj ss ** {
       c = ss.c
@@ -40,8 +41,8 @@ incomplete concrete ConjunctionRomance of Conjunction =
       s2 = \\c => xs.s2 ! c ; ----e (conjunctCase c) ; 
       a = conjAgr x.a xs.a ; isNeg = orB x.isNeg xs.isNeg
       } ;
-    BaseAP x y = twoTable AForm x y ** {isPre = andB x.isPre y.isPre} ;
-    ConsAP xs x = consrTable AForm comma xs x ** {isPre = andB xs.isPre x.isPre} ;
+    BaseAP x y = twoTable AForm x y ** {isPre = andB x.isPre y.isPre ; copTyp = y.copTyp} ;
+    ConsAP x xs = consrTable AForm comma x xs ** {isPre = andB x.isPre xs.isPre ; copTyp = xs.copTyp} ;
     BaseRS x y = twoTable2 Mood Agr x y ** {c = y.c} ;
     ConsRS xs x = consrTable2 Mood Agr comma xs x ** {c = xs.c} ;
     BaseIAdv = twoSS ;
@@ -55,7 +56,7 @@ incomplete concrete ConjunctionRomance of Conjunction =
     [AdV] = {s1,s2 : Str} ;
     [IAdv] = {s1,s2 : Str} ;
     [NP] = {s1,s2 : Case => Str ; a : Agr ; isNeg : Bool} ;
-    [AP] = {s1,s2 : AForm  => Str ; isPre : Bool} ;
+    [AP] = {s1,s2 : AForm  => Str ; isPre : Bool ; copTyp : CopulaType} ;
     [RS] = {s1,s2 : Mood => Agr => Str ; c : Case} ;
     [CN] = {s1,s2 : Number => Str ; g : Gender} ;
 

--- a/src/romance/VerbRomance.gf
+++ b/src/romance/VerbRomance.gf
@@ -91,7 +91,13 @@ incomplete concrete VerbRomance of Verb =
 
     UseCopula = predV copula ;
 
-    CompAP ap = {s = \\ag => let agr = complAgr ag in ap.s ! genNum2Aform agr.g agr.n ; cop = serCopula} ;
+    CompAP ap = {
+      s = \\ag =>
+        let
+          agr = complAgr ag
+        in ap.s ! genNum2Aform agr.g agr.n ;
+      cop = ap.copTyp
+      } ;
     CompCN cn = { s = \\ag =>
         let agr = complAgr ag in
         artIndef False cn.g agr.n Nom ++ cn.s ! agr.n ;
@@ -115,4 +121,5 @@ incomplete concrete VerbRomance of Verb =
     VPSlashPrep vp prep = vp ** {
       c2 = {s = prep.s ; c = prep.c ; isDir = False}
       } ;
-}
+
+} ;

--- a/src/spanish/LexiconSpa.gf
+++ b/src/spanish/LexiconSpa.gf
@@ -1,7 +1,7 @@
 --# -path=.:../romance:../common:../abstract:../../prelude
 
 concrete LexiconSpa of Lexicon = CatSpa ** open 
-  (M=MorphoSpa), ParadigmsSpa, BeschSpa in {
+  (M=MorphoSpa), ParadigmsSpa, (D = DiffSpa), BeschSpa in {
 
 flags 
     coding=utf8 ;
@@ -233,6 +233,7 @@ lin
    correct_A = regA "correcto" ;
    dry_A = regA "seco" ;
    dull_A = regA "desafilado" ;
+   ready_A = adjCopula (mkA "listo") D.estarCopula ;
    full_A = regA "lleno" ;
    heavy_A = regA "pesado" ;
    near_A = regA "cercano" ;

--- a/src/spanish/ParadigmsSpa.gf
+++ b/src/spanish/ParadigmsSpa.gf
@@ -165,7 +165,9 @@ oper
 
     mkA : (bueno : A) -> (mejor : A) -> A ; -- special comparison (default with "mas")
 
-    mkA : (blanco : A) -> (hueso : Str) -> A -- noninflecting component after the adjective
+    mkA : (blanco : A) -> (hueso : Str) -> A ; -- noninflecting component after the adjective
+
+    mkA : A -> CopulaType -> A -- force copula type
     } ;
 
 -- The functions above create postfix adjectives. To switch
@@ -357,23 +359,24 @@ oper
   makeNP x g n = {s = (pn2np (mk2PN x g)).s; a = agrP3 g n ; hasClit = False ; isPol = False ; isNeg = False} ** {lock_NP = <>} ;
 
   mk7A a b c d e f g =
-    compADeg {s = \\_ => (mkAdj a b c d e f g).s ; isPre = False ; lock_A = <>} ;
+    compADeg {s = \\_ => (mkAdj a b c d e f g).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
 
   mk5A a b c d e = mk7A a a b b c d e ;
 
-  mk2A a b = compADeg {s = \\_ => (adjEspanol a b).s ; isPre = False ; lock_A = <>} ;
+  mk2A a b = compADeg {s = \\_ => (adjEspanol a b).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
 
-  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; lock_A = <>} ;
-  prefA a = {s = a.s ; isPre = True ; lock_A = <>} ;
+  regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  adjCopula a cop = a ** {copTyp = cop} ;
+  prefA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
 
   mkA2 a p = a ** {c2 = p ; lock_A2 = <>} ;
 
   mkADeg a b =
    {s = table {Posit => a.s ! Posit ; _ => b.s ! Posit} ;
-    isPre = a.isPre ; lock_A = <>} ;
+    isPre = a.isPre ; copTyp = a.copTyp ; lock_A = <>} ;
   compADeg a =
     {s = table {Posit => a.s ! Posit ; _ => \\f => "más" ++ a.s ! Posit ! f} ;
-     isPre = a.isPre ;
+     isPre = a.isPre ; copTyp = a.copTyp ;
      lock_A = <>} ;
   regADeg a = compADeg (regA a) ;
 
@@ -515,12 +518,15 @@ oper
     mkA : (bueno : A) -> (mejor : A) -> A = mkADeg ;
     mkA : (blanco : A) -> (hueso : Str) -> A = \blanco,hueso -> blanco **
       { s = \\x,y => blanco.s ! x ! y ++ hueso } ;
+    mkA : A -> CopulaType -> A =
+      adjCopula ;
     } ;
 
   mk7A : (_,_,_,_,_,_,_ : Str) -> A ;
   mk5A : (solo,sola,solos,solas,solamente : Str) -> A ;
   mk2A : (espanol,espanola : Str) -> A ;
   regA : Str -> A ;
+  adjCopula : A -> CopulaType -> A ;
   mkADeg : A -> A -> A ;
   compADeg : A -> A ;
   regADeg : Str -> A ;


### PR DESCRIPTION
- so that one can force the use of a copula verb
- before this, a sentence like "he was ready when I saw him" would be
  translated as "ele era pronto quando eu o via" in Portuguese,
  instead of using the estar copula