### PR TITLE
(Romance,Por) allow Romance Languages to choose different verb forms for the same tense/anteriority

### DIFF
--- a/src/portuguese/DiffPor.gf
+++ b/src/portuguese/DiffPor.gf
@@ -1,6 +1,6 @@
 --# -path=.:../romance:../abstract:../common:../prelude
 
-instance DiffPor of DiffRomance - [partAgr,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoPor, BeschPor, Prelude in {
+instance DiffPor of DiffRomance - [chooseTA,partAgr,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoPor, BeschPor, Prelude in {
 
   flags optimize=noexpand ;
         coding=utf8 ;
@@ -199,6 +199,23 @@ instance DiffPor of DiffRomance - [partAgr,vpAgrSubj,vpAgrClits] = open CommonRo
     vpAgrClit : Agr -> VPAgr = \a ->
       vpAgrNone ;
 
+  oper
+    chooseTA : RTense -> Anteriority
+      -> (VF => Str) -> (VF => Str)
+      -> Number -> Person -> Mood -> Str -> Str * Str ;
+    chooseTA t a verb vaux n p m part = case <t,a> of {
+    <RPast,Simul>  => <verb ! VFin VPasse n p, []> ; --# notpresent
+    <RPast,Anter>  => <vaux ! VFin (VImperf m) n p, part> ; --# notpresent
+    <RFut,Simul>   => <verb ! VFin VFut n p, []> ; --# notpresent
+    <RFut,Anter>   => <vaux ! VFin VFut n p, part> ; --# notpresent
+    <RCond,Simul>  => <verb ! VFin VCondit n p, []> ; --# notpresent
+    <RCond,Anter>  => <vaux ! VFin VCondit n p, part> ; --# notpresent
+    <RPasse,Simul> => <verb ! VFin VPasse n p, []> ; --# notpresent
+    <RPasse,Anter> => <vaux ! VFin VPasse n p, part> ; --# notpresent
+    <RPres,Anter>  => <verb ! VFin (VImperf m) n p, []> ; --# notpresent
+    <RPres,Simul>  => <verb ! VFin (VPres m) n p, []>
+    } ;
+
 -- oper's opers
   oper
     argPron : Gender -> Number -> Person -> Case -> Str =
@@ -216,8 +233,8 @@ instance DiffPor of DiffRomance - [partAgr,vpAgrSubj,vpAgrClits] = open CommonRo
       \g,n,p -> case <<g,n,p> : Gender * Number * Person> of {
         <_,Sg,P1> => cases "me" "mim" ;
         <_,Sg,P2> => cases "te" "ti" ;
-        <_,Pl,P1> => cases "nos" "nós" ; --- nosotros
-        <_,Pl,P2> => cases "vos" "vós" ; --- vosotros
+        <_,Pl,P1> => cases "nos" "nós" ;
+        <_,Pl,P2> => cases "vos" "vós" ;
         <Fem,Sg,P3> => cases3 "a" "sua" "ela" ;
         <_,  Sg,P3> => cases3 "o" "seu" "ele" ;
         <Fem,Pl,P3> => cases3 "as" "suas" "elas" ;

--- a/src/romance/DiffRomance.gf
+++ b/src/romance/DiffRomance.gf
@@ -169,5 +169,20 @@ oper
 
   contractInf : Bool -> Bool -> Bool = \_,_ -> False ; -- only True in Ita, by orB
 
-}
+  chooseTA : RTense -> Anteriority
+    -> (VF => Str) -> (VF => Str)
+    -> Number -> Person -> Mood -> Str -> Str * Str ;
+  chooseTA t a verb vaux n p m part = case <t,a> of {
+    <RPast,Simul>  => <verb ! VFin (VImperf m) n p, []> ; --# notpresent
+    <RPast,Anter>  => <vaux ! VFin (VImperf m) n p, part> ; --# notpresent
+    <RFut,Simul>   => <verb ! VFin VFut n p, []> ; --# notpresent
+    <RFut,Anter>   => <vaux ! VFin VFut n p, part> ; --# notpresent
+    <RCond,Simul>  => <verb ! VFin VCondit n p, []> ; --# notpresent
+    <RCond,Anter>  => <vaux ! VFin VCondit n p, part> ; --# notpresent
+    <RPasse,Simul> => <verb ! VFin VPasse n p, []> ; --# notpresent
+    <RPasse,Anter> => <vaux ! VFin VPasse n p, part> ; --# notpresent
+    <RPres,Anter>  => <vaux ! VFin (VPres m) n p, part> ; --# notpresent
+    <RPres,Simul>  => <verb ! VFin (VPres m) n p, []>
+    } ;
 
+} ;

--- a/src/romance/ResRomance.gf
+++ b/src/romance/ResRomance.gf
@@ -228,18 +228,7 @@ oper
 ----            } ;
 
 
-          vps : Str * Str = case <te,a> of {
-            <RPast,Simul> => <verb ! VFin (VImperf m) num per, []> ; --# notpresent
-            <RPast,Anter> => <vaux ! VFin (VImperf m) num per, part> ; --# notpresent
-            <RFut,Simul>  => <verb ! VFin (VFut) num per, []> ; --# notpresent
-            <RFut,Anter>  => <vaux ! VFin (VFut) num per, part> ; --# notpresent
-            <RCond,Simul> => <verb ! VFin (VCondit) num per, []> ; --# notpresent
-            <RCond,Anter> => <vaux ! VFin (VCondit) num per, part> ; --# notpresent
-            <RPasse,Simul> => <verb ! VFin (VPasse) num per, []> ; --# notpresent
-            <RPasse,Anter> => <vaux ! VFin (VPasse) num per, part> ; --# notpresent
-            <RPres,Anter> => <vaux ! VFin (VPres m) num per, part> ; --# notpresent
-            <RPres,Simul> => <verb ! VFin (VPres m) num per, []>
-            } ;
+          vps : Str * Str = chooseTA te a verb vaux num per m part ;
 
           fin = vps.p1 ;
           inf = vps.p2 ;

--- a/src/romance/SentenceRomance.gf
+++ b/src/romance/SentenceRomance.gf
@@ -113,19 +113,8 @@ incomplete concrete SentenceRomance of Sentence =
 ----            VPAgrClit g n => verb ! VPart g n  
 ----            } ;
 
-          vpss : Str * Str = case <te,a> of {
+          vpss : Str * Str = chooseTA te a verb vaux num per m part ;
 
-            <RPast,Simul> => <verb ! VFin (VImperf m) num per, []> ; --# notpresent
-            <RPast,Anter> => <vaux ! VFin (VImperf m) num per, part> ; --# notpresent
-            <RFut,Simul>  => <verb ! VFin (VFut) num per, []> ; --# notpresent
-            <RFut,Anter>  => <vaux ! VFin (VFut) num per, part> ; --# notpresent
-            <RCond,Simul> => <verb ! VFin (VCondit) num per, []> ; --# notpresent
-            <RCond,Anter> => <vaux ! VFin (VCondit) num per, part> ; --# notpresent
-            <RPasse,Simul> => <verb ! VFin (VPasse) num per, []> ; --# notpresent
-            <RPasse,Anter> => <vaux ! VFin (VPasse) num per, part> ; --# notpresent
-            <RPres,Anter> => <vaux ! VFin (VPres m) num per, part> ; --# notpresent
-            <RPres,Simul> => <verb ! VFin (VPres m) num per, []> 
-            } ;
           fin = vpss.p1 ;
           inf = vpss.p2 ;
           hypt = verbHyphen vp.s ; -- in French, -t- in some cases, otherwise - ; empty in other langs

--- a/src/spanish/LangSpa.gf
+++ b/src/spanish/LangSpa.gf
@@ -1,4 +1,4 @@
---# -path=.:../romance:../abstract:../common:../api
+--# -path=.:../romance:../abstract:../common:../api:../prelude
 
 concrete LangSpa of Lang = 
   GrammarSpa,


### PR DESCRIPTION
for Portuguese it's best to
- pick imperfect tense when tense/anteriority is present anterior
- pick perfect tense when tense/anteriority is past simultaneous

this increases compilation times for Portuguese in 10 seconds though.