### PR TITLE
(Por) improve smart paradigm for nouns

### DIFF
--- a/src/portuguese/MorphoPor.gf
+++ b/src/portuguese/MorphoPor.gf
@@ -85,9 +85,6 @@ oper
   mkNounIrreg : Str -> Str -> Gender -> Noun = \mec,mecs ->
     mkNoun (numForms mec mecs) ;
 
-  smartGenNoun : Str -> Gender -> Noun =
-    \vinho,g -> mkNomReg vinho ** {g = g} ;
-
   mkNomReg : Str -> Noun = \vinho -> case vinho of {
     chapéu + "-" + de + "-" + sol => mkNoun (nomChapeudesol chapéu de sol) Masc ;
 


### PR DESCRIPTION
- handle 'ão' better (thanks @inariksit!)
- add more cases (for compounds with hyphen, acutes ending in 'l', etc
- concentrate smartness in mkNomReg (i.e., make smartGenNoun dumb)