### PR TITLE
(Por) change copula type from bool to sum param

### DIFF
--- a/src/portuguese/DiffPor.gf
+++ b/src/portuguese/DiffPor.gf
@@ -72,11 +72,20 @@ instance DiffPor of DiffRomance - [chooseTA,partAgr,vpAgrSubj,vpAgrClits] = open
       in
       neg.p1 ++ verb ++ bindIf refl.p2 ++ refl.p1 ++ bindIf clpr.p3 ++ clpr.p1 ++ compl ;
 
+  param
+    Copula = SerCop | EstarCop | FicarCop ;
+
   oper
-    CopulaType = Bool ;
-    selectCopula = \isEstar -> case isEstar of {True => estar_V ; False => copula} ;
-    serCopula = False ;
-    estarCopula = True ;
+    CopulaType = Copula ;
+    selectCopula coptyp = case coptyp of {
+      SerCop => copula ;
+      EstarCop => estar_V ;
+      FicarCop => ficar_V
+      } ;
+
+    serCopula = SerCop ;
+    estarCopula = EstarCop ;
+    ficarCopula = FicarCop ;
 
   oper
     -- the other Cases are defined in ResRomance

--- a/src/portuguese/ParadigmsPor.gf
+++ b/src/portuguese/ParadigmsPor.gf
@@ -256,7 +256,7 @@ oper
     mkA : (blanco : A) -> (hueso : Str) -> A -- noninflecting component after the adjective
       = mkNonInflectA ;
 
-    mkA : A -> CopulaType -> A -- force copula type, e.g. "João está doente", "João é doente"
+    mkA : A -> CopulaType -> A -- force copula type, e.g. "João está doente", "João é doente". Choose among ``serCopula``, ``estarCopula``, and ``ficarCopula``
       = adjCopula ;
 
     } ;

--- a/src/romance/DiffRomance.gf
+++ b/src/romance/DiffRomance.gf
@@ -52,7 +52,7 @@ interface DiffRomance = open CommonRomance, Prelude in {
 
   oper mkImperative : Bool -> Person -> VP -> RPolarity => Gender => Number => Str ;
 
--- To render the copula (ser/estar in Spa,Cat)
+-- To render the copula (ser/estar in Spa,Cat,Por)
 
   oper CopulaType : PType ;
   oper selectCopula : CopulaType -> Verb ;


### PR DESCRIPTION
Portuguese actually has several verbs that can act as copulas,
although the main ones are ser and estar. this allows other types of
copulas to be added.