### PR TITLE
(Cat,Por,Spa) Iberic imperative

### DIFF
--- a/src/catalan/DiffCat.gf
+++ b/src/catalan/DiffCat.gf
@@ -108,28 +108,26 @@ oper
 
    infForm _ _ _ _  = True ;
 
-   mkImperative b p vp =
-      \\pol,g,n =>
-        let
-          pe    = case b of {True => P3 ; _ => p} ;
-          agr   = {g = g ; n = n ; p = pe} ;
-          refl  = case vp.s.vtyp of {
-            VRefl => <reflPron n pe Acc,True> ;
-            _ => <[],False>
-            } ;
-
-          clpr  =  <vp.clit1 ++ vp.clit2, [],vp.clit3.hasClit> ;  ---- TODO: True if clit
-----          clpr  = <[],[],False> ; ----e pronArg agr.n agr.p vp.clAcc vp.clDat ;
-----e          verb  = case <aag.n, pol,pe> of {
-----e            <Sg,Neg,P2> => (vp.s ! VPInfinit Simul clpr.p3).inf ! aag ;
-----e            _ => (vp.s ! VPImperat).fin ! agr
-----e            } ;
-          verb  = vp.s.s ! vImper n pe ; ----e
-          neg   = vp.neg ! pol ;
-          compl = neg.p2 ++ clpr.p2 ++ vp.comp ! agr ++ vp.ext ! pol
-        in
-        neg.p1 ++ verb ++ bindIf refl.p2 ++ refl.p1 ++ bindIf clpr.p3 ++ clpr.p1 ++ compl
-         ;
+   mkImperative isPol p vp =
+     \\pol,g,n => case pol of {
+       RPos   => neg.p1 ++ imper ++ bindIf refl.isRefl ++ refl.pron
+                   ++ bindIf hasClit ++ clit ++ compl ;
+       RNeg _ => neg.p1 ++ refl.pron ++ clit ++ compl ++ subj 
+     } where {
+       pe   = case isPol of {True => P3 ; _ => p} ;
+       refl = case vp.s.vtyp of {
+         VRefl => {pron = reflPron n pe Acc ; isRefl = True} ;
+         _     => {pron = [] ; isRefl = False}
+         } ;
+       clit    = vp.clit1 ++ vp.clit2 ;
+       hasClit = vp.clit3.hasClit ;
+       imper   = vp.s.s ! vImper n pe ;
+       subj    = vp.s.s ! VFin (VPres Conjunct) n pe ;
+       neg     = vp.neg ! pol ;
+       agr     = {g = g ; n = n ; p = pe} ;
+       compl   = neg.p2 ++ vp.comp ! agr ++ vp.ext ! pol
+     } ;
+   
     CopulaType = Bool ;
     selectCopula = \isEstar -> case isEstar of {True => estar_V ; False => copula} ;
     serCopula = False ;

--- a/src/portuguese/DiffPor.gf
+++ b/src/portuguese/DiffPor.gf
@@ -55,22 +55,31 @@ instance DiffPor of DiffRomance - [chooseTA,partAgr,vpAgrSubj,vpAgrClits] = open
       defaultPronArg ;
 
   oper
-    mkImperative b p vp =
-      \\pol,g,n =>
-        let
-          pe    = case b of {True => P3 ; _ => p} ;
-          agr   = {g = g ; n = n ; p = pe} ;
-          refl  = case vp.s.vtyp of {
-            VRefl => <reflPron n pe Acc,True> ;
-            _ => <[],False>
-            } ;
+    mkImperative isPol p vp =
+      \\pol,g,n => case pol of {
+        RPos   => neg.p1 ++ imper ++ bindHyphenIf refl.isRefl ++ refl.pron
+          ++ bindIf hasClit ++ clit ++ compl ;
+        RNeg _ => neg.p1 ++ refl.pron ++ clit ++ subj ++ compl
+      } where {
+        pe   = case isPol of {True => P2 ; _ => P3} ;
+        refl = case vp.s.vtyp of {
+          VRefl => {pron = reflPron n pe Acc ; isRefl = True} ;
+          _     => {pron = [] ; isRefl = False}
+          } ;
+        clit    = vp.clit1 ++ vp.clit2 ;
+        hasClit = vp.clit3.hasClit ;
+        imper   = vp.s.s ! vImper n pe ;
+        subj    = vp.s.s ! VFin (VPres Conjunct) n p ;
+        neg     = vp.neg ! pol ;
+        agr     = {g = g ; n = n ; p = pe} ;
+        compl   = neg.p2 ++ vp.comp ! agr ++ vp.ext ! pol
+      } ;
 
-          clpr  =  <vp.clit1 ++ vp.clit2, [],vp.clit3.hasClit> ;
-          verb  = vp.s.s ! vImper n pe ;
-          neg   = vp.neg ! pol ;
-          compl = neg.p2 ++ clpr.p2 ++ vp.comp ! agr ++ vp.ext ! pol
-      in
-      neg.p1 ++ verb ++ bindIf refl.p2 ++ refl.p1 ++ bindIf clpr.p3 ++ clpr.p1 ++ compl ;
+    bindHyphenIf : Bool -> Str ;
+    bindHyphenIf b = case b of {
+      True => BIND ++ "-" ++ BIND ;
+      _    => []
+      } ;
 
   param
     Copula = SerCop | EstarCop | FicarCop ;

--- a/src/portuguese/ExtraPor.gf
+++ b/src/portuguese/ExtraPor.gf
@@ -45,4 +45,4 @@ concrete ExtraPor of ExtraPorAbs = ExtraRomancePor **
 
     UseComp_estar comp = insertComplement comp.s (predV B.estar_V) ;
 
-}
+} ;

--- a/src/portuguese/LexiconPor.gf
+++ b/src/portuguese/LexiconPor.gf
@@ -39,7 +39,7 @@ lin
    near_A      = mkA "perto" ;
    new_A       = prefixA (mkA "novo") ;
    old_A       = prefixA (mkA "velho") ;
-   ready_A     = adjCopula (mkA "pronto") D.estarCopula ;
+   ready_A     = mkA (mkA "pronto") D.estarCopula ;
    red_A       = mkA "vermelho" ;
    rotten_A    = mkA "podre" ;
    round_A     = mkA "redondo" ;
@@ -52,7 +52,7 @@ lin
    thick_A     = mkA "grosso" ;
    thin_A      = mkA "fino" ; -- delgado, magro
    ugly_A      = mkA "feio" ;
-   uncertain_A = mkA "incerto" ;
+   uncertain_A = mkA (mkA "incerto") D.estarCopula ;
    warm_A      = mkA "quente" ;
    wet_A       = mkA "molhado" ;
    white_A     = compADeg (mkA "branco") ;
@@ -191,7 +191,7 @@ lin
    question_N   = mkN "pergunta" ;
    radio_N      = mkN "rádio" ;
    rain_N       = mkN "chuva" ;
-   reason_N     = mkN "razão" ;
+   reason_N     = mkN "razão" feminine ;
    religion_N   = mkN "religião" ;
    restaurant_N = mkN "restaurante" ;
    river_N      = mkN "rio" ;
@@ -232,7 +232,7 @@ lin
    table_N      = mkN "mesa" ;
    tail_N       = mkN "rabo" ;
    teacher_N    = mkN "professor" ;
-   television_N = mkN "televisão" ;
+   television_N = mkN "televisão" feminine ;
    tongue_N     = mkN "língua" ;
    tooth_N      = mkN "dente" ;
    train_N      = mkN "trem" ;
@@ -278,7 +278,7 @@ lin
    hit_V2        = mkV2 (mkV "bater") ;
    hold_V2       = mkV2 have_V ;
    hunt_V2       = mkV2 (mkV "caçar") ;
-   kill_V2       = mkV2 (mkV "matar") ;
+   kill_V2       = mkV2 (mkV "matar" "morto") ;
    know_V2       = mkV2 (mkV "conhecer") ;
    learn_V2      = mkV2 (mkV "aprender") ;
    leave_V2      = mkV2 (mkV "partir") ;
@@ -301,7 +301,7 @@ lin
    squeeze_V2    = mkV2 (mkV "apertar") ;
    stab_V2       = mkV2 (mkV (recear_Besch "esfaquear")) ;
    suck_V2       = mkV2 (mkV "chupar") ;
-   switch8off_V2 = mkV2 (mkV "apagar") ;
+   switch8off_V2 = mkV2 (mkV "desligar") ;
    switch8on_V2  = mkV2 (mkV "ligar") ; -- acender
    teach_V2      = mkV2 (mkV "ensinar") ;
    throw_V2      = mkV2 (mkV "jogar") ;

--- a/src/spanish/DiffSpa.gf
+++ b/src/spanish/DiffSpa.gf
@@ -112,27 +112,27 @@ instance DiffSpa of DiffRomance - [partAgr,vpAgrSubj,vpAgrClits,contractInf] = o
 
     infForm _ _ _ _  = True ;
 
-    mkImperative b p vp =
-      \\pol,g,n => 
-        let 
-          pe    = case b of {True => P3 ; _ => p} ;
-          agr   = {g = g ; n = n ; p = pe} ;
-          refl  = case vp.s.vtyp of {
-            VRefl => <reflPron n pe Acc,True> ;
-            _ => <[],False> 
-            } ;
 
-          clpr  =  <vp.clit1 ++ vp.clit2, [],vp.clit3.hasClit> ; 
-----          clpr  = <[],[],False> ; ----e pronArg agr.n agr.p vp.clAcc vp.clDat ;
-----e          verb  = case <aag.n, pol,pe> of {
-----e            <Sg,Neg,P2> => (vp.s ! VPInfinit Simul clpr.p3).inf ! aag ;
-----e            _ => (vp.s ! VPImperat).fin ! agr
-----e            } ;
-          verb  = vp.s.s ! vImper n pe ;
-          neg   = vp.neg ! pol ;
-          compl = neg.p2 ++ clpr.p2 ++ vp.comp ! agr ++ vp.ext ! pol
-        in
-        neg.p1 ++ verb ++ bindIf refl.p2 ++ refl.p1 ++ bindIf clpr.p3 ++ clpr.p1 ++ compl ;
+    mkImperative isPol p vp =
+      \\pol,g,n => case pol of {
+        RPos   => neg.p1 ++ imper ++ bindIf refl.isRefl ++ refl.pron
+          ++ bindIf hasClit ++ clit ++ compl ;
+        RNeg _ => neg.p1 ++ refl.pron ++ clit ++ subj ++ compl
+      } where {
+        pe   = case isPol of {True => P3 ; _ => p} ;
+        refl = case vp.s.vtyp of {
+          VRefl => {pron = reflPron n pe Acc ; isRefl = True} ;
+          _     => {pron = [] ; isRefl = False}
+          } ;
+        clit    = vp.clit1 ++ vp.clit2 ;
+        hasClit = vp.clit3.hasClit ;
+        imper   = vp.s.s ! vImper n pe ;
+        subj    = vp.s.s ! VFin (VPres Conjunct) n pe ;
+        neg     = vp.neg ! pol ;
+        agr     = {g = g ; n = n ; p = pe} ;
+        compl   = neg.p2 ++ vp.comp ! agr ++ vp.ext ! pol
+      } ;
+
 
     CopulaType = Bool ;
     selectCopula = \isEstar -> case isEstar of {True => estar_V ; False => copula} ;


### PR DESCRIPTION
- reflexive pronoun is before the verb in the negative, not after
- verb form is not the same as positive imperative, but the same as
  present subjunctive

thanks to @inariksit for catching this bug!

(Por) handle politeness better
formal -> 2nd person singular (tu)
informal sg -> 3rd person singular (você, conjugated correctly)
informal pl -> 3rd person plural (vocês, conjugated correctly)

unlike Spa, Por uses 2nd person as polite form; the PorRG thus would
have no direct access to vós (second person plural), which is rather
rare (in Brazilian Por, at least). colloquial speech in Brazil
actually mangles both, using tu with você conjugation, etc; but this
out of scope for the RGL.

(Por) fix imperative
- should use hyphen to bind the reflexive pronoun


(Por) update lexicon given past changes in morphological paradigms 