### PR TITLE
(Romance) insertAdV before first negation particle

### DIFF
--- a/src/french/DiffFre.gf
+++ b/src/french/DiffFre.gf
@@ -2,6 +2,7 @@
 
 instance DiffFre of DiffRomance - [
   imperClit,
+  insertAdV,
   invertedClause,
   verbHyphen,
   iAdvQuestionInv
@@ -313,5 +314,13 @@ instance DiffFre of DiffRomance - [
   bindHyphensT : Str = bindHyphen ++ "t" ++ bindHyphen ;
 
   verbHyphen : Verb -> Str = \v -> v.s ! (VInfin True) ; --- kluge: use this field to store - or -t-
+
+  insertAdV : Str -> VP -> VP ;
+  insertAdV co vp = vp ** {
+    neg = \\b => let vpn = vp.neg ! b
+      -- hacky: the AdV is directly attached to the verb, so we put it
+      -- in the neg field
+      in {p1 = vpn.p1 ; p2 = vpn.p2 ++ co}
+    } ;
 
 }

--- a/src/romance/DiffRomance.gf
+++ b/src/romance/DiffRomance.gf
@@ -189,4 +189,12 @@ oper
     <RPres,Simul>  => <verb ! VFin (VPres m) n p, []>
     } ;
 
+  insertAdV : Str -> VP -> VP ;
+  insertAdV co vp = vp ** {
+    neg = \\b => let vpn = vp.neg ! b
+      -- hacky: the AdV is directly attached to the verb, so we put it
+      -- in the neg field
+      in {p1 = co ++ vpn.p1 ; p2 = vpn.p2}
+    } ;
+
 } ;

--- a/src/romance/ResRomance.gf
+++ b/src/romance/ResRomance.gf
@@ -133,12 +133,6 @@ oper
     comp  = \\a => vp.comp ! a ++ co ;
     } ;
 
-  insertAdV : Str -> VP -> VP ;
-  insertAdV co vp = vp ** {
-    neg = \\b => let vpn = vp.neg ! b
-      in {p1 = vpn.p1 ; p2 = vpn.p2 ++ co}
-    } ;
-
   insertClit3 : Str -> VP -> VP = \co,vp -> {
     s     = vp.s ;
     agr   = vp.agr ;


### PR DESCRIPTION
- mv insertAdV to DiffRomance
- use former version for French, as exception

I made this so that I could get the proper linearization for this tree (based on RGL Extend):
```
Matrix: TFullStop (PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN dog_N)) (AdVVP probably_AdV (UseV bark_V))))) NoVoc) TEmpty 
 MatrixEng: the dog probably barked .
-MatrixPor: o cachorro ladrava provavelmente .
+MatrixPor: o cachorro provavelmente ladrava .
```

I'm not sure it hasn't introduced other bugs, so I don't know if we should merge just yet.