### PR TITLE
(Romance,Por,Spa) refactor Extend{Por,Spa} into ExtendRomanceFunctor

### DIFF
--- a/src/catalan/DiffCat.gf
+++ b/src/catalan/DiffCat.gf
@@ -1,5 +1,5 @@
 --# -path=.:../romance:../abstract:../common:prelude
-instance DiffCat of DiffRomance - [partAgr,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoCat, BeschCat, Prelude in {
+instance DiffCat of DiffRomance - [partAgr,stare_V,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoCat, BeschCat, Prelude in {
 
   flags optimize=noexpand ;
   coding=utf8 ;
@@ -199,12 +199,10 @@ oper
       _ => False
       } ;
 
-    auxPassive : Verb = verbBeschH (estar_54 "estar") ;
+    haver_V, auxPassive : Verb = verbBeschH (estar_54 "estar") ;
 
-    copula = verbBeschH (ser_52 "ser") ;
-    estar_V = verbBeschH (estar_54 "estar") ;
-
-    haver_V : Verb = verbBeschH (haver_59 "haver" True) ;
+    essere_V, copula = verbBeschH (ser_52 "ser") ;
+    stare_V, estar_V = verbBeschH (estar_54 "estar") ;
 
     verbBeschH : Verbum -> Verb = \v -> verbBesch v ** {vtyp = VHabere ; p = []} ;
 

--- a/src/common/ExtendFunctor.gf
+++ b/src/common/ExtendFunctor.gf
@@ -105,10 +105,12 @@ lin
   youPolFem_Pron = youPol_Pron ;  -- DEFAULT you polite (masc)
   youPolPl_Pron = youPl_Pron ;  -- DEFAULT you plural (masc)
   youPolPlFem_Pron = youPl_Pron ;  -- DEFAULT you plural (masc)
+  UncontractedNeg = variants {} ; -- do not, etc, as opposed to don't
   UttAccNP = UttNP ; -- him (accusative) ; DEFAULT he
   UttDatNP np = UttAccNP (lin NP np) ; -- him(dative) ; DEFAULT he
   UttAccIP = UttIP ; -- whom (accusative) ; DEFAULT who
   UttDatIP ip = UttAccIP (lin IP ip) ; -- whom (dative) ; DEFAULT who
+  UttVPShort = UttVP ; -- have fun, as opposed to "to have fun" ; DEFAULT UttVP
 
 oper
   quoted : Str -> Str = \s -> "\"" ++ s ++ "\"" ; ---- TODO bind ; move to Prelude?

--- a/src/french/DiffFre.gf
+++ b/src/french/DiffFre.gf
@@ -246,9 +246,7 @@ instance DiffFre of DiffRomance - [
 
     getVTypT : VType -> VBool = \t -> case t of {VTyp _ b => b} ; -- only in Fre
 
-    auxPassive : Verb = copula ;
-
-    copula : Verb = {s = table VF ["être";bindHyphen;"suis";"es";"est";"sommes";"êtes";"sont";"sois";"sois"
+    copula, auxPassive, essere_V : Verb = {s = table VF ["être";bindHyphen;"suis";"es";"est";"sommes";"êtes";"sont";"sois";"sois"
 ;"soit";"soyons";"soyez";"soient";
 "étais";"étais";"était";"étions";"étiez";"étaient";--# notpresent
 "fusse";"fusses";"fût";"fussions";"fussiez";"fussent";--# notpresent
@@ -314,4 +312,4 @@ instance DiffFre of DiffRomance - [
 
   verbHyphen : Verb -> Str = \v -> v.s ! (VInfin True) ; --- kluge: use this field to store - or -t-
 
-}
+} ;

--- a/src/italian/DiffIta.gf
+++ b/src/italian/DiffIta.gf
@@ -226,7 +226,7 @@ instance DiffIta of DiffRomance - [contractInf] = open CommonRomance, PhonoIta, 
 
     auxPassive : Verb = venire_V ;
 
-    copula = verbBesch (essere_1 "essere") ** {vtyp = VEsse ; p = []} ;
+    copula, essere_V = verbBesch (essere_1 "essere") ** {vtyp = VEsse ; p = []} ;
     avere_V = verbBesch (avere_2 "avere") ** {vtyp = VHabere ; p = []} ;
     venire_V = verbBesch (venire_110 "venire") ** {vtyp = VEsse ; p = []} ;
 

--- a/src/portuguese/ConstructionPor.gf
+++ b/src/portuguese/ConstructionPor.gf
@@ -2,7 +2,7 @@
 
 concrete ConstructionPor of Construction = CatPor **
   open SyntaxPor, SymbolicPor, ParadigmsPor, BeschPor,
-  (L = LexiconPor), (B = DiffPor), (R = ResPor),
+  (L = LexiconPor), (D = DiffPor), (R = ResPor),
   (S = SyntaxPor), (C = CommonRomance), CommonRomance,
        Prelude in {
   flags coding=utf8 ;
@@ -22,13 +22,13 @@ lin
 
   what_name_QCl x = mkQCl how_IAdv (mkCl (lin NP x) (reflV (mkV "chamar"))) ;
   how_old_QCl x = mkQCl (mkIP how8many_IDet L.year_N) x have_V2 ;
-  how_far_QCl x = mkQCl (lin IAdv (ss "a que distância")) (mkCl x B.estar_V) ;
+  how_far_QCl x = mkQCl (lin IAdv (ss "a que distância")) (mkCl x D.stare_V) ;
 
 -- some more things
   weather_adjCl ap = mkCl (mkVP (mkVA (mkV (fazer_Besch "fazer"))) (lin AP ap)) ;
 
-  is_right_VP = mkVP (mkVA B.estar_V) (mkAP (mkA "certo")) ;
-  is_wrong_VP = mkVP (mkVA B.estar_V) (mkAP (mkA "errado")) ;
+  is_right_VP = mkVP (mkVA D.stare_V) (mkAP (mkA "certo")) ;
+  is_wrong_VP = mkVP (mkVA D.stare_V) (mkAP (mkA "errado")) ;
 
   n_units_AP card cn a = mkAP (lin AdA (mkUtt (mkNP <lin Card card : Card> (lin CN cn))))
                               (lin A a) ;
@@ -225,4 +225,4 @@ lin thai_Language      = mkLanguage "tailandês" ;
 lin turkish_Language   = mkLanguage "turco" ;
 lin urdu_Language      = mkLanguage "urdu" ;
 
-}
+} ;

--- a/src/portuguese/DiffPor.gf
+++ b/src/portuguese/DiffPor.gf
@@ -1,6 +1,6 @@
 --# -path=.:../romance:../abstract:../common:../prelude
 
-instance DiffPor of DiffRomance - [iAdvQuestionInv,chooseTA,otherInv,partAgr,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoPor, BeschPor, Prelude in {
+instance DiffPor of DiffRomance - [iAdvQuestionInv,chooseTA,otherInv,partAgr,stare_V,vpAgrSubj,vpAgrClits] = open CommonRomance, PhonoPor, BeschPor, Prelude in {
 
   flags optimize=noexpand ;
         coding=utf8 ;
@@ -87,8 +87,8 @@ instance DiffPor of DiffRomance - [iAdvQuestionInv,chooseTA,otherInv,partAgr,vpA
   oper
     CopulaType = Copula ;
     selectCopula coptyp = case coptyp of {
-      SerCop => copula ;
-      EstarCop => estar_V ;
+      SerCop => essere_V ;
+      EstarCop => stare_V ;
       FicarCop => ficar_V
       } ;
 
@@ -263,14 +263,14 @@ instance DiffPor of DiffRomance - [iAdvQuestionInv,chooseTA,otherInv,partAgr,vpA
         <_,  Pl,P3> => cases3 "os" "seus" "eles"
       } ;
 
-    estar_V : Verb = verboV (estar_Besch "estar") ;
+    essere_V : Verb = verboV (ser_Besch "ser") ;
+    stare_V : Verb = verboV (estar_Besch "estar") ;
 
     haver_V : Verb = verboV (haver_Besch "haver") ;
-
     ficar_V : Verb = verboV (ficar_Besch "ficar") ;
 
     verboV : Verbum -> Verb ;
     -- make a verb of type haver
     verboV v = verbBesch v ** {vtyp = VHabere ; p = [] ; lock_V = <>} ;
 
-}
+} ;

--- a/src/portuguese/ExtendPor.gf
+++ b/src/portuguese/ExtendPor.gf
@@ -1,81 +1,39 @@
---# -path=alltenses:../common:../abstract
-
-concrete ExtendPor of Extend =
-  CatPor ** ExtendFunctor -
+--# -path=alltenses:../common:../abstract:../romance
+concrete ExtendPor of Extend = CatPor ** ExtendRomanceFunctor -
   [
-    AdAdV,
-      AdjAsCN,
-      AdjAsNP,
-      ApposNP,
-      BaseVPS,
-      ByVP,
-      CompBareCN,
-      ComplBareVS,
-      ComplSlashPartLast,
-      CompoundAP,
-      CompoundN,
-      CompVP,
-      ConjVPS,
-      ConsVPS,
-      --EmptyRelSlash,
-      ExistsNP,
-      GenIP,
-      GenModIP,
-      GenModNP,
-      GenNP,
-      GerundAdv,
-      GerundCN,
-      GerundNP,
-      IAdvAdv,
-      ICompAP,
-      InOrderToVP,
-      ListVPS,
-      MkVPS,
-      PassAgentVPSlash,
-      PassVPSlash,
-      PastPartAP,
-      PastPartAgentAP,
-      PositAdVAdj,
-      PredVPS,
-      PresPartAP,
-      ProDrop,
-      PurposeVP,
-      UseComp_estar,
-      VPS,
-      iFem_Pron,
-      theyFem_Pron,
-      UttAdV,
-      UttVPShort,
-      weFem_Pron,
-      WithoutVP,
-      youFem_Pron,
-      youPlFem_Pron,
-      youPolFem_Pron,
-      youPolPlFem_Pron,
-      youPolPl_Pron
-   ]                   -- don't forget to put the names of your own
+     CompoundAP,
+     CompoundN,
+     ExistsNP,
+     GenRP,
+     GenRP,
+     ICompAP,
+     InOrderToVP,
+     WithoutVP,
+     iFem_Pron,
+     theyFem_Pron,
+     weFem_Pron,
+     youFem_Pron,
+     youPlFem_Pron,
+     youPolFem_Pron,
+     youPolPlFem_Pron,
+     youPolPl_Pron
+    ]                   -- don't forget to put the names of your own
                        -- definitions here
   with
-    (Grammar = GrammarPor), (Syntax = SyntaxPor) **
+    (Grammar = GrammarPor), (Syntax = SyntaxPor), (ResRomance = ResPor) **
   open
-  GrammarPor,
-  ResPor,
   MorphoPor,
   Coordination,
   Prelude,
   ParadigmsPor,
+  (L = LexiconPor),
   (S = StructuralPor) in {
 
-  lin
-    GenNP np =
-      let denp = (np.s ! ResPor.genitive).ton in {
-        s = \\_,_,_,_ => [] ;
-        sp = \\_,_,_ => denp ;
-        s2 = denp ;
-        isNeg = False ;
-      } ;
-
-    GenIP ip = {s = \\_,_,c => ip.s ! c} ;
+    lin
+    ExistsNP np =
+      mkClause [] True False np.a
+      (insertComplement (\\_ => (np.s ! Nom).ton)
+         (predV exist_V)) ;
 
     GenRP nu cn = {
       s = \\_b,_aagr,_c => cujo ! g ! n ++ num ++ cn.s ! n ;
@@ -88,56 +46,7 @@ concrete ExtendPor of Extend =
         num = if_then_Str nu.isNum (nu.s ! g) []
       } ;
 
-    GenModNP num np cn = DetCN (DetQuant (GenNP (lin NP np)) num) cn ;
-
-    GenModIP num ip cn = IdetCN (IdetQuant (GenIP (lin IP ip)) num) cn ;
-
-    CompBareCN cn = {
-      s = \\agr => cn.s ! agr.n ;
-      cop = serCopula
-      } ;
-
-    EmptyRelSlash cls = {
-      s = \\agr,t,a,p,m => cls.s ! agr ! DDir ! t ! a ! p ! m ++ cls.c2.s ;
-      c = Nom
-      } ;
-
-  ---- these come from ExtraRomance: how to avoid the repetition?
-  ---- can't seem to be able to use two functors
-  lincat
-    VPS = {s : Mood => Agr => Bool => Str} ;
-    [VPS] = {s1,s2 : Mood => Agr => Bool => Str} ;
-
   lin
-    BaseVPS x y = twoTable3 Mood Agr Bool x y ;
-    ConsVPS = consrTable3 Mood Agr Bool comma ;
-
-    PredVPS np vpi = {
-      s = \\m => (np.s ! Nom).comp ++ vpi.s ! m ! np.a ! np.isNeg
-      } ;
-
-    MkVPS tm p vp = {
-      s = \\m,agr,isNeg =>
-        tm.s ++ p.s ++
-        (mkClausePol (orB isNeg vp.isNeg) [] False False agr vp).s
-          ! DDir ! tm.t ! tm.a ! p.p ! m
-      } ;
-
-    ConjVPS = conjunctDistrTable3 Mood Agr Bool ;
-
-  lin
-    ProDrop p = {
-      s = table {
-        Nom => let pn = p.s ! Nom in {c1 = pn.c1 ; c2 = pn.c2 ; comp = [] ; ton = pn.ton} ;
-        c => p.s ! c
-        } ;
-      a = p.a ;
-      poss = p.poss ;
-      hasClit = p.hasClit ;
-      isPol = p.isPol ;
-      isNeg = False
-      } ;
-
     ICompAP ap = {
       s =\\a => "o quão" ++ ap.s ! (genNum2Aform a.g a.n) ;
       cop = serCopula
@@ -147,63 +56,9 @@ concrete ExtendPor of Extend =
       s = "o quão" ++ adv.s
       } ;
 
-    CompIQuant iq = {s = \\aa => iq.s ! aa.n ! aa.g ! Nom ; cop = serCopula} ;
-
-    PrepCN prep cn = {s = prep.s ++ prepCase prep.c ++ cn.s ! Sg} ;
-
-  lin
-    PresPartAP vp = {
-      s = \\af => gerVP vp (aform2aagr af ** {p = P3}) ;
-      isPre = False ;
-      copTyp = serCopula
-      } ;
-
-    PastPartAP vps = pastPartAP vps [] ;
-
-    PastPartAgentAP vps np = pastPartAP vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
-
-    PassVPSlash vps = passVPSlash vps [] ;
-
-    PassAgentVPSlash vps np = passVPSlash vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
-
-    ExistsNP np =
-      mkClause [] True False np.a
-      (insertComplement (\\_ => (np.s ! Nom).ton)
-         (predV (mkV "existir"))) ;
-
-    PurposeVP vp = {
-      s = infVP vp (Ag Masc Sg P3)
-      } ;
-
-    ComplBareVS = ComplVS ;
-
-    AdjAsCN ap = {
-      s =\\n => ap.s ! (genNum2Aform Masc n) ;
-      g = Masc
-      } ;
-
-    AdjAsNP ap = heavyNP {
-      s = \\_c => ap.s ! ASg Masc APred ;
-      a = Ag Masc Sg P3
-      } ;
-
   oper
-    pastPartAP : VPSlash -> Str -> AP ;
-    pastPartAP vps agent = lin AP {
-      s = \\af => vps.comp ! (aform2aagr af ** {p = P3}) ++ vps.s.s ! VPart (aform2gender af) (aform2number af) ++ agent ;
-      isPre = False ;
-      copTyp = serCopula
-      } ;
-
-    passVPSlash : VPSlash -> Str -> VP ;
-    passVPSlash vps agent = let
-      auxvp = predV auxPassive
-      in
-      vps ** {
-        s = auxvp.s ;
-        agr = auxvp.agr ;
-        comp  = \\a => vps.comp ! a ++ (let agr = complAgr a in vps.s.s ! VPart agr.g agr.n) ++ agent ;
-      } ;
+    exist_V : V ;
+    exist_V = mkV "existir" ;
 
   lin
     CompoundN noun noun2 = { -- order is different because that's needed for correct translation from english
@@ -221,75 +76,15 @@ concrete ExtendPor of Extend =
       copTyp = adj.copTyp
       } ;
 
-    GerundCN vp = {
-      s = \\n => infVP vp {g = Masc ; n = n ; p = P3} ;
-      g = Masc
-      } ;
-
-    GerundNP vp = let
-      neutrAgr = Ag Masc Sg P3
-      in heavyNP {
-        s = \\_ => gerVP vp neutrAgr ;
-        a = neutrAgr
-      } ;
-
-    GerundAdv vp = {
-      s = gerundStr vp
-      } ;
-
     WithoutVP vp = {
-      s = "sem" ++ gerundStr vp
-      } ;
-
-    ByVP vp = {
-      s = "by" ++ gerundStr vp
+      s = "sem" ++ infStr vp
       } ;
 
     InOrderToVP vp = {
-      s = "a fim de" ++ gerundStr vp
+      s = "a fim de" ++ infStr vp
       } ;
-
-    ApposNP np1 np2 = np1 ** {
-      s = \\c => {
-        c1 = (np1.s ! c).c1  ++ (np2.s ! c).c1 ;
-        c2 = (np1.s ! c).c2 ++ (np2.s ! c).c2 ;
-        comp = (np1.s ! c).comp ++ (np2.s ! c).comp ;
-        ton = (np1.s ! c).ton ++ (np2.s ! c).ton
-        } ;
-      } ;
-
-    AdAdV aa av = {
-      s = aa.s ++ av.s
-      } ;
-
-    UttAdV av = av ;
-
-    PositAdVAdj a = {
-      s = a.s ! Posit ! AA
-      } ;
-
-    --TODO: actually use ant
-    CompVP ant p vp = let
-      neg = negation ! p.p
-      in {
-        s = \\agr => ant.s ++ p.s ++ "de" ++ neg.p1 ++ infVP vp agr ;
-        cop = serCopula
-      } ;
-
-    UttVPShort = UttVP ;
-
-    ComplSlashPartLast = ComplSlash ;
-
-  oper
-    gerundStr : VP -> Str ;
-    gerundStr vp = gerVP vp (Ag Masc Sg P3) ;
 
   lin
-    UncontractedNeg = {s = [] ; p = RNeg False} ;
-
-    -- Romance
-    UseComp_estar comp = insertComplement comp.s (predV estar_V) ;
-
     iFem_Pron = pronAgr S.i_Pron Fem Sg P1 ;
     weFem_Pron = pronAgr S.we_Pron Fem Pl P1 ;
     youFem_Pron = pronAgr S.youSg_Pron Fem Sg P3 ;

--- a/src/portuguese/IdiomPor.gf
+++ b/src/portuguese/IdiomPor.gf
@@ -46,7 +46,7 @@ concrete IdiomPor of Idiom = CatPor **
            in
            vp.s.s ! VGer ++ clpr.p1 ++ obj
         )
-        (predV B.estar_V) ;
+        (predV B.stare_V) ;
 
     ImpPl1 vp = {s =
       mkImperative False P1 vp ! RPos ! Masc ! Pl ; --- fem

--- a/src/romance/DiffRomance.gf
+++ b/src/romance/DiffRomance.gf
@@ -189,4 +189,9 @@ oper
     <RPres,Simul>  => <verb ! VFin (VPres m) n p, []>
     } ;
 
+  oper
+    essere_V : Verb ;
+    stare_V : Verb ;
+    stare_V = essere_V ;
+
 } ;

--- a/src/romance/ExtendRomanceFunctor.gf
+++ b/src/romance/ExtendRomanceFunctor.gf
@@ -1,0 +1,267 @@
+incomplete concrete ExtendRomanceFunctor of Extend =
+  Cat ** open Grammar, ResRomance in {
+
+  lincat
+    RNP = Grammar.NP ;
+    RNPList = Grammar.ListNP ;
+
+  ---- these come from ExtraRomance: how to avoid the repetition?
+  ---- can't seem to be able to use two functors
+  lincat
+    VPS = {s : Mood => Agr => Bool => Str} ;
+    [VPS] = {s1,s2 : Mood => Agr => Bool => Str} ;
+
+  lin
+    BaseVPS x y = twoTable3 Mood Agr Bool x y ;
+    ConsVPS = consrTable3 Mood Agr Bool comma ;
+
+    BaseVPI = variants {} ;
+    ConsVPI = variants {} ;
+    BaseVPS2 = variants {} ;
+    ConsVPS2 = variants {} ;
+    BaseVPI2 = variants {} ;
+    ConsVPI2 = variants {} ;
+
+    --GenNP = variants {} ;
+    GenNP np =
+      let denp = (np.s ! ResRomance.genitive).ton in {
+        s = \\_,_,_,_ => [] ;
+        sp = \\_,_,_ => denp ;
+        s2 = denp ;
+        isNeg = False ;
+      } ;
+
+    GenIP ip = {s = \\_,_,c => ip.s ! c} ;
+    GenRP = variants {} ;     -- Num -> CN -> RP ; -- whose car
+
+    GenModNP num np cn = DetCN (DetQuant (GenNP (lin NP np)) num) cn ;
+    GenModIP num ip cn = IdetCN (IdetQuant (GenIP (lin IP ip)) num) cn ;
+
+    CompBareCN cn = {
+      s = \\agr => cn.s ! agr.n ;
+      cop = serCopula
+      } ;
+
+    StrandQuestSlash = QuestSlash ; -- whom does John live with ; DEFAULT with whom does John live
+    StrandRelSlash = RelSlash ; -- that he lives in ; DEFAULT in which he lives
+
+    EmptyRelSlash = variants {} ;
+    -- --TODO debug this definition
+    -- EmptyRelSlash cls = {
+    --   s = \\agr,t,a,p,m => cls.s ! agr ! DDir ! t ! a ! p ! m ++ cls.c2.s ;
+    --   c = Nom
+    --   } ;
+
+  lin
+    PredVPS np vpi = {
+      s = \\m => (np.s ! Nom).comp ++ vpi.s ! m ! np.a ! np.isNeg
+      } ;
+    MkVPS tm p vp = {
+      s = \\m,agr,isNeg =>
+        tm.s ++ p.s ++
+        (mkClausePol (orB isNeg vp.isNeg) [] False False agr vp).s
+          ! DDir ! tm.t ! tm.a ! p.p ! m
+      } ;
+    ConjVPS = conjunctDistrTable3 Mood Agr Bool ;
+
+    MkVPI vp = variants {} ;     -- Temp -> Pol -> VP -> VPI ; -- to sleep / hasn't slept
+    ConjVPI = variants {} ;     -- Conj -> [VPI] -> VPI ; -- has walked and won't sleep
+    ComplVPIVV = variants {} ;     -- VV -> VPI -> VP ; -- want to sleep and to walk
+    MkVPS2 = variants {} ;     --     : Temp -> Pol -> VPSlash -> VPS2 ;  -- has loved
+    ConjVPS2 = variants {} ;     --   : Conj -> [VPS2] -> VPS2 ;          -- has loved and now hates
+    ComplVPS2 = variants {} ;     --  : VPS2 -> NP -> VPS ;               -- has loved and now hates that person
+    MkVPI2 = variants {} ;     --     : Ant  -> Pol -> VPSlash -> VPI2 ;  -- to have loved
+    ConjVPI2 = variants {} ;     --   : Conj -> [VPI2] -> VPI2 ;          -- to love and have hated
+    ComplVPI2 = variants {} ;     --  : VPI2 -> NP -> VPI ;               -- to love and hate that person
+
+  lin
+    ProDrop p = p ** {
+      s = table {
+        Nom => let pn = p.s ! Nom
+          in {c1 = pn.c1 ; c2 = pn.c2 ; comp = [] ; ton = pn.ton} ;
+        c => p.s ! c
+        } ;
+      isNeg = False
+      } ;
+
+    ICompAP = variants {} ;     -- AP -> IComp ; -- "how old"
+    IAdvAdv = variants {} ;     -- Adv -> IAdv ; -- "how often"
+
+    CompIQuant iq = {s = \\aa => iq.s ! aa.n ! aa.g ! Nom ; cop = serCopula} ;
+
+    PrepCN prep cn = {s = prep.s ++ prepCase prep.c ++ cn.s ! Sg} ;
+
+    FocusObj = variants {} ;     -- NP -> SSlash -> Utt ; -- her I love
+    FocusAdv = variants {} ;     -- Adv -> S -> Utt ; -- today I will sleep
+    FocusAdV = variants {} ;     -- AdV -> S -> Utt ; -- never will I sleep
+      FocusAP = variants {} ;     -- AP -> NP -> Utt ; -- green was the tree
+    
+  lin
+    EmbedPresPart = variants {} ;     -- VP -> SC ; -- looking at Mary (is fun)
+
+    PresPartAP vp = {
+      s = \\af => gerVP vp (aform2aagr af ** {p = P3}) ;
+      isPre = False ;
+      copTyp = serCopula
+      } ;
+
+    PassVPSlash vps = passVPSlash vps [] ;
+    PassAgentVPSlash vps np = passVPSlash vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
+
+    PastPartAP vps = pastPartAP vps [] ;
+    PastPartAgentAP vps np = pastPartAP vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
+
+    ExistsNP = variants {} ;
+
+    NominalizeVPSlashNP = variants {} ;     -- VPSlash -> NP -> NP ;
+
+    ExistCN cn = ExistNP (DetCN (DetQuant IndefArt NumSg) cn) ;
+    ExistMassCN cn = ExistNP (MassNP cn) ;
+    ExistPluralCN cn = ExistNP (DetCN (DetQuant IndefArt NumPl) cn) ;
+
+  lin
+    ComplBareVS = ComplVS ;     -- VS -> S -> VP ; -- say she runs ; DEFAULT say that she runs
+    SlashBareV2S = SlashV2S ;     -- V2S -> S -> VPSlash ; -- answer (to him) it is good ; DEFAULT answer that it is good
+    ComplDirectVS vs utt = AdvVP (UseV <lin V vs : V>) (lin Adv {s = ":" ++ quoted utt.s}) ; -- DEFAULT complement added as Adv in quotes
+    ComplDirectVQ vq utt = AdvVP (UseV <lin V vq : V>) (lin Adv {s = ":" ++ quoted utt.s}) ; -- DEFAULT complement added as Adv in quotes
+    FrontComplDirectVS = variants {} ; -- NP -> VS -> Utt -> Cl ;      -- "I am here", she said
+    FrontComplDirectVQ  = variants {} ; -- NP -> VQ -> Utt -> Cl ;      -- "where", she asked
+    PredAPVP ap vp = ImpersCl (UseComp (CompAP (SentAP ap (EmbedVP vp)))) ; -- DEFAULT it is (good to walk)
+
+    AdjAsCN ap = {
+      s =\\n => ap.s ! (genNum2Aform Masc n) ;
+      g = Masc
+      } ;
+
+    AdjAsNP ap = heavyNP {
+      s = \\_c => ap.s ! ASg Masc APred ;
+      a = Ag Masc Sg P3
+      } ;
+
+  lin
+    ReflRNP = variants {} ;     -- VPSlash -> RNP -> VP ; -- love my family and myself
+    ReflPron = variants {} ;     -- RNP ; -- myself
+    ReflPoss = variants {} ;     -- Num -> CN -> RNP ; -- my car(s)
+    PredetRNP = variants {} ;     -- Predet -> RNP -> RNP ; -- all my brothers
+    ConjRNP = variants {} ;     -- Conj -> RNPList -> RNP ; -- my family, John and myself
+    Base_rr_RNP = variants {} ;     -- RNP -> RNP -> RNPList ; -- my family, myself
+    Base_nr_RNP = variants {} ;     -- NP -> RNP -> RNPList ; -- John, myself
+    Base_rn_RNP = variants {} ;     -- RNP -> NP -> RNPList ; -- myself, John
+    Cons_rr_RNP = variants {} ;     -- RNP -> RNPList -> RNPList ; -- my family, myself, John
+    Cons_nr_RNP = variants {} ;     -- NP -> RNPList -> RNPList ; -- John, my family, myself
+    ComplGenVV = variants {} ;     -- VV -> Ant -> Pol -> VP -> VP ; -- want not to have slept
+    ComplSlashPartLast = ComplSlash ;
+
+    CompoundN = variants {} ;     -- N -> N -> N ; -- control system / controls system / control-system
+    CompoundAP = variants {} ;     -- N -> A -> AP ; -- language independent / language-independent
+
+  lin
+    GerundNP vp = let
+      neutrAgr = Ag Masc Sg P3
+      in heavyNP {
+        s = \\_ => gerVP vp neutrAgr ;
+        a = neutrAgr
+      } ;
+
+    GerundCN vp = {
+      s = \\n => gerVP vp {g = Masc ; n = n ; p = P3} ;
+      g = Masc
+      } ;
+
+    GerundAdv vp = {
+      s = gerundStr vp
+      } ;
+
+  lin
+    PurposeVP vp = {
+      s = infVP vp (Ag Masc Sg P3)
+      } ;
+    
+    WithoutVP = variants {} ;     -- VP -> Adv ; -- without publishing the document
+
+    ByVP vp = {
+      s = gerundStr vp
+      } ;
+
+    InOrderToVP = variants {} ;     -- VP -> Adv ; -- (in order) to publish the document
+
+    ApposNP np1 np2 = np1 ** {
+      s = \\c => {
+        c1 = (np1.s ! c).c1  ++ (np2.s ! c).c1 ;
+        c2 = (np1.s ! c).c2 ++ (np2.s ! c).c2 ;
+        comp = (np1.s ! c).comp ++ (np2.s ! c).comp ;
+        ton = (np1.s ! c).ton ++ (np2.s ! c).ton
+        } ;
+      } ;
+
+    AdAdV aa av = {
+      s = aa.s ++ av.s
+      } ;
+    UttAdV av = av ;
+    PositAdVAdj a = {
+      s = a.s ! Posit ! AA
+      } ;
+
+  lin
+    CompS = variants {} ;     -- S -> Comp ; -- (the fact is) that she sleeps
+    CompQS = variants {} ;     -- QS -> Comp ; -- (the question is) who sleeps
+
+    --TODO: actually use ant
+    CompVP ant p vp = let
+      neg = negation ! p.p
+      in {
+        s = \\agr => ant.s ++ p.s ++ "de" ++ neg.p1 ++ infVP vp agr ;
+        cop = serCopula
+      } ;
+
+  lin
+    DetNPMasc = DetNP ;
+    DetNPFem = DetNP ;
+
+  lin
+    iFem_Pron = i_Pron ; -- DEFAULT I (masc)
+    youFem_Pron = youSg_Pron ; -- DEFAULT you (masc)
+    weFem_Pron = we_Pron ;  -- DEFAULT we (masc)
+    youPlFem_Pron = youPl_Pron ;  -- DEFAULT you plural (masc)
+    theyFem_Pron = they_Pron ;  -- DEFAULT they (masc)
+    youPolFem_Pron = youPol_Pron ;  -- DEFAULT you polite (masc)
+    youPolPl_Pron = youPl_Pron ;  -- DEFAULT you plural (masc)
+    youPolPlFem_Pron = youPl_Pron ;  -- DEFAULT you plural (masc)
+
+  lin
+    UseComp_estar comp = insertComplement comp.s (predV stare_V) ;
+    UncontractedNeg = {s = [] ; p = RNeg False} ;
+    UttAccNP = UttNP ; -- him (accusative) ; DEFAULT he
+    UttDatNP np = UttAccNP (lin NP np) ; -- him(dative) ; DEFAULT he
+    UttAccIP = UttIP ; -- whom (accusative) ; DEFAULT who
+    UttDatIP ip = UttAccIP (lin IP ip) ; -- whom (dative) ; DEFAULT who
+    UttVPShort = UttVP ;
+
+  oper
+    quoted : Str -> Str = \s -> "\"" ++ s ++ "\"" ; ---- TODO bind ; move to Prelude?
+
+  oper
+    gerundStr : VP -> Str ;
+    gerundStr vp = gerVP vp (Ag Masc Sg P3) ;
+
+    infStr : VP -> Str ;
+    infStr vp = infVP vp (Ag Masc Sg P3) ;
+
+    pastPartAP : VPSlash -> Str -> AP ;
+    pastPartAP vps agent = lin AP {
+      s = \\af => vps.comp ! (aform2aagr af ** {p = P3}) ++ vps.s.s ! VPart (aform2gender af) (aform2number af) ++ agent ;
+      isPre = False ;
+      copTyp = serCopula
+      } ;
+
+    passVPSlash : VPSlash -> Str -> VP ;
+    passVPSlash vps agent = let
+      auxvp = predV auxPassive
+      in
+      vps ** {
+        s = auxvp.s ;
+        agr = auxvp.agr ;
+        comp  = \\a => vps.comp ! a ++ (let agr = complAgr a in vps.s.s ! VPart agr.g agr.n) ++ agent ;
+      } ;
+
+} ;

--- a/src/spanish/DiffSpa.gf
+++ b/src/spanish/DiffSpa.gf
@@ -1,6 +1,6 @@
 --# -path=.:../romance:../abstract:../common:prelude
 
-instance DiffSpa of DiffRomance - [iAdvQuestionInv,otherInv,partAgr,vpAgrSubj,vpAgrClits,contractInf] = open CommonRomance, PhonoSpa, BeschSpa, Prelude in {
+instance DiffSpa of DiffRomance - [iAdvQuestionInv,otherInv,partAgr,stare_V,vpAgrSubj,vpAgrClits,contractInf] = open CommonRomance, PhonoSpa, BeschSpa, Prelude in {
 
   flags optimize=noexpand ;
     coding=utf8 ;
@@ -207,11 +207,9 @@ instance DiffSpa of DiffRomance - [iAdvQuestionInv,otherInv,partAgr,vpAgrSubj,vp
       _ => False
       } ;
 
-    auxPassive : Verb = verbBeschH (estar_2 "estar") ;
+    copula, essere_V : Verb = verbBeschH (ser_1 "ser") ;
 
-    copula : Verb = verbBeschH (ser_1 "ser") ;
-
-    estar_V : Verb = verbBeschH (estar_2 "estar") ;
+    estar_V, stare_V, auxPassive : Verb = verbBeschH (estar_2 "estar") ;
     
     haber_V : Verb = verbBeschH (haber_3 "haber") ;
 

--- a/src/spanish/ExtendSpa.gf
+++ b/src/spanish/ExtendSpa.gf
@@ -1,67 +1,38 @@
---# -path=alltenses:../common:../abstract
-
-concrete ExtendSpa of Extend =
-  CatSpa ** ExtendFunctor -
-   [
-     iFem_Pron, youFem_Pron, weFem_Pron, youPlFem_Pron, theyFem_Pron,
-        youPolFem_Pron, youPolPl_Pron, youPolPlFem_Pron,
-      ProDrop,
-      AdAdV,
-      AdjAsCN,
-      AdjAsNP,
-      ApposNP,
-      BaseVPS,
-      ByVP,
-      CompBareCN,
-      ComplBareVS,
-      ComplSlashPartLast,
-      CompoundAP,
-      CompoundN,
-      CompVP,
-      ConjVPS,
-      ConsVPS,
-      --EmptyRelSlash,
-      ExistsNP,
-      GenIP,
-      GenModIP,
-      GenModNP,
-      GenNP,
-      GerundAdv,
-      GerundCN,
-      GerundNP,
-      IAdvAdv,
-      ICompAP,
-      InOrderToVP,
-      ListVPS,
-      MkVPS,
-      PassAgentVPSlash,
-      PassVPSlash,
-      PastPartAP,
-      PastPartAgentAP,
-      PositAdVAdj,
-      PredVPS,
-      PresPartAP,
-      PurposeVP,
-      UseComp_estar,
-      VPS,
-      UttAdV,
-      UttVPShort,
-      WithoutVP
-   ]                   -- put the names of your own definitions here
+--# -path=alltenses:../common:../abstract:../romance
+concrete ExtendSpa of Extend = CatSpa ** ExtendRomanceFunctor -
+  [
+ CompVP,
+ CompoundAP,
+ CompoundN,
+ ExistsNP,
+ GenRP,
+ GenRP,
+ IAdvAdv,
+ ICompAP,
+ InOrderToVP,
+ WithoutVP,
+ iFem_Pron,
+ theyFem_Pron,
+ weFem_Pron,
+ youFem_Pron,
+ youPlFem_Pron,
+ youPolFem_Pron,
+ youPolPlFem_Pron,
+ youPolPl_Pron
+    ]                   -- don't forget to put the names of your own
+                       -- definitions here
   with
-    (Grammar = GrammarSpa) **
+    (Grammar = GrammarSpa), (Syntax = SyntaxSpa), (ResRomance = ResSpa) **
   open
-    GrammarSpa,
-    ResSpa,
-    MorphoSpa,
-    Coordination,
-    Prelude,
-    ParadigmsSpa in {
+  GrammarSpa,
+  ResSpa,
+  MorphoSpa,
+  Coordination,
+  Prelude,
+  ParadigmsSpa in {
     -- put your own definitions here
 
   lin
-    UseComp_estar comp = insertComplement comp.s (predV estar_V) ;
-
     iFem_Pron =  mkPronoun
       "yo" "me" "me" "mí"
       "mi" "mi" "mis" "mis"
@@ -98,60 +69,6 @@ concrete ExtendSpa of Extend =
       "su" "su" "sus" "sus"
       Fem Pl P3 ;
 
-    ProDrop p = p ** {
-      s = table {
-        Nom => let pn = p.s ! Nom in {c1 = pn.c1 ; c2 = pn.c2 ; comp = [] ; ton = pn.ton} ;
-        c => p.s ! c
-        } ;
-      isNeg = False
-      } ;
-
---- All that follows is copied from Portuguese /IL
-
-    GenNP np =
-      let denp = (np.s ! ResSpa.genitive).ton in {
-        s = \\_,_,_,_ => [] ;
-        sp = \\_,_,_ => denp ;
-        s2 = denp ;
-        isNeg = False ;
-      } ;
-
-     GenIP ip = {s = \\_,_,c => ip.s ! c} ;
-
-     GenModNP num np cn = DetCN (DetQuant (GenNP (lin NP np)) num) cn ;
-
-     GenModIP num ip cn = IdetCN (IdetQuant (GenIP (lin IP ip)) num) cn ;
-
-     CompBareCN cn = {
-       s = \\agr => cn.s ! agr.n ;
-       cop = serCopula
-       } ;
-
-     EmptyRelSlash cls = {
-       s = \\agr,t,a,p,m => cls.s ! agr ! DDir ! t ! a ! p ! m ++ cls.c2.s ;
-       c = Nom
-       } ;
-  lincat
-    VPS = {s : Mood => Agr => Bool => Str} ;
-    [VPS] = {s1,s2 : Mood => Agr => Bool => Str} ;
-
-  lin
-    BaseVPS x y = twoTable3 Mood Agr Bool x y ;
-    ConsVPS = consrTable3 Mood Agr Bool comma ;
-
-    PredVPS np vpi = {
-      s = \\m => (np.s ! Nom).comp ++ vpi.s ! m ! np.a ! np.isNeg
-      } ;
-
-    MkVPS tm p vp = {
-      s = \\m,agr,isNeg =>
-        tm.s ++ p.s ++
-        (mkClausePol (orB isNeg vp.isNeg) [] False False agr vp).s
-          ! DDir ! tm.t ! tm.a ! p.p ! m
-      } ;
-
-    ConjVPS = conjunctDistrTable3 Mood Agr Bool ;
-
     ICompAP ap = {
       s =\\a => "que tan" ++ ap.s ! (genNum2Aform a.g a.n) ;
       cop = serCopula
@@ -161,65 +78,11 @@ concrete ExtendSpa of Extend =
       s = "que tan" ++ adv.s
       } ;
 
-    CompIQuant iq = {s = \\aa => iq.s ! aa.n ! aa.g ! Nom ; cop = serCopula} ;
-
-    PrepCN prep cn = {s = prep.s ++ prepCase prep.c ++ cn.s ! Sg} ;
-
-  lin
-    PresPartAP vp = {
-      s = \\af => gerVP vp (aform2aagr af ** {p = P3}) ;
-      isPre = False ;
-      copTyp = serCopula
-      } ;
-
-    PastPartAP vps = pastPartAP vps [] ;
-
-    PastPartAgentAP vps np = pastPartAP vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
-
-    PassVPSlash vps = passVPSlash vps [] ;
-
-    PassAgentVPSlash vps np = passVPSlash vps (let by = <Grammar.by8agent_Prep : Prep> in by.s ++ (np.s ! by.c).ton) ;
-
     ExistsNP np =
       mkClause [] True False np.a
       (insertComplement (\\_ => (np.s ! Nom).ton)
          (predV (mkV "existir"))) ;
 
-    PurposeVP vp = {
-      s = infVP vp (Ag Masc Sg P3)
-      } ;
-
-    ComplBareVS = ComplVS ;
-
-    AdjAsCN ap = {
-      s =\\n => ap.s ! (genNum2Aform Masc n) ;
-      g = Masc
-      } ;
-
-    AdjAsNP ap = heavyNP {
-      s = \\_c => ap.s ! ASg Masc APred ;
-      a = Ag Masc Sg P3
-      } ;
-
-  oper
-    pastPartAP : VPSlash -> Str -> AP ;
-    pastPartAP vps agent = lin AP {
-      s = \\af => vps.comp ! (aform2aagr af ** {p = P3}) ++ vps.s.s ! VPart (aform2gender af) (aform2number af) ++ agent ;
-      isPre = False ;
-      copTyp = serCopula
-      } ;
-
-    passVPSlash : VPSlash -> Str -> VP ;
-    passVPSlash vps agent = let
-      auxvp = predV auxPassive
-      in
-      vps ** {
-        s = auxvp.s ;
-        agr = auxvp.agr ;
-        comp  = \\a => vps.comp ! a ++ (let agr = complAgr a in vps.s.s ! VPart agr.g agr.n) ++ agent ;
-      } ;
-
-  lin
     CompoundN noun noun2 = { -- order is different because that's needed for correct translation from english
       s = \\n => noun2.s ! n
         ++ variants {"de" ; genForms "do" "da" ! noun.g}
@@ -235,51 +98,12 @@ concrete ExtendSpa of Extend =
       copTyp = adj.copTyp
       } ;
 
-    GerundCN vp = {
-      s = \\n => gerVP vp {g = Masc ; n = n ; p = P3} ;
-      g = Masc
-      } ;
-
-    GerundNP vp = let
-      neutrAgr = Ag Masc Sg P3
-      in heavyNP {
-        s = \\_ => gerVP vp neutrAgr ;
-        a = neutrAgr
-      } ;
-
-    GerundAdv vp = {
-      s = gerundStr vp
-      } ;
-
     WithoutVP vp = {
       s = "sin" ++ infStr vp
       } ;
 
-    ByVP vp = {
-      s = gerundStr vp
-      } ;
-
     InOrderToVP vp = {
       s = "para" ++ infStr vp
-      } ;
-
-    ApposNP np1 np2 = np1 ** {
-      s = \\c => {
-        c1 = (np1.s ! c).c1  ++ (np2.s ! c).c1 ;
-        c2 = (np1.s ! c).c2 ++ (np2.s ! c).c2 ;
-        comp = (np1.s ! c).comp ++ (np2.s ! c).comp ;
-        ton = (np1.s ! c).ton ++ (np2.s ! c).ton
-        } ;
-      } ;
-
-    AdAdV aa av = {
-      s = aa.s ++ av.s
-      } ;
-
-    UttAdV av = av ;
-
-    PositAdVAdj a = {
-      s = a.s ! Posit ! AA
       } ;
 
     --TODO: actually use ant
@@ -290,17 +114,4 @@ concrete ExtendSpa of Extend =
         cop = serCopula
       } ;
 
-    UttVPShort = UttVP ;
-
-    ComplSlashPartLast = ComplSlash ;
-
-  oper
-    gerundStr : VP -> Str ;
-    gerundStr vp = gerVP vp (Ag Masc Sg P3) ;
-    infStr : VP -> Str ;
-    infStr vp = infVP vp (Ag Masc Sg P3) ;
-
-  lin
-    UncontractedNeg = {s = [] ; p = RNeg False} ;
-
-    }
+} ;


### PR DESCRIPTION
- couldn't get a functor on top of another working in GFSS2018, so now
  we just copy the relevant definitions from ExtendFunctor and add the
  Romance-specific ones
- add stare_V to DiffRomance (and essere_V for symmetry) so that we
  can use it in ExtendRomance; using Latin verb name for fairness;
- add two missing lins to ExtendFunctor

  + related changes

- [ ] sharing can probably be increased by using an interface (or using the existing ones)
- [ ] refactor French
- [ ] add Italian, Catalan