### PR TITLE
French mixed up arguments

### DIFF
--- a/src/french/MorphoFre.gf
+++ b/src/french/MorphoFre.gf
@@ -73,7 +73,7 @@ oper
 -- Here are some patterns. First one that describes the worst case.
 
   mkAdj' : (_,_,_,_,_ : Str) -> Adj ;
-  mkAdj' vieux vieil vieuxs vieille vieillement = {
+  mkAdj' vieux vieil vieille vieuxs vieillement = {
     s = table {
       ASg Masc _ => pre {#voyelle => vieil ; "h" => vieil ; _ => vieux} ;
       ASg Fem _  => vieille ;

--- a/src/french/MorphoFre.gf
+++ b/src/french/MorphoFre.gf
@@ -73,7 +73,7 @@ oper
 -- Here are some patterns. First one that describes the worst case.
 
   mkAdj' : (_,_,_,_,_ : Str) -> Adj ;
-  mkAdj' vieux vieil vieille vieuxs vieillement = {
+  mkAdj' vieux vieil vieuxs vieille vieillement = {
     s = table {
       ASg Masc _ => pre {#voyelle => vieil ; "h" => vieil ; _ => vieux} ;
       ASg Fem _  => vieille ;

--- a/src/french/ParadigmsFre.gf
+++ b/src/french/ParadigmsFre.gf
@@ -393,8 +393,8 @@ oper
     mkPN : N -> PN = \x -> lin PN {s = x.s ! Sg ; g = x.g} ;
     } ;
 
-  mk4A a b c d = mk5A a a b c d ;
-  mk5A a b c d e = compADeg {s = \\_ => (mkAdj' a b c d e).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  mk4A masc fem mascpl aa = mk5A masc masc fem mascpl aa ;
+  mk5A masc masc fem mascpl aa = compADeg {s = \\_ => (mkAdj' masc masc mascpl fem aa).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
   regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
   prefA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
   adjCopula a cop = a ** {copTyp = cop} ;

--- a/src/french/ParadigmsFre.gf
+++ b/src/french/ParadigmsFre.gf
@@ -393,8 +393,8 @@ oper
     mkPN : N -> PN = \x -> lin PN {s = x.s ! Sg ; g = x.g} ;
     } ;
 
-  mk4A masc fem mascpl aa = mk5A masc masc fem mascpl aa ;
-  mk5A masc masc fem mascpl aa = compADeg {s = \\_ => (mkAdj' masc masc mascpl fem aa).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
+  mk4A a b c d = mk5A a a b c d ;
+  mk5A a b c d e = compADeg {s = \\_ => (mkAdj' a b c d e).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
   regA a = compADeg {s = \\_ => (mkAdjReg a).s ; isPre = False ; copTyp = serCopula ; lock_A = <>} ;
   prefA a = {s = a.s ; isPre = True ; copTyp = a.copTyp ; lock_A = <>} ;
   adjCopula a cop = a ** {copTyp = cop} ;


### PR DESCRIPTION
It seems like the arguments got mixed up after recent updates to both mkA-paradigms and the mkAdj'-function in MorphoFre. I noticed it because i had some unittests set up with french feminine plural forms that started linearizing as masculine plurals. This change fixes it at least for mk4A and mk5A, not sure if there are other dependent functions using mkAdj' that may be affected. 