### PR TITLE
(Por, UD) misc fixes

### DIFF
--- a/src/portuguese/DiffPor.gf
+++ b/src/portuguese/DiffPor.gf
@@ -238,7 +238,7 @@ instance DiffPor of DiffRomance - [iAdvQuestionInv,chooseTA,otherInv,partAgr,sta
     <RCond,Simul>  => <verb ! VFin VCondit n p, []> ; --# notpresent
     <RCond,Anter>  => <vaux ! VFin VCondit n p, part> ; --# notpresent
     <RPasse,Simul> => <verb ! VFin VPasse n p, []> ; --# notpresent
-    <RPasse,Anter> => <vaux ! VFin VPasse n p, part> ; --# notpresent
+    <RPasse,Anter>  => <vaux ! VFin (VPres m) n p, part> ; --# notpresent
     <RPres,Anter>  => <verb ! VFin VPasse n p, []> ; --# notpresent
     <RPres,Simul>  => <verb ! VFin (VPres m) n p, []>
     } ;

--- a/src/portuguese/ExtendPor.gf
+++ b/src/portuguese/ExtendPor.gf
@@ -8,6 +8,7 @@ concrete ExtendPor of Extend = CatPor ** ExtendRomanceFunctor -
      GenRP,
      ICompAP,
      InOrderToVP,
+     EmbedSSlash,
      WithoutVP,
      iFem_Pron,
      theyFem_Pron,
@@ -59,6 +60,9 @@ concrete ExtendPor of Extend = CatPor ** ExtendRomanceFunctor -
   oper
     exist_V : V ;
     exist_V = mkV "existir" ;
+
+  lin
+    EmbedSSlash s = {s = \\_ => "o que" ++ s.s ! {g = Masc ; n = Sg} ! Indic} ;
 
   lin
     CompoundN noun noun2 = { -- order is different because that's needed for correct translation from english

--- a/src/spanish/ExtendSpa.gf
+++ b/src/spanish/ExtendSpa.gf
@@ -5,6 +5,7 @@ concrete ExtendSpa of Extend = CatSpa ** ExtendRomanceFunctor -
  CompoundAP,
  CompoundN,
  ExistsNP,
+ EmbedSSlash,
  GenRP,
  GenRP,
  IAdvAdv,

--- a/treebanks/ud-rgl-trees.txt
+++ b/treebanks/ud-rgl-trees.txt
@@ -33,7 +33,7 @@ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (ImpersCl (UseComp (CompAd
 PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePN john_PN) (ComplVA become_VA (PositA clever_A))))) NoVoc
 PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePN john_PN) (ProgrVP (UseV sleep_V))))) NoVoc
 PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (ExistNPAdv (DetCN (DetQuant IndefArt NumSg) (UseN cow_N)) (PrepNP in_Prep (DetCN (DetQuant DefArt NumSg) (UseN forest_N)))))) NoVoc
-PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredSCVP (EmbedQS (UseQCl (TTAnt TPast ASimul) PPos (QuestSlash whatSg_IP (SlashVP (UsePron she_Pron) (SlashV2a do_V2))))) (UseComp (CompAP (PositA important_A)))))) NoVoc
+PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredSCVP (EmbedSSlash (UseSlash (TTAnt TPast ASimul) PPos (SlashVP (UsePron she_Pron) (SlashV2a do_V2)))) (UseComp (CompAP (PositA important_A)))))) NoVoc
 PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredSCVP (EmbedS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (UseV sleep_V)))) (AdvVP (PassV2 see_V2) (PrepNP by8agent_Prep everything_NP))))) NoVoc
 PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN man_N)) (UseComp (CompAdv here_Adv))))) NoVoc
 PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash (IdetCN (IdetQuant which_IQuant NumSg) (UseN book_N)) (SlashVP (UsePron youSg_Pron) (SlashV2a like_V2))))) NoVoc


### PR DESCRIPTION
* correct tree in ud treebank
- needs Extend's EmbedSSlash

* (Por) add EmbedSSlash

* (Por) change verb form for RPasse AAnter
the current linearization of RPasse Anter tense combination is not
grammatical Portuguese, while the auxiliar in the present + participle
past form is not available anywhere (it is grammatical Portuguese but
not as common as simple past, which gets the RPast ASimul
linearization)