### PR TITLE
Pron ordering

### DIFF
--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -106,13 +106,17 @@ concrete CatGer of Cat =
     Tense = {s : Str ; t : ResGer.Tense ; m : Mood} ;
 
   linref
+    NP = \np -> np.s!(NPC Nom) ++ np.adv ++ np.ext ++ np.rc ; -- HL 6/2019
+    CN = \cn -> cn.s ! Strong ! Pl ! Nom ++ cn.adv ++ cn.ext ++ cn.rc ! Pl ;
+
     SSlash = \ss -> ss.s ! Main ++ ss.c2.s  ;
     ClSlash = \cls -> cls.s ! MIndic ! Pres ! Simul ! Pos ! Main ++ cls.c2.s ;
 
     VP = \vp -> useInfVP False vp ;
     VPSlash = \vps -> useInfVP False vps ++ vps.c2.s ;
 
-	AP = \ap -> ap.s ! APred ++ ap.ext ;
+	AP = \ap -> ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ++ ap.ext ;
+        A2 = \a2 -> a2.s ! Posit ! APred ++ a2.c2.s ;
 
     V, VS, VQ, VA = \v -> useInfVP False (predV v) ;
     V2, V2A, V2Q, V2S = \v -> useInfVP False (predV v) ++ v.c2.s ;

--- a/src/german/ConstructionGer.gf
+++ b/src/german/ConstructionGer.gf
@@ -10,7 +10,7 @@ lin
   hungry_VP = mkVP (mkA "hungrig") ;
   thirsty_VP = mkVP (mkA "durstig") ;
   tired_VP = mkVP (mkA "müde") ;
-  scared_VP = mkVP have_V2 (mkNP (mkN "Angst" "Angsten" feminine)) ;
+  scared_VP = mkVP have_V2 (mkNP (mkN "Angst" "Ängste" feminine)) ;
   ill_VP = mkVP (mkA "krank") ;
   ready_VP = mkVP (mkA "bereit") ;
 

--- a/src/german/DictVerbsGer.gf
+++ b/src/german/DictVerbsGer.gf
@@ -256,8 +256,8 @@ lin
   abgehen_V = prefixV "ab" (irregV "gehen" "geht" "ging" "ginge" "gegangen") ;
   abgenzern_V2 = dirV2 (prefixV "ab" (regV "genzern"))  ;
   abgeraten_von_V2 = prepV2 (prefixV "ab" (irregV "geraten" "gerät" "geriet" "geriete" "geraten")) von_Prep ;
-  abgewoehnen_rV2 = reflV2 (prefixV "ab" (regV "gewöhnen")) accusative accPrep ;
-  abgewoehnen_rVV = reflVV (prefixV "ab" (regV "gewöhnen")) accusative ;
+  abgewoehnen_rV2 = reflV2 (prefixV "ab" (regV "gewöhnen")) dative accPrep ;
+  abgewoehnen_rVV = reflVV (prefixV "ab" (regV "gewöhnen")) dative ;
   abgraebeln_V = prefixV "ab" (regV "gräbeln") ;
   abgraten_V2 = dirV2 (prefixV "ab" (regV "graten"))  ;
   abgrenzen_V2 = dirV2 (prefixV "ab" (regV "grenzen"))  ;
@@ -338,9 +338,9 @@ lin
   absahnen_V2 = dirV2 (prefixV "ab" (regV "sahnen"))  ;
   abschachern_dat_V3 = accdatV3 (prefixV "ab" (regV "schachern"))  ;
   abschaffen_V2 = dirV2 (prefixV "ab" (regV "schaffen"))  ;
-  abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) accusative accPrep bei_Prep ;
+  abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;
   abschauen_bei_V3 = dirV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) bei_Prep ;
-  abschauen_rV2 = reflV2 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) accusative accPrep ;
+  abschauen_rV2 = reflV2 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep ;
   abschenken_V2 = dirV2 (prefixV "ab" (regV "schenken"))  ;
   abschenken_V = prefixV "ab" (regV "schenken") ;
   abschicken_V2 = dirV2 (prefixV "ab" (regV "schicken"))  ;
@@ -350,7 +350,7 @@ lin
   abschliessen_V2 = dirV2 (prefixV "ab" (irregV "schließen" "schließt" "schloss" "schlösse" "geschlossen"))  ;
   abschmettern_V2 = dirV2 (prefixV "ab" (irregV "schmettern" "schmettert" "schmetterte" "schmetterte" "geschmettert"))  ;
   abschmieren_V = prefixV "ab" (regV "schmieren") ;
-  abschminken_rV2 = reflV2 (prefixV "ab" (regV "schminken")) accusative accPrep ;
+  abschminken_rV2 = reflV2 (prefixV "ab" (regV "schminken")) dative accPrep ;
   abschminken_V2 = dirV2 (prefixV "ab" (regV "schminken"))  ;
   abschmirgeln_V2 = dirV2 (prefixV "ab" (regV "schmirgeln"))  ;
   abschmuecken_V2 = dirV2 (prefixV "ab" (regV "schmücken"))  ;
@@ -580,7 +580,7 @@ lin
   anfreunden_mit_rV2 = reflV2 (prefixV "an" (regV "freunden")) accusative mit_Prep ;
   anfuehlen_V2 = dirV2 (prefixV "an" (regV "fühlen"))  ;
   anfuehlen_wie_rV2 = reflV2 (prefixV "an" (regV "fühlen")) accusative (mkPrep "wie" nominative) ;
-  angeben_mit_V2 = prepV2 (prefixV "an" (irregV "geben" "gebt" "gab" "gäbe" "gegeben")) mit_Prep ;
+  angeben_mit_V2 = prepV2 (prefixV "an" (irregV "geben" "gibt" "gab" "gäbe" "gegeben")) mit_Prep ;
   angehen_sV = dassV (prefixV "an" (irregV "gehen" "geht" "ging" "ginge" "gegangen"))  ;
   angehen_V2 = dirV2 (prefixV "an" (irregV "gehen" "geht" "ging" "ginge" "gegangen"))  ;
   angehoeren_dat_V2 = mkV2 (prefixV "an" (regV "gehören")) datPrep ;
@@ -797,9 +797,9 @@ lin
   auffassen_als_V3 = dirV3 (prefixV "auf" (regV "fassen")) (mkPrep "als" accusative) ;
   auffrieren_V = prefixV "auf" (irregV "frieren" "friert" "fror" "fröre" "gefroren") ;
   auffuehren_V2 = dirV2 (prefixV "auf" (regV "führen"))  ;
-  aufgeben_V2 = dirV2 (prefixV "auf" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
-  aufgeben_V = prefixV "auf" (irregV "geben" "gebt" "gab" "gäbe" "gegeben") ;
-  aufgeben_VV = mkVV (prefixV "auf" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
+  aufgeben_V2 = dirV2 (prefixV "auf" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
+  aufgeben_V = prefixV "auf" (irregV "geben" "gibt" "gab" "gäbe" "gegeben") ;
+  aufgeben_VV = mkVV (prefixV "auf" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
   aufgehen_dat_V2 = mkV2 (prefixV "auf" (irregV "gehen" "geht" "ging" "ginge" "gegangen")) datPrep ;
   aufgehen_V = prefixV "auf" (irregV "gehen" "geht" "ging" "ginge" "gegangen") ;
   aufhaengen_V2 = dirV2 (prefixV "auf" (regV "hängen"))  ;
@@ -925,7 +925,7 @@ lin
   ausbuexen_von_V2 = prepV2 (prefixV "aus" (regV "büxen")) von_Prep ;
   ausbuexen_V = prefixV "aus" (regV "büxen") ;
   ausdehnen_rV = reflV (prefixV "aus" (regV "dehnen")) accusative ;
-  ausdenken_rV2 = reflV2 (prefixV "aus" (irregV "denken" "denkt" "dachte" "dächte" "gedacht")) accusative accPrep ;
+  ausdenken_rV2 = reflV2 (prefixV "aus" (irregV "denken" "denkt" "dachte" "dächte" "gedacht")) dative accPrep ;
   ausdruecken_rVA = reflVA (prefixV "aus" (regV "drücken")) accusative ;
   ausdruecken_V2 = dirV2 (prefixV "aus" (regV "drücken"))  ;
 --  ausdruecken_V = prefixV "aus" (irregV "drücken" "drückt" "drückte" "drückte" "gedrückt") ;
@@ -938,7 +938,7 @@ lin
   ausfuehren_V2 = dirV2 (prefixV "aus" (regV "führen"))  ;
   ausfuehren_VS = mkVS (prefixV "aus" (regV "führen"))  ;
   ausfuellen_V2 = dirV2 (prefixV "aus" (regV "füllen"))  ;
-  ausgeben_V2 = dirV2 (prefixV "aus" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
+  ausgeben_V2 = dirV2 (prefixV "aus" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
   ausgehen_mit_V2 = prepV2 (prefixV "aus" (irregV "gehen" "geht" "ging" "ginge" "gegangen")) mit_Prep ;
   ausgehen_V = prefixV "aus" (irregV "gehen" "geht" "ging" "ginge" "gegangen") ;
   ausgleichen_durch_V3 = dirV3 (prefixV "aus" (irregV "gleichen" "gleicht" "glich" "gliche" "geglichen")) durch_Prep ;
@@ -1194,7 +1194,7 @@ lin
   behandeln_als_V3 = dirV3 (regV "behandeln") (mkPrep "als" accusative) ;
   behandeln_mit_V3 = dirV3 (regV "behandeln") mit_Prep ;
   behaupten_VS = mkVS (irregV "behaupten" "behauptet" "behauptete" "behaupte" "behauptet")  ;
-  behelfen_mit_rV2 = reflV2 (irregV "behelfen" "behilft" "behalf" "behalf" "beholfen") accusative mit_Prep ;
+  behelfen_mit_rV2 = reflV2 (irregV "behelfen" "behilft" "behalf" "behalf" "beholfen") dative mit_Prep ;
   behelligen_mit_V3 = dirV3 (regV "behelligen") mit_Prep ;
   beherbergen_V2 = dirV2 (regV "beherbergen")  ;
   beherrschen_V2 = dirV2 (regV "beherrschen")  ;
@@ -1902,7 +1902,7 @@ lin
   einen_V2 = dirV2 (regV "einen")  ;
   einfallen_dat_sV2 = dassV2 (prefixV "ein" (irregV "fallen" "fallt" "fiel" "fiele" "gefallen")) datPrep ;
   einfallen_in_V2 = prepV2 (prefixV "ein" (irregV "fallen" "fallt" "fiel" "fiele" "gefallen")) (mkPrep "in" accusative) ;
-  einfangen_rV2 = reflV2 (prefixV "ein" (irregV "fangen" "fängt" "fing" "fing" "gefangen")) accusative accPrep ;
+  einfangen_rV2 = reflV2 (prefixV "ein" (irregV "fangen" "fängt" "fing" "fing" "gefangen")) dative accPrep ;
   einfangen_V2 = dirV2 (prefixV "ein" (irregV "fangen" "fängt" "fing" "fing" "gefangen"))  ;
   einfinden_loc_rV2 = reflV2 (prefixV "ein" (irregV "finden" "findet" "fand" "fände" "gefunden")) accusative loc_Prep ;
   einfloessen_dat_V2S = mkV2S (prefixV "ein" (irregV "flößen" "flößt" "flöße" "flöße" "geflößt")) datPrep ;
@@ -1913,7 +1913,7 @@ lin
   einfuegen_rV = reflV (prefixV "ein" (regV "fügen")) accusative ;
   einfuehren_in_V3 = dirV3 (prefixV "ein" (regV "führen")) (mkPrep "in" accusative) ;
   einfuehren_V2 = dirV2 (prefixV "ein" (regV "führen"))  ;
-  eingeben_in_V3 = dirV3 (prefixV "ein" (irregV "geben" "gebt" "gab" "gäbe" "gegeben")) (mkPrep "in" accusative) ;
+  eingeben_in_V3 = dirV3 (prefixV "ein" (irregV "geben" "gibt" "gab" "gäbe" "gegeben")) (mkPrep "in" accusative) ;
   eingehen_in_V2 = prepV2 (prefixV "ein" (irregV "gehen" "geht" "ging" "ginge" "gegangen")) (mkPrep "in" accusative) ;
   eingehen_V = prefixV "ein" (irregV "gehen" "geht" "ging" "ginge" "gegangen") ;
   eingemeinden_V2 = dirV2 (prefixV "ein" (irregV "gemeinden" "gemeindet" "gemeindete" "gemeindete" "gemeindet"))  ;
@@ -2210,7 +2210,7 @@ lin
   ergaenzen_mit_V3 = dirV3 (irregV "ergänzen" "ergänzt" "ergänzte" "ergänzte" "ergänzt") mit_Prep ;
   ergattern_V2 = dirV2 (irregV "ergattern" "ergattert" "ergatterte" "ergattere" "ergattert")  ;
   ergaunern_V2 = dirV2 (irregV "ergaunern" "ergaunert" "ergaunerte" "ergaunerte" "ergaunert")  ;
-  ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergebt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
+  ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergibt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
   ergetzen_am_V2 = prepV2 (irregV "ergetzen" "ergetzt" "ergetzte" "ergetzte" "ergetzt") (mkPrep "an" dative) ;
   ergiessen_in_V2 = prepV2 (irregV "ergießen" "ergießt" "ergoss" "ergösse" "ergossen") (mkPrep "in" accusative) ;
   ergiessen_ueber_V2 = prepV2 (irregV "ergießen" "ergießt" "ergoss" "ergösse" "ergossen") (mkPrep "über" accusative) ;
@@ -2266,7 +2266,7 @@ lin
   erleichtern_rV = reflV (irregV "erleichtern" "erleichtert" "erleichterte" "erleichtere" "erleichtert") accusative ;
   erleiden_V2 = dirV2 (irregV "erleiden" "erleidet" "erlitt" "erlitte" "erlitten")  ;
   erlernen_V2 = dirV2 (irregV "erlernen" "erlernt" "erlernte" "erlernte" "erlernt")  ;
-  erlesen_rV2 = reflV2 (irregV "erlesen" "erlest" "erlas" "erläse" "erlesen") accusative accPrep ;
+  erlesen_rV2 = reflV2 (irregV "erlesen" "erlest" "erlas" "erläse" "erlesen") dative accPrep ;
   erleuchten_V2 = dirV2 (irregV "erleuchten" "erleuchtet" "erleuchtete" "erleuchtete" "erleuchtet")  ;
   erloeschen_V = irregV "erlöschen" "erlöscht" "erlosch" "erlösche" "erloschen" ;
   erloesen_V2 = dirV2 (irregV "erlösen" "erlöst" "erlöste" "erlöste" "erlöst")  ;
@@ -2369,7 +2369,7 @@ lin
   erwaermen_V2 = dirV2 (irregV "erwärmen" "erwärmt" "erwärmte" "erwärmte" "erwärmt")  ;
   erwahren_V2 = dirV2 (irregV "erwahren" "erwahrt" "erwahrte" "erwahrte" "erwahrt")  ;
   erwarten_V2 = dirV2 (irregV "erwarten" "erwartet" "erwartete" "erwarte" "erwartet")  ;
-  erwarten_von_rV3 = reflV3 (irregV "erwarten" "erwartet" "erwartete" "erwarte" "erwartet") accusative accPrep von_Prep ;
+  erwarten_von_rV3 = reflV3 (irregV "erwarten" "erwartet" "erwartete" "erwarte" "erwartet") dative accPrep von_Prep ;
   erweichen_V2 = dirV2 (irregV "erweichen" "erweicht" "erweichte" "erweichte" "erweicht")  ;
   erweisen_dat_V3 = accdatV3 (irregV "erweisen" "erweist" "erwies" "erwiese" "erwiesen")  ;
   erweitern_V2 = dirV2 (irregV "erweitern" "erweitert" "erweiterte" "erweiterte" "erweitert")  ;
@@ -2761,7 +2761,7 @@ lin
   gebaerden_als_rV2 = reflV2 (irregV "gebärden" "gebärdet" "gebärdete" "gebärdete" "gebärdet") accusative (mkPrep "als" nominative) ;
   gebaerden_wie_rV2 = reflV2 (irregV "gebärden" "gebärdet" "gebärdete" "gebärdete" "gebärdet") accusative (mkPrep "wie" nominative) ;
   gebaeren_V2 = dirV2 (irregV "gebären" "gebärt" "gebar" "gebäre" "geboren")  ;
-  geben_dat_V3 = accdatV3 (irregV "geben" "gebt" "gab" "gäbe" "gegeben")  ;
+  geben_dat_V3 = accdatV3 (irregV "geben" "gibt" "gab" "gäbe" "gegeben")  ;
   gebieten_dat_V2V = mkV2V (irregV "gebieten" "gebietet" "gebot" "geböte" "geboten") datPrep ;
   gebrauchen_V2 = dirV2 (irregV "gebrauchen" "gebraucht" "gebrauchte" "gebrauchte" "gebraucht")  ;
   gebuehren_dat_sV2 = dassV2 (irregV "gebühren" "gebührt" "gebührte" "gebührte" "gebührt") datPrep ;
@@ -2826,7 +2826,7 @@ lin
   gestatten_dat_V2S = mkV2S (irregV "gestatten" "gestattet" "gestattete" "gestattete" "gestattet") datPrep ;
   gestatten_dat_V3 = accdatV3 (irregV "gestatten" "gestattet" "gestattete" "gestattete" "gestattet")  ;
   gestikulieren_V = regV "gestikulieren" ;
-  getrauen_rVV = reflVV (irregV "getrauen" "getraut" "getraute" "getraute" "getraut") dative ;
+  getrauen_rVV = reflVV (irregV "getrauen" "getraut" "getraute" "getraute" "getraut") accusative ;
   gettoisieren_V2 = dirV2 (regV "gettoisieren")  ;
   gewaehren_dat_V3 = accdatV3 (irregV "gewähren" "gewährt" "gewährte" "gewährte" "gewährt")  ;
   gewaehrleisten_dat_V2S = mkV2S (irregV "gewährleisten" "gewährleistet" "gewährleistete" "gewährleistete" "gewährleistet") datPrep ;
@@ -2904,7 +2904,7 @@ lin
   grausen_sV2 = dassV2 (regV "grausen") accPrep ;
   grausen_V2 = dirV2 (regV "grausen")  ;
   greifen_dir_V2 = prepV2 (irregV "greifen" "greift" "griff" "griffe" "gegriffen") dir_Prep ;
-  greifen_rV2 = reflV2 (irregV "greifen" "greift" "griff" "griffe" "gegriffen") accusative accPrep ;
+  greifen_rV2 = reflV2 (irregV "greifen" "greift" "griff" "griffe" "gegriffen") dative accPrep ;
   greinen_V = regV "greinen" ;
   grenzen_an_V2 = prepV2 (regV "grenzen") (mkPrep "an" accusative) ;
   grienen_V = regV "grienen" ;
@@ -3041,7 +3041,7 @@ lin
   herausarbeiten_VS = mkVS (prefixV "heraus" (regV "arbeiten"))  ;
   herausfinden_V2 = dirV2 (prefixV "heraus" (irregV "finden" "findet" "fand" "fände" "gefunden"))  ;
   herausfinden_VS = mkVS (prefixV "heraus" (irregV "finden" "findet" "fand" "fände" "gefunden"))  ;
-  herausgeben_V2 = dirV2 (prefixV "heraus" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
+  herausgeben_V2 = dirV2 (prefixV "heraus" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
   herauskommen_aus_V2 = prepV2 (prefixV "heraus" (irregV "kommen" "kommt" "kam" "käme" "gekommen")) aus_Prep ;
   herauskommen_sV = dassV (prefixV "heraus" (irregV "kommen" "kommt" "kam" "käme" "gekommen"))  ;
   herauskristallisieren_rV = reflV (prefixV "heraus" (regV "kristallisieren")) accusative ;
@@ -3677,7 +3677,7 @@ lin
   krakeelen_V = regV "krakeelen" ;
   krakeelen_VS = mkVS (regV "krakeelen")  ;
   krakeln_dir_V3 = dirV3 (regV "krakeln") dir_Prep ;
-  krallen_rV2 = reflV2 (regV "krallen") accusative accPrep ;
+  krallen_rV2 = reflV2 (regV "krallen") dative accPrep ;
   kramen_aus_V3 = dirV3 (regV "kramen") aus_Prep ;
   kramen_in_nach_V3 = mkV3 (regV "kramen") (mkPrep "in" accusative) nach_Prep ;
   kranken_am_V2 = prepV2 (regV "kranken") (mkPrep "an" dative) ;
@@ -3843,12 +3843,12 @@ lin
   leiden_V2 = dirV2 (irregV "leiden" "leidet" "litt" "litte" "gelitten")  ;
   leidtun_dat_sV2 = dassV2 (prefixV "leid" (irregV "tun" "tut" "tat" "täte" "getan")) datPrep ;
   leidtun_dat_V2 = mkV2 (prefixV "leid" (irregV "tun" "tut" "tat" "täte" "getan")) datPrep ;
-  leihen_bei_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") accusative accPrep bei_Prep ;
+  leihen_bei_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") dative accPrep bei_Prep ;
   leihen_dat_V3 = accdatV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen")  ;
-  leihen_im_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") accusative accPrep (mkPrep "in" dative) ;
-  leihen_von_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") accusative accPrep von_Prep ;
+  leihen_im_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") dative accPrep (mkPrep "in" dative) ;
+  leihen_von_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") dative accPrep von_Prep ;
   leimen_V2 = dirV2 (regV "leimen")  ;
-  leisten_rV2 = reflV2 (irregV "leisten" "leistet" "leistete" "leiste" "geleistet") accusative accPrep ;
+  leisten_rV2 = reflV2 (irregV "leisten" "leistet" "leistete" "leiste" "geleistet") dative accPrep ;
   leisten_V2 = dirV2 (irregV "leisten" "leistet" "leistete" "leiste" "geleistet")  ;
   leitartikeln_V = regV "leitartikeln" ;
   leiten_V2 = dirV2 (irregV "leiten" "leitet" "leitete" "leite" "geleitet")  ;
@@ -4057,7 +4057,7 @@ lin
   miterleben_VS = mkVS (prefixV "mit" (irregV "erleben" "erlebt" "erlebte" "erlebte" "erlebt"))  ;
   mitessen_mit_V2 = prepV2 (prefixV "mit" (irregV "essen" "isst" "aß" "aß" "gegessen")) mit_Prep ;
   mitfuehlen_mit_V2 = prepV2 (prefixV "mit" (regV "fühlen")) mit_Prep ;
-  mitgeben_V2 = dirV2 (prefixV "mit" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
+  mitgeben_V2 = dirV2 (prefixV "mit" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
   mitgehen_mit_V2 = prepV2 (prefixV "mit" (irregV "gehen" "geht" "ging" "ging" "gegangen")) mit_Prep ;
   mitkommen_mit_V2 = prepV2 (prefixV "mit" (irregV "kommen" "kommt" "kam" "käme" "gekommen")) mit_Prep ;
   mitmischen_bei_V2 = prepV2 (prefixV "mit" (regV "mischen")) bei_Prep ;
@@ -4137,7 +4137,7 @@ lin
   nachforschen_VQ = mkVQ (prefixV "nach" (regV "forschen"))  ;
   nachfuehlen_dat_V2S = mkV2S (prefixV "nach" (regV "fühlen")) datPrep ;
   nachfuehlen_dat_V3 = accdatV3 (prefixV "nach" (regV "fühlen"))  ;
-  nachgeben_dat_V2 = mkV2 (prefixV "nach" (irregV "geben" "gebt" "gab" "gäbe" "gegeben")) datPrep ;
+  nachgeben_dat_V2 = mkV2 (prefixV "nach" (irregV "geben" "gibt" "gab" "gäbe" "gegeben")) datPrep ;
   nachgehen_dat_V2 = mkV2 (prefixV "nach" (irregV "gehen" "geht" "ging" "ginge" "gegangen")) datPrep ;
   nachgruebeln_ueber_V2 = prepV2 (prefixV "nach" (regV "grübeln")) (mkPrep "über" dative) ;
   nachhaken_bei_V2 = prepV2 (prefixV "nach" (regV "haken")) bei_Prep ;
@@ -4780,9 +4780,9 @@ lin
   reimen_auf_V3 = dirV3 (regV "reimen") (mkPrep "auf" accusative) ;
   reimen_V2 = dirV2 (regV "reimen")  ;
   reinchecken_in_V2 = prepV2 (prefixV "rein" (regV "checken")) (mkPrep "in" accusative) ;
-  reinchecken_rV2 = reflV2 (prefixV "rein" (regV "checken")) accusative accPrep ;
+  reinchecken_rV2 = reflV2 (prefixV "rein" (regV "checken")) dative accPrep ;
   reinigen_V2 = dirV2 (regV "reinigen")  ;
-  reinpfeifen_rV2 = reflV2 (prefixV "rein" (irregV "pfeifen" "pfeift" "pfiff" "priffe" "reingepfiffen")) accusative accPrep ;
+  reinpfeifen_rV2 = reflV2 (prefixV "rein" (irregV "pfeifen" "pfeift" "pfiff" "priffe" "reingepfiffen")) dative accPrep ;
   reinziehen_in_V3 = dirV3 (prefixV "rein" (irregV "ziehen" "zieht" "zog" "zöge" "gezogen")) (mkPrep "in" accusative) ;
   reisen_dir_V2 = prepV2 (regV "reisen") dir_Prep ;
   reissen_V2 = dirV2 (irregV "reißen" "reißt" "riss" "risse" "gerissen")  ;
@@ -5012,8 +5012,8 @@ lin
   schelten_V2 = dirV2 (irregV "schelten" "schilt" "schalt" "schölte" "gescholten")  ;
   schematisieren_V2 = dirV2 (regV "schematisieren")  ;
   schenken_dat_V3 = accdatV3 (regV "schenken")  ;
-  schenken_rV2 = reflV2 (regV "schenken") accusative accPrep ;
-  schenken_rVV = reflVV (regV "schenken") accusative ;
+  schenken_rV2 = reflV2 (regV "schenken") dative accPrep ;
+  schenken_rVV = reflVV (regV "schenken") dative ;
   scheppen_V2 = dirV2 (regV "scheppen")  ;
   scheppern_V = regV "scheppern" ;
   scheren_2_V = regV "scheren" ;
@@ -5357,8 +5357,8 @@ lin
   spannen_VS = mkVS (regV "spannen")  ;
   sparen_an_V2 = prepV2 (regV "sparen") (mkPrep "an" accusative) ;
   sparen_mit_V2 = prepV2 (regV "sparen") mit_Prep ;
-  sparen_rV2 = reflV2 (regV "sparen") accusative accPrep ;
-  sparen_rVV = reflVV (regV "sparen") accusative ;
+  sparen_rV2 = reflV2 (regV "sparen") dative accPrep ;
+  sparen_rVV = reflVV (regV "sparen") dative ;
   sparen_V2 = dirV2 (regV "sparen")  ;
   spassen_mit_V2 = prepV2 (regV "spaßen") mit_Prep ;
   spassen_VS = mkVS (regV "spaßen")  ;
@@ -5867,8 +5867,8 @@ lin
   ueberfliegen_V2 = dirV2 (irregV "überfliegen" "überfliegt" "überflog" "überflögee" "überflogen")  ;
   ueberfordern_V2 = dirV2 (irregV "überfordern" "überfordert" "überforderte" "überforderte" "überfordert")  ;
   ueberfuehren_gen_V3 = mkV3 (irregV "überführen" "überführt" "überführte" "überführte" "überführt") genPrep accPrep ;
-  uebergeben_dat_V3 = accdatV3 (irregV "übergeben" "übergebt" "übergab" "übergäbe" "übergeben")  ;
-  uebergeben_rV = reflV (irregV "übergeben" "übergebt" "übergab" "übergäbe" "übergeben") accusative ;
+  uebergeben_dat_V3 = accdatV3 (irregV "übergeben" "übergibt" "übergab" "übergäbe" "übergeben")  ;
+  uebergeben_rV = reflV (irregV "übergeben" "übergibt" "übergab" "übergäbe" "übergeben") accusative ;
   uebergehen_V2 = dirV2 (irregV "übergehen" "übergeht" "überging" "überginge" "übergegangen")  ;
   uebergehen_VS = mkVS (irregV "übergehen" "übergeht" "überging" "überginge" "übergegangen")  ;
   ueberholen_V2 = dirV2 (irregV "überholen" "überholt" "überholte" "überholte" "überholt")  ;
@@ -5938,7 +5938,7 @@ lin
   umfriedigen_V2 = dirV2 (irregV "umfriedigen" "umfriedigt" "umfriedigte" "umfriedigte" "umfriedigt")  ;
   umfunktionieren_zu_V3 = dirV3 (prefixV "um" (regV "funktionieren")) zu_Prep ;
   umgarnen_V2 = dirV2 (regV "umgarnen")  ;
-  umgeben_mit_V3 = dirV3 (irregV "umgeben" "umgebt" "umgab" "umgäbe" "umgeben") mit_Prep ;
+  umgeben_mit_V3 = dirV3 (irregV "umgeben" "umgibt" "umgab" "umgäbe" "umgeben") mit_Prep ;
   umgehen_V2 = dirV2 (irregV "umgehen" "umgeht" "umging" "umging" "umgangen")  ;
   umgestalten_V2 = dirV2 (prefixV "um" (irregV "gestalten" "gestaltet" "gestaltete" "gestaltete" "gestaltet"))  ;
   umhinkoennen_VV = mkVV (prefixV "umhin" (irregV "können" "kann" "konnte" "konnte" "gekonnt"))  ;
@@ -6198,7 +6198,7 @@ lin
   vergammeln_V = irregV "vergammeln" "vergammelt" "vergammelte" "vergammelte" "vergammelt" ;
   vergasen_V2 = dirV2 (irregV "vergasen" "vergast" "vergaste" "vergaste" "vergast")  ;
   vergattern_zu_V3 = dirV3 (irregV "vergattern" "vergatternt" "vergatterte" "vergatterte" "vergattert") zu_Prep ;
-  vergeben_dat_V2S = mkV2S (irregV "vergeben" "vergebt" "vergab" "vergäbe" "vergeben") datPrep ;
+  vergeben_dat_V2S = mkV2S (irregV "vergeben" "vergibt" "vergab" "vergäbe" "vergeben") datPrep ;
   vergegenstaendlichen_V2 = dirV2 (irregV "vergegenständlichen" "vergegenständlicht" "vergegenständlichte" "vergegenständlichte" "vergegenständlicht")  ;
   vergegenwaertigen_dat_V2S = mkV2S (irregV "vergegenwärtigen" "vergegenwärtigt" "vergegenwärtigte" "vergegenwärtigte" "vergegenwärtigt") datPrep ;
   vergegenwaertigen_dat_V3 = accdatV3 (irregV "vergegenwärtigen" "vergegenwärtigt" "vergegenwärtigte" "vergegenwärtigte" "vergegenwärtigt")  ;
@@ -6638,7 +6638,7 @@ lin
   vorbeugen_dat_V2 = mkV2 (prefixV "vor" (regV "beugen")) datPrep ;
   vorfallen_sV = dassV (irregV "vorfallen" "fallt" "fiel" "fiele" "gefallen")  ;
   vorfuehlen_bei_V2 = prepV2 (prefixV "vor" (regV "fühlen")) bei_Prep ;
-  vorgeben_VV = mkVV (prefixV "vor" (irregV "geben" "gebt" "gab" "gäbe" "gegeben"))  ;
+  vorgeben_VV = mkVV (prefixV "vor" (irregV "geben" "gibt" "gab" "gäbe" "gegeben"))  ;
   vorgehen_sV = dassV (prefixV "vor" (irregV "gehen" "geht" "ging" "ginge" "gegangen"))  ;
   vorhaben_VV = mkVV (prefixV "vor" (irregV "haben" "hat" "hatte" "hatte" "gehabt"))  ;
   vorhergehen_dat_V2 = mkV2 (prefixV "vor" (irregV "hergehen" "hergeht" "hergehte" "hergehte" "gehergeht")) datPrep ;

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -74,7 +74,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
 
     PastPartAP vp = {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ vp.a2 ++ vp.inf ++ 
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf ++ 
                   vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
@@ -84,7 +84,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     PastPartAgentAP vp np = 
     let agent = appPrepNP P.von_Prep np
     in {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ vp.a2 ++ agent ++ vp.inf ++ 
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ agent ++ 
+                   vp.inf ++ 
                    vp.c2.s ++ --- junk if not TV
                    vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
@@ -129,9 +130,13 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           subj  = [] ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
           neg   = tm.s ++ p.s ++ vp.a1 ! b ;
-          obj0  = (vp.nn ! agr).p1 ;
-          obj   = (vp.nn ! agr).p2 ;
-          compl = obj0 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
+          -- obj1  = (vp.nn ! agr).p1 ;
+          -- obj   = (vp.nn ! agr).p2 ; 
+          -- compl = obj1 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
+          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ nonpronouns
+          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
+          obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
+          compl = obj1 ++ neg ++ obj2 ++ obj3 ;
           inf   = vp.inf ++ verb.inf ;
           extra = vp.ext ;
           inffin : Str = 
@@ -189,7 +194,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
   lin
 	EsVV vv vp = predV vv ** {
-		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1 , n.p2 > ;
+		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1 , n.p2 , n.p3, n.p4> ;
 		inf = vp.s.s ! (VInf True) ++ vp.inf ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
 		a1 = vp.a1 ;
 		a2 = vp.a2 ;
@@ -198,7 +203,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 		adj = vp.adj } ;
 		
 	EsV2A v2a ap s = predV v2a ** {
-		nn = \\_ => <"es",[]> ; 
+		nn = \\_ => <"es",[],[],[]> ; 
 		adj = ap.s ! APred ; 
 		ext = "," ++ "dass" ++ s.s ! Sub} ;
 
@@ -243,9 +248,9 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
           neg   = vp.a1 ! b ;
-          obj0  = (vp.nn ! agr).p1 ;
-          obj   = (vp.nn ! agr).p2 ;
-          compl = obj0 ++ neg  ++ vp.adj ++ obj ++ vp.a2 ; -- adj added
+          obj1  = (vp.nn ! agr).p1 ;
+          obj2  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ;
+          compl = obj1 ++ neg  ++ vp.adj ++ obj2 ++ vp.a2 ; -- adj added
           inf   = vp.inf ++ verb.inf ; -- not used for linearisation of Main/Inv
           extra = vp.ext ;
           inffin : Str = 

--- a/src/german/IrregGer.gf
+++ b/src/german/IrregGer.gf
@@ -212,7 +212,7 @@ in {
   lin werben_V =  irregV "werben" "wirbt" "warb" "würbe" "geworben" ;
   lin werden_V = lin V (M.mkV "werden" "werde" "wirst" "wird" "werdet" "werd" 
                           "wurde" "wurdest" "wurden" "wurdet"
-                          "würde" "geworden" [] M.VHaben) ;
+                          "würde" "geworden" [] M.VSein) ;
   lin werfen_V =  irregV "werfen" "wirft" "warf" "würfe" "geworfen" ;
   lin wiegen_V =  irregV "wiegen" "wiegt" "wog" "wöge" "gewogen" ;
   lin winden_V =  irregV "winden" "windt" "wand" "wände" "gewunden" ;

--- a/src/german/LexiconGer.gf
+++ b/src/german/LexiconGer.gf
@@ -196,7 +196,7 @@ lin
   switch8off_V2 = dirV2 (prefixV "aus" (regV "schalten")) ;
   switch8on_V2 = dirV2 (prefixV "ein" (regV "schalten")) ;
   table_N = mkN "Tisch"  ;
-  talk_V3 = mkV3 (regV "reden") datPrep von_Prep ;
+  talk_V3 = mkV3 (regV "reden") (mkPrep "mit" dative) (mkPrep "über" accusative) ; -- 6/2019
   teacher_N = reg2N "Lehrer" "Lehrer" masculine ;
   teach_V2 = dirV2 (no_geV (regV "unterrichten")) ;
   television_N = reg2N "Fernsehen" "Fernsehen" neuter;
@@ -316,7 +316,7 @@ lin
   flow_V = seinV (Irreg.fließen_V) ; 
   fly_V = seinV (Irreg.fliegen_V) ; 
   freeze_V = Irreg.frieren_V ; 
-  give_V3 = accdatV3 Irreg.geben_V ;
+  give_V3 = accdatV3 Irreg.geben_V ; 
   laugh_V = regV "lachen" ;
   lie_V = Irreg.lügen_V ; 
   play_V = regV "spielen" ;

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -584,11 +584,12 @@ mkV2 : overload {
     mkV3 : V -> V3 
       = \v -> lin V3 (v ** {c2 = accPrep ; c3 = datPrep}) ;
     mkV3 : V -> Prep -> Prep -> V3
-      = \v,c,d -> v ** {c2 = c ; c3 = d ; lock_V3 = <>} ;
+      = \v,c,d -> lin V3 (v ** {c2 = c ; c3 = d}) ;
     } ;
 
-  dirV3 v p = mkV3 v (mkPrep [] accusative) p ;
-  accdatV3 v = mkV3 v (mkPrep [] dative) (mkPrep [] accusative) ; 
+  dirV3 v p = mkV3 v accPrep p ;        -- accPrep sets isPrep=False
+--  accdatV3 v = mkV3 v datPrep accPrep ; 
+  accdatV3 v = dirV3 v datPrep ;        -- to fit to Eng: direct obj = c2, HL 6/2019
 
   mkVS v = v ** {lock_VS = <>} ;
   mkVQ v = v ** {lock_VQ = <>} ;

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -188,8 +188,7 @@ resource ResGer = ParamX ** open Prelude in {
       in
       case <t,m> of {
         <Pres,MIndic>    => VFin b (VPresInd   an ap) ;
-        <Pres,MConjunct> => VFin b (VPresSubj  an ap) 
-                                                        ;  --# notpresent
+        <Pres,MConjunct> => VFin b (VPresSubj  an ap) ;  --# notpresent
         <Past,MIndic>    => VFin b (VImpfInd   an ap) ;  --# notpresent
         <Past,MConjunct> => VFin b (VImpfSubj  an ap) ;  --# notpresent
         _ => VInf False --# notpresent
@@ -502,14 +501,14 @@ resource ResGer = ParamX ** open Prelude in {
 
   VPC : Type = {
       s : Bool => Agr => VPForm => { -- True = prefix glued to verb
-        fin : Str ;          -- hat
-        inf : Str            -- wollen
-        } 
+        fin : Str ;          -- hat|wird
+        inf : Str            -- gelesen, lesen können|lesen (können),gelesen haben,
+        }                    -- HL 11/6/2019 todo: Fut Anter: haben lesen können = lesen gekonnt haben
       } ;
 
    VP : Type = {
-      s  : Verb ;
-      nn : Agr => Str * Str ; -- dich/deine Frau
+      s  : Verb ;                         -- HL 6/2019: <refl|pron,NP,PP,AP|CN|Adv>
+      nn : Agr => Str * Str * Str * Str ; --            <sich|ihr,deine Frau,an sie,gut> 
       a1 : Polarity => Str ;  -- nicht = adV
       a2 : Str ;              -- heute = adv
       adj : Str ;             -- space for adjectival complements ("ich finde dich schön")
@@ -552,12 +551,10 @@ resource ResGer = ParamX ** open Prelude in {
         werden_V.s ! VFin False (VImpfSubj (numberAgr a) (personAgr a)) ;  --# notpresent
 
       auf = verb.prefix ;
-
       vf : Bool -> Str -> Str -> {fin,inf : Str} = \b,fin,inf -> {
         fin = fin ; 
         inf = verb.particle ++ if_then_Str b [] auf ++ inf  --- negation of main b
-        } ;
-
+        } ; 
     in {
     s = \\b,a => table {
       VPFinite m t Simul => case t of {
@@ -567,18 +564,33 @@ resource ResGer = ParamX ** open Prelude in {
         Cond => vf True (wuerde a) vinf ;   --# notpresent
         Pres => vf b (vfin b m t a) []
         } ;
-      VPFinite m t Anter => case t of {               --# notpresent
-        Pres | Past => vf True (hat m t a) vpart ;      --# notpresent
-        Fut  => vf True (wird m a) (vpart ++ haben) ;   --# notpresent
-        Cond => vf True (wuerde a) (vpart ++ haben)   --# notpresent
-        } ;                                        --# notpresent
+      VPFinite m t Anter => case t of {                  --# notpresent
+        Pres | Past => vf True (hat m t a) vpart ;       --# notpresent
+        Fut  => vf True (wird m a) (vpart ++ haben) ;    --# notpresent
+        Cond => vf True (wuerde a) (vpart ++ haben)      --# notpresent 
+        } ;                                              --# notpresent
       VPImperat False => vf False (verb.s ! VImper (numberAgr a)) [] ;
       VPImperat True  => vf False (verb.s ! VFin False (VPresSubj Pl P3)) [] ;
-      VPInfinit Anter => vf True [] (vpart ++ haben) ; --# notpresent
+      VPInfinit Anter => vf True [] (vpart ++ haben) ;   --# notpresent
       VPInfinit Simul => vf True [] (verb.s ! VInf b)
       }
     } ;
-
+      -- Remark (HL): something needs to be done for modal verbs:
+      -- vf : Bool -> Str -> Str -> Str -> {fin : Str ; inf : Str * Str} = \b,fin,inf,inf2 -> {
+      --   fin = fin ; 
+      --   inf = <verb.particle ++ if_then_Str b [] auf ++ inf, inf2>  --- negation of main b
+      --   } ; -- HL: {fin: wird, inf: <geschlafen haben, []>}, 
+      --       --     {fin: wird, inf: <wollen,haben>=gewollt haben}
+      --       -- but this does not work with (PassV2 v2)
+      -- VPFinite m t Anter => case t of {                  --
+        -- Fut  => case isAux of {                             -- HL 6/2019, Duden 318: Ersatzinfinitiv
+        --   False => vf True (wird m a) (vpart ++ haben) ;    -- wird (nicht) schlafen gekonnt haben 
+        --   True => vf True (wird m a) vpart haben } ;        -- => wird (nicht) haben schlafen können
+        -- Cond => case isAux of {                             --
+        --   False => vf True (wuerde a) (vpart ++ haben) [] ; --
+        --   True => vf True (wuerde a) vpart haben }          -- HL: würde (nicht) haben schlafen können
+        -- } ;                                                 
+        -- But this doesn't fit to (PassV2 v2).
 
   predVGen : Bool -> Verb -> VPSlash = \isAux, verb -> {
     s = {
@@ -591,9 +603,9 @@ resource ResGer = ParamX ** open Prelude in {
 
     a1  : Polarity => Str = negation ;
     a2  : Str = [] ;
-    nn  : Agr => Str * Str = case verb.vtype of {
-      VAct => \\_ => <[],[]> ;
-      VRefl c => \\a => <reflPron ! a ! c,[]>
+    nn  : Agr => Str * Str * Str * Str = case verb.vtype of {
+      VAct => \\_ => <[],[],[],[]> ;
+      VRefl c => \\a => <reflPron ! a ! c,[],[],[]>
       } ;
     isAux = isAux ; ----
     inf,ext,infExt,adj : Str = [] ;
@@ -668,26 +680,39 @@ resource ResGer = ParamX ** open Prelude in {
 
 -- Extending a verb phrase with new constituents.
 
-  insertObj : (Agr => Str) -> VPSlash -> VPSlash = insertObjNP False ;
+  insertObj : (Agr => Str) -> VPSlash -> VPSlash = \obj,vp ->  -- obj:Comp A|Adv|CN
+    vp ** { nn = \\a => let vpnn = vp.nn ! a in  <vpnn.p1, vpnn.p2, vpnn.p3, obj ! a ++ vpnn.p4> } ;
 
   insertObjc : (Agr => Str) -> VPSlash -> VPSlash = \obj,vp ->
     insertObj obj vp ** {c2 = vp.c2 ; missingAdv = vp.missingAdv } ;
 
-  insertObjNP : Bool -> (Agr => Str) -> VPSlash -> VPSlash = \isPron, obj,vp -> vp ** {
-    nn = \\a => 
-      let vpnn = vp.nn ! a in 
-      case isPron of {
-        True  => <obj ! a ++ vpnn.p1,            vpnn.p2> ;
-        False => <           vpnn.p1, obj ! a ++ vpnn.p2>
-        }} ;
+  insertObjNP : NP -> Preposition -> VPSlash -> VPSlash = \np,prep,vp ->
+    let c = case prep.c of { NPC cc => cc ; _ => Nom } ;
+        obj : Agr => Str = \\_ => appPrepNP prep np ;
+    in vp ** {
+      nn = \\a =>                  -- HL 11/6/19: rough objNP order:
+        let vpnn = vp.nn ! a in    -- vfin < accPron < refl < (gen|dat)Pron < nonPronNP < neg < prepNP < vinf|comp
+        case <np.isPron,prep.isPrep,c> of { -- (assuming v.c2=acc) nonPron: dat < acc|gen  (acc < gen not enforced)
+          <True, False,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- <es|ihn sich,  np, pp, comp>
+          <True, False,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- <sich ihm,     np, pp, comp>
+          <False,False,Dat> => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4> ; -- <prons, dat ++ np, pp, comp>
+          <False,False,_>   => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- <prons, np ++ gen|acc, pp, comp>
+          <_,    True, _>   => <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4>   -- <prons, np, mit ihr|np, compl>
+        }
+    } ;    -- the ordering of objects of v:V3 (and v:V4) is also determined by Slash?V3 (and Slash?V4)
 
-  isLightComplement : Bool -> Preposition -> Bool = \isPron,prep -> case isPron of {
-     False => False ;
-     _ => case prep.isPrep of {
-       True => False ;
-       _ => True
-       }
-     } ;
+  insertObjRefl : VPSlash -> VPSlash = \vp -> -- HL 6/2019, to order reflPron < neg < prep+reflPron
+    let prep = vp.c2 ;
+        b = notB prep.isPrep ;
+        c = case prep.c of { NPC cc => cc ; _ => Acc } ;
+        obj : Agr => Str = \\a => prep.s ++ reflPron ! a ! c ;
+    in vp ** {
+      nn = \\a =>
+        let vpnn = vp.nn ! a in
+        case b of {
+          True  => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ;
+          False => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4> }
+    } ;
 
   insertAdV : Str -> VP -> VP = \adv,vp -> vp ** {
     a1 = \\a => adv ++ vp.a1 ! a } ; -- immer nicht
@@ -706,10 +731,9 @@ resource ResGer = ParamX ** open Prelude in {
 
   insertAdj : Str -> Str * Str -> Str -> VPSlash -> VPSlash = \adj,c,ext,vp -> vp ** {
     nn = \\a => 
-      let vpnn = vp.nn ! a in 
-		<vpnn.p1 ++ c.p1 , vpnn.p2> ;
-	adj = vp.adj ++ adj ++ c.p2 ;
-	ext = vp.ext ++ ext} ;
+      let vpnn = vp.nn ! a in <vpnn.p1, vpnn.p2 ++ c.p1, vpnn.p3, vpnn.p4> ;  -- ihr? | der Frau treu
+    adj = vp.adj ++ adj ++ c.p2 ;                                             -- neugierig auf das Buch
+    ext = vp.ext ++ ext} ;           
 
 --------------------------------------------
 --CLAUSE CONSTRUCTION
@@ -730,18 +754,19 @@ resource ResGer = ParamX ** open Prelude in {
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
           neg   = vp.a1 ! b ;
-          obj0  = (vp.nn ! agr).p1 ;
-          obj   = (vp.nn ! agr).p2 ;
-          compl = obj0 ++ neg  ++ vp.adj ++ obj ++ vp.a2 ; -- adj added
-          inf   = vp.inf ++ verb.inf ; -- not used for linearisation of Main/Inv
+          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ nonpronouns
+          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
+          obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
+          compl = obj1 ++ neg ++ obj2 ++ obj3 ;
+          inf   = vp.inf ++ verb.inf ; 
           extra = vp.ext ;
-          inffin : Str = 
+          inffin : Str =                             -- not used for Main/Inv
             case <a,vp.isAux> of {                       
 	           <Anter,True> => verb.fin ++ inf ; -- double inf   --# notpresent
-             _            => inf ++ verb.fin              --- or just auxiliary vp
-            }                                            
+                   _            => inf ++ verb.fin   --- or just auxiliary vp
+            } ;
         in
-        case o of {
+        case o of { 
 	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
 	    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
 	    Sub  => subj ++ compl ++ vp.infExt ++ inffin ++ extra
@@ -767,7 +792,7 @@ resource ResGer = ParamX ** open Prelude in {
 
   infVP : Bool -> VP -> ((Agr => Str) * Str * Str * Str) = \isAux, vp -> let vps = useVP vp in
     <
-     \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++  vp.a2,
+     \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4 ++ vp.a2,
      vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf,
      vp.inf,
      vp.infExt ++ vp.ext
@@ -837,12 +862,10 @@ resource ResGer = ParamX ** open Prelude in {
     {s : PCase => Str ; a : Agr} -> {s : PCase => Str ; a : Agr ; isPron : Bool ; adv,ext,rc : Str} = \np ->
     np ** {isPron = False; adv,ext,rc = []} ; -- this could be wrong
 
-  oper
-
-      relPron :  RelGenNum => Case => Str = \\rgn,c =>
+  relPron :  RelGenNum => Case => Str = \\rgn,c =>
     case rgn of {
     RGenNum gn => 
-    case <gn,c> of {
+      case <gn,c> of {
       <GSg Fem,Gen> => "deren" ;
       <GSg g,Gen>   => "dessen" ;
       <GPl,Dat>     => "denen" ;
@@ -863,3 +886,4 @@ resource ResGer = ParamX ** open Prelude in {
         in <subj , agr> ;
 
 }
+

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -188,7 +188,8 @@ resource ResGer = ParamX ** open Prelude in {
       in
       case <t,m> of {
         <Pres,MIndic>    => VFin b (VPresInd   an ap) ;
-        <Pres,MConjunct> => VFin b (VPresSubj  an ap) ;  --# notpresent
+        <Pres,MConjunct> => VFin b (VPresSubj  an ap) 
+                                                      ;  --# notpresent
         <Past,MIndic>    => VFin b (VImpfInd   an ap) ;  --# notpresent
         <Past,MConjunct> => VFin b (VImpfSubj  an ap) ;  --# notpresent
         _ => VInf False --# notpresent

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -502,8 +502,8 @@ resource ResGer = ParamX ** open Prelude in {
   VPC : Type = {
       s : Bool => Agr => VPForm => { -- True = prefix glued to verb
         fin : Str ;          -- hat|wird
-        inf : Str            -- gelesen, lesen können|lesen (können),gelesen haben,
-        }                    -- HL 11/6/2019 todo: Fut Anter: haben lesen können = lesen gekonnt haben
+        inf : Str            -- wollen,gelesen|lesen wollen,gelesen haben,
+        }                    -- HL 11/6/2019 todo: Fut Anter: haben lesen wollen = lesen gewollt haben
       } ;
 
    VP : Type = {
@@ -575,22 +575,6 @@ resource ResGer = ParamX ** open Prelude in {
       VPInfinit Simul => vf True [] (verb.s ! VInf b)
       }
     } ;
-      -- Remark (HL): something needs to be done for modal verbs:
-      -- vf : Bool -> Str -> Str -> Str -> {fin : Str ; inf : Str * Str} = \b,fin,inf,inf2 -> {
-      --   fin = fin ; 
-      --   inf = <verb.particle ++ if_then_Str b [] auf ++ inf, inf2>  --- negation of main b
-      --   } ; -- HL: {fin: wird, inf: <geschlafen haben, []>}, 
-      --       --     {fin: wird, inf: <wollen,haben>=gewollt haben}
-      --       -- but this does not work with (PassV2 v2)
-      -- VPFinite m t Anter => case t of {                  --
-        -- Fut  => case isAux of {                             -- HL 6/2019, Duden 318: Ersatzinfinitiv
-        --   False => vf True (wird m a) (vpart ++ haben) ;    -- wird (nicht) schlafen gekonnt haben 
-        --   True => vf True (wird m a) vpart haben } ;        -- => wird (nicht) haben schlafen können
-        -- Cond => case isAux of {                             --
-        --   False => vf True (wuerde a) (vpart ++ haben) [] ; --
-        --   True => vf True (wuerde a) vpart haben }          -- HL: würde (nicht) haben schlafen können
-        -- } ;                                                 
-        -- But this doesn't fit to (PassV2 v2).
 
   predVGen : Bool -> Verb -> VPSlash = \isAux, verb -> {
     s = {

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -13,7 +13,8 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
 			"uns graut" "*uns grauen"
 	   allows pre/post-positions in subjects -->
 	 		"nach mir wurde gedürstet" "*mir wurde gedürstet" 
-			can't think of case of postpositions in subject -}
+			can't think of case of postpositions in subject 
+                        HL: "des Geldes wegen wird gearbeitet"  -}
 
     PredSCVP sc vp = mkClause sc.s (agrP3 Sg) vp ;
 
@@ -26,10 +27,10 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
             } ;
           agr  = Ag Fem (numImp n) ps.p1 ; --- g does not matter
           verb = vps.s ! False ! agr ! VPImperat ps.p3 ;
-          inf  = vp.inf ++ verb.inf ;
+          inf  = vp.inf ++ verb.inf ;  -- HL .nn
+          obj  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4
         in
-        verb.fin ++ ps.p2 ++ 
-        (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ (vp.nn ! agr).p2 ++ vp.a2 ++ inf ++ vp.ext
+        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
     } ; 
 
     SlashVP np vp = 

--- a/src/german/StructuralGer.gf
+++ b/src/german/StructuralGer.gf
@@ -116,7 +116,7 @@ concrete StructuralGer of Structural = CatGer **
   we_Pron = mkPronPers "wir" "uns"  "uns"   "unser"  "unser" Fem Pl P1 ;
 
   whatSg_IP = {s = caselist "was" "was" "was" "wessen" ; n = Sg} ; ----
-  whatPl_IP = {s = caselist "was" "was" "was" "wessen" ; n = Pl} ; ----
+  whatPl_IP = {s = caselist "was" "was" "was" "wessen" ; n = Sg} ; -- HL 6/2016
 
   when_IAdv = ss "wann" ;
   when_Subj = ss "wenn" ;
@@ -124,7 +124,7 @@ concrete StructuralGer of Structural = CatGer **
   which_IQuant = {s = \\n,g,c => (detLikeAdj True n "welch").s ! g ! NPC c} ;
 
   whoSg_IP = {s = caselist "wer" "wen" "wem" "wessen" ; n = Sg} ;
-  whoPl_IP = {s = caselist "wer" "wen" "wem" "wessen" ; n = Pl} ;
+  whoPl_IP = {s = caselist "wer" "wen" "wem" "wessen" ; n = Sg} ; -- HL 6/2016
   why_IAdv = ss "warum" ;
   without_Prep = mkPrep "ohne" P.accusative ;
   with_Prep = mkPrep "mit" P.dative ;

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -21,12 +21,10 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       insertExtrapos (comma ++ q.s ! QIndir) (predV v) ;
     ComplVA v ap = insertAdj (v.c2.s ++ ap.s ! APred) ap.c ap.ext (predV v) ; -- changed
 
-    SlashV2a v = predVc v ;
+    SlashV2a v = (predVc v) ** {missingAdv = True} ; -- HL 12/6/2019 for reflexive verbs with objects, rV2:V2, rV3:V3
       
-    Slash2V3 v np =
-      insertObjc (\\_ => appPrepNP v.c2 np) (predVc v) ** {c2 = v.c3} ;
-    Slash3V3 v np =
-      insertObjc (\\_ => appPrepNP v.c3 np) (predVc v) ;
+    Slash2V3 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; missingAdv = True} ; 
+    Slash3V3 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True} ;
 
     SlashV2S v s = 
       insertExtrapos (conjThat ++ s.s ! Sub) (predVc v) ;
@@ -45,7 +43,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
 
     ComplSlash vps np =
-      let vp = insertObjNP (isLightComplement np.isPron vps.c2) (\\_ => appPrepNP vps.c2 np) vps ;
+      let vp = insertObjNP np vps.c2 vps ;
        in case vp.missingAdv of {
         True  => vp ;
         False => objAgr np vp } ; -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of the object introduced by ComplSlash.
@@ -68,6 +66,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInf vpi.p2 (
           insertObj vpi.p1 (
             insertObj (\\_ => appPrepNP v.c2 np) vps))) ;
+--            insertObjNP v.c2 np vps))) ;
 
     UseComp comp =
        insertExtrapos comp.ext (insertObj comp.s (predV sein_V)) ; -- agr not used
@@ -95,8 +94,9 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     AdvVPSlash vp adv = vp ** insertAdv adv.s vp ;
     AdVVPSlash adv vp = vp ** insertAdv adv.s vp ;
 
-    ReflVP vp = insertObj (\\a => appPrep vp.c2 
-      (\\k => usePrepC k (\c -> reflPron ! a ! c))) vp ;
+    -- ReflVP vp = insertObj (\\a => appPrep vp.c2 
+    --   (\\k => usePrepC k (\c -> reflPron ! a ! c))) vp ;
+    ReflVP vp = insertObjRefl vp ; -- HL, 19/06/2019
 
     PassV2 v = insertInf (v.s ! VPastPart APred) (predV werdenPass) ;
 

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -1,0 +1,20 @@
+abstract TestLang = 
+  Grammar, 
+  Lexicon
+  , TestLexiconGerAbs
+  , Construction
+  ** {    
+  flags startcat=Phr ;
+  cat 
+    VPSlashSlash ;
+  fun
+    ReflVPSlash : V3 -> VPSlash ;
+
+    -- SlashV3a : V3 -> VPSlashSlash ; -- unneccessary
+
+    Slash2V4 : V4 -> NP -> VPSlashSlash ;
+    Slash3V4 : V4 -> NP -> VPSlashSlash ;
+    Slash4V4 : V4 -> NP -> VPSlashSlash ;
+
+    ComplSlashSlash: VPSlashSlash -> NP -> VPSlash ;
+  } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -1,0 +1,27 @@
+--# -path=.:../../src/abstract:../../src/common:../../src/api:../../src/prelude:../../src/english
+-- --# -path=.:../abstract:../common:../api:../prelude
+
+concrete TestLangEng of TestLang = 
+  GrammarEng,
+  LexiconEng
+  , TestLexiconEng
+  , ConstructionEng
+  ** open (R=ResEng),(P=ParadigmsEng),Prelude in {
+
+  flags 
+    startcat = Phr ; unlexer = text ; lexer = text ;
+
+  lincat
+    VPSlashSlash = VPSlash ** {c3 : Str} ;
+  lin 
+    ReflVPSlash v3 = (R.predVc ((P.reflV (lin V v3)) ** {c2 = v3.c3 ; missingAdv = True})); 
+
+    ComplSlashSlash vpss np = R.insertObjc (appPrep vpss.c2 (lin NP np)) (vpss ** {c2 = vpss.c3 ; missingAdv = True }) ;
+
+    Slash2V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c2 (lin NP np)) (R.predVc v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
+    Slash3V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c3 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
+    Slash4V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c4 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
+
+  oper
+    appPrep : Str -> NP -> (R.Agr => Str) = \p,np -> \\_ => p ++ np.s ! R.NPAcc ;
+} ;

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -1,0 +1,28 @@
+--# -path=.:../../src/abstract:../../src/common:../../src/api:../../src/prelude:../../src/german
+-- --# -path=.:../abstract:../common:../api:../prelude
+
+concrete TestLangGer of TestLang = 
+  GrammarGer,
+  LexiconGer
+  , TestLexiconGer
+  , ConstructionGer
+  ** open (R=ResGer),Prelude in {
+
+flags startcat = Phr ; unlexer = text ; lexer = text ;
+  lincat
+    VPSlashSlash = VPSlash ** {c3 : R.Preposition} ;
+  lin 
+    ReflVPSlash v3 = (R.insertObjRefl (R.predVc v3) ** {c2 = v3.c3 ; missingAdv = True}); -- reflexive use of v:V3, untested
+
+    -- SlashV3a v = (R.predVc v) ** {c3 = v.c3} ;
+
+    Slash2V4 v np = (lin VPSlash (R.insertObjNP np v.c2 (R.predV v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
+    Slash3V4 v np = (lin VPSlash (R.insertObjNP np v.c3 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
+    Slash4V4 v np = (lin VPSlash (R.insertObjNP np v.c4 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
+
+    ComplSlashSlash vpss np = R.insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
+
+    -- linref
+    --   V4 = \v -> useInfVP False (R.predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+
+} ;

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -1,0 +1,51 @@
+--# -path=.:../abstract:../common:../prelude:               HL 19/06/2019
+-- Some english interpretations of the verbs in TestLexiconGerAbs to test
+-- translations and corresponding c2,c3,c4-objects under Slash?V3, Slash?V4.
+
+concrete TestLexiconEng of TestLexiconGerAbs = 
+  CatEng ** open (R=ResEng), (P=Prelude), ParadigmsEng
+in {
+
+lincat 
+  V4 = R.Verb ** {c2,c3,c4 : Str} ;
+
+oper
+  reflV2 : V -> Prep -> V2 ;         -- reflexive, with prep-object
+  reflV2 v p = prepV2 (reflV v) p ;
+
+  reflV3 : V -> Prep -> Prep -> V3 ; -- reflexive, with two prep-objects
+  reflV3 v p q = mkV3 (reflV v) p q ;
+
+  -- quaternary verbs:
+  mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
+         \v,p2,p3,p4 -> lin V4 (v ** { c2=p2.s ; c3=p3.s ; c4=p4.s }) ;
+  dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v noPrep c d ;
+
+lin
+  aendern_rV = (regV "change") ;
+  anstrengen_rV = let v : R.Verb = (irregV "make" "made" "made") ; 
+                      compl : Str = "an effort" 
+    in {s = \\vf => v.s!vf ++ compl ; isRefl = P.False ; p = []} ;
+
+  bedienen_gen_rV2 = dirV2 (regV "use") ;
+  stuetzen_auf_rV2 = mkV2 (irregV "rely" "relied" "relied") (mkPrep "on") ;
+  ergeben_dat_rV2 = mkV2 (regV "surrender") (mkPrep "to") ;
+  merken_rV2 = dirV2 (regV "remember") ;
+
+  anklagen_gen_V3 = dirV3 (regV "accuse") (mkPrep "of") ;
+  erklaeren_dat_V3 = dirV3 (regV "explain") (mkPrep "to") ;
+  erinnern_an_V3 = dirV3 (regV "remind") (mkPrep "of") ;
+  danken_dat_fuer_V3 = dirV3 (regV "thank") (mkPrep "for") ;
+  lehren_V3 = mkV3 (irregV "teach" "taught" "taught") noPrep noPrep ;
+
+  abschauen_bei_rV3 = dirV3 (regV "copy") (mkPrep "from") ; 
+  leihen_von_rV3 = dirV3 (regV "borrow") (mkPrep "from") ; 
+
+  entschuldigen_bei_fuer_rV3 = mkV3 (regV "apologize") (mkPrep "to") (mkPrep "for") ; 
+  raechen_am_fuer_rV3 = mkV3 (regV "revenge") (mkPrep "on") (mkPrep "for") ; 
+
+  kaufen_bei_fuer_V4 = dirV4 (irregV "buy" "bought" "bought") (mkPrep "from") (mkPrep "for") ;
+  mieten_von_fuer_V4 = dirV4 (regV "rent") (mkPrep "from") (mkPrep "for") ;
+
+  neugierig_auf_A2 = mkA2 (regA "curious") (mkPrep "about") ;
+}

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -1,0 +1,52 @@
+--# -path=.:../abstract:../common:../prelude: 
+
+concrete TestLexiconGer of TestLexiconGerAbs = 
+  CatGer ** open (R=ResGer), (P=Prelude), ParadigmsGer 
+in {
+
+lincat 
+  V4 = R.Verb ** {c2,c3,c4 : R.Preposition} ;
+
+oper
+  reflV2 : V -> Case -> Prep -> V2 ; -- reflexive, with case and prep-object
+  reflV2 v c p = prepV2 (reflV v c) p ;
+
+  reflV3 : V -> Case -> Prep -> Prep -> V3 ; -- reflexive, with case, and prep-objects
+  reflV3 v c p q = mkV3 (reflV v c) p q ;
+
+  bei_Prep   = mkPrep "bei" dative ; 
+  fuer_Prep  = mkPrep "für" accusative ;
+
+  -- quaternary verbs:
+  mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
+         \v,p2,p3,p4 -> lin V4 (v ** { c2=p2 ; c3=p3 ; c4=p4 }) ;
+  dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v accPrep c d ;
+
+lin
+  aendern_rV = reflV (regV "ändern") accusative ;
+  anstrengen_rV = reflV (prefixV "an" (regV "strengen")) accusative ;
+
+  bedienen_gen_rV2 = reflV2 (regV "bedienen") accusative genPrep ;
+  stuetzen_auf_rV2 = reflV2 (regV "stützen") accusative (mkPrep "auf" accusative) ;
+  ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergibt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
+  merken_rV2 = reflV2 (regV "merken") dative accPrep ;
+
+  erklaeren_dat_V3 = accdatV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
+  anklagen_gen_V3 = dirV3 (prefixV "an" (regV "klagen")) genPrep ;
+  erinnern_an_V3 = dirV3 (irregV "erinnern" "erinnert" "erinnerte" "erinnerte" "erinnert") (mkPrep "an" accusative) ; 
+  danken_dat_fuer_V3 = mkV3 (regV "danken") datPrep (mkPrep "für" accusative) ;
+  lehren_V3 = dirV3 (regV "lehren") accPrep ;
+
+  abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;
+  leihen_von_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") dative accPrep von_Prep ;
+
+  entschuldigen_bei_fuer_rV3 = 
+    reflV3 (irregV "entschuldigen" "entschuldigt" "entschuldigte" "entschuldigte" "entschuldigt") accusative bei_Prep fuer_Prep ;
+  raechen_am_fuer_rV3 = reflV3 (regV "rächen") accusative (mkPrep "an" dative) fuer_Prep ;
+
+  kaufen_bei_fuer_V4 = dirV4 (regV "kaufen") bei_Prep fuer_Prep ;
+  mieten_von_fuer_V4 = dirV4 (regV "mieten") von_Prep fuer_Prep ;
+
+  neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
+
+}

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -1,0 +1,32 @@
+--# -path=.:../abstract:../common:../prelude: -- partially extracted from DictVerbsGerAbs
+abstract TestLexiconGerAbs = Cat ** {
+cat 
+  V4 ;
+
+fun
+  aendern_rV : V ;
+  anstrengen_rV : V ;
+
+  bedienen_gen_rV2 : V2 ;
+  stuetzen_auf_rV2 : V2 ;
+  ergeben_dat_rV2 : V2 ;
+  merken_rV2 : V2 ;
+
+  anklagen_gen_V3 : V3 ;
+  erklaeren_dat_V3 : V3 ;
+  lehren_V3 : V3 ;
+  erinnern_an_V3 : V3 ;
+  danken_dat_fuer_V3 : V3 ;
+
+  abschauen_bei_rV3 : V3 ;
+  leihen_von_rV3 : V3 ;
+
+  entschuldigen_bei_fuer_rV3 : V3 ;
+  raechen_am_fuer_rV3 : V3 ;
+
+  kaufen_bei_fuer_V4 : V4 ;
+  mieten_von_fuer_V4 : V4 ;
+
+  neugierig_auf_A2 : A2 ;
+
+}

--- a/tests/german/examples.dub.out
+++ b/tests/german/examples.dub.out
@@ -1,0 +1,141 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (UseComp (CompNP (PredetNP not_Predet (DetCN (DetQuant IndefArt NumSg) (UseN child_N)))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (UseComp (CompNP (PredetNP not_Predet (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN child_N)))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not one child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (UseComp (CompNP (PredetNP not_Predet (DetCN someSg_Det (UseN child_N)))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not some child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompCN (AdvCN (UseN child_N) ?10)))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child ?10
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompCN (RelCN (UseN child_N) ?10)))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child ?10
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompCN (SentCN (UseN child_N) ?10)))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child ?10
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompCN (UseN child_N)))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompNP (DetCN (DetQuant IndefArt NumSg) (UseN child_N))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not a child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompNP (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN child_N))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not one child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompNP (DetCN someSg_Det (UseN child_N))))))) NoVoc
+TestLangGer: ich bin nicht ein Kind
+TestLangEng: I am not some child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: ich sehe einen Mann nicht
+TestLangEng: I don't see a man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN man_N)))))) NoVoc
+TestLangGer: ich sehe einen Mann nicht
+TestLangEng: I don't see one man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN someSg_Det (UseN man_N)))))) NoVoc
+TestLangGer: ich sehe einen Mann nicht
+TestLangEng: I don't see some man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) somebody_NP)))) NoVoc
+TestLangGer: ich sehe jemanden nicht
+TestLangEng: I don't see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumPl) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe Gründe nicht
+TestLangEng: I don't see reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (DetCN (DetQuant IndefArt NumPl) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe nicht Gründe
+TestLangEng: I see not reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuant IndefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: wir wollen einen Mann nicht sehen
+TestLangEng: we don't want to see a man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN man_N)))))) NoVoc
+TestLangGer: wir wollen einen Mann nicht sehen
+TestLangEng: we don't want to see one man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN someSg_Det (UseN man_N)))))) NoVoc
+TestLangGer: wir wollen einen Mann nicht sehen
+TestLangEng: we don't want to see some man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (PredetNP not_Predet (DetCN (DetQuant IndefArt NumSg) (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not a man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (PredetNP not_Predet (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not one man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (PredetNP not_Predet (DetCN someSg_Det (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not some man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (DetCN (DetQuant IndefArt NumSg) (UseN man_N)))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not a man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN man_N)))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not one man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (DetCN someSg_Det (UseN man_N)))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we want to see not some man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumSg) (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we don't want to see a man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we don't want to see one man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (DetCN someSg_Det (UseN man_N))))))) NoVoc
+TestLangGer: wir wollen nicht einen Mann sehen
+TestLangEng: we don't want to see some man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (PredetNP not_Predet somebody_NP))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we want to see not somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet somebody_NP)))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we want to see not somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) somebody_NP))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we don't want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn sie
+TestLangEng: we taught her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn sie
+TestLangEng: we taught them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn sie
+TestLangEng: we taught him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn sie
+TestLangEng: we taught him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehrten sie ihn
+TestLangEng: we taught him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehrten sie ihn
+TestLangEng: we taught him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehrten sie ihn
+TestLangEng: we taught her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehrten sie ihn
+TestLangEng: we taught them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cheese_N))) (DetCN (DetQuant DefArt NumSg) (UseN cow_N)))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für den Käse
+TestLangEng: we don't thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cow_N))) (DetCN (DetQuant DefArt NumSg) (UseN cheese_N)))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für den Käse
+TestLangEng: we don't thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PPos (RelVP IdRP (ComplSlash (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: wir , die sich das Buch von dir liehen
+TestLangEng: we , that borrowed the book from you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PPos (RelVP IdRP (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron youSg_Pron)))))) NoVoc
+TestLangGer: wir , die sich das Buch von dir liehen
+TestLangEng: we , that borrowed the book from you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PPos (RelVP IdRP (ComplSlash (Slash3V3 leihen_von_rV3 (PredetNP not_Predet (UsePron youSg_Pron))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: wir , die sich das Buch nicht von dir liehen
+TestLangEng: we , that borrowed the book from not you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PPos (RelVP IdRP (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (PredetNP not_Predet (UsePron youSg_Pron))))))) NoVoc
+TestLangGer: wir , die sich das Buch nicht von dir liehen
+TestLangEng: we , that borrowed the book from not you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PNeg (RelVP IdRP (ComplSlash (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: wir , die sich das Buch nicht von dir liehen
+TestLangEng: we , that didn't borrow the book from you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (UsePron we_Pron) (UseRCl (TTAnt TPast ASimul) PNeg (RelVP IdRP (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron youSg_Pron)))))) NoVoc
+TestLangGer: wir , die sich das Buch nicht von dir liehen
+TestLangEng: we , that didn't borrow the book from you

--- a/tests/german/examples.eng.out
+++ b/tests/german/examples.eng.out
@@ -1,0 +1,375 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives her the apple
+TestLangGer: das Kind gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: the child gives her the apple
+TestLangGer: das Kind gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives him the apple
+TestLangGer: das Kind gibt ihn dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron he_Pron))))) NoVoc
+TestLangEng: the child gives him the apple
+TestLangGer: das Kind gibt ihn dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives it the apple
+TestLangGer: das Kind gibt dem Apfel das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives it the apple
+TestLangGer: das Kind gibt es dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: the child gives it the apple
+TestLangGer: das Kind gibt dem Apfel das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: the child gives it the apple
+TestLangGer: das Kind gibt es dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives them the apple
+TestLangGer: das Kind gibt dem Apfel die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives them the apple
+TestLangGer: das Kind gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
+TestLangEng: the child gives them the apple
+TestLangGer: das Kind gibt dem Apfel die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron they_Pron))))) NoVoc
+TestLangEng: the child gives them the apple
+TestLangGer: das Kind gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that the child gives her
+TestLangGer: der Apfel , dem das Kind sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that the child gives her
+TestLangGer: der Apfel , den das Kind ihr gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives her
+TestLangGer: der Apfel , dem das sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives her
+TestLangGer: der Apfel , den das ihr gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives her
+TestLangGer: der Apfel , dem es sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives her
+TestLangGer: der Apfel , den es ihr gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives him
+TestLangGer: der Apfel , dem das ihn gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives him
+TestLangGer: der Apfel , den das ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives him
+TestLangGer: der Apfel , dem es ihn gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives him
+TestLangGer: der Apfel , den es ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , dem das das gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , dem das es gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , den das dem gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , den das ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , dem es das gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , dem es es gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , den es dem gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives it
+TestLangGer: der Apfel , den es ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , dem das die gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , dem das sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , den das denen gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , den das ihnen gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , dem es die gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , dem es sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , den es denen gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it gives them
+TestLangGer: der Apfel , den es ihnen gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangEng: the woman that the child gives the apple
+TestLangGer: die Frau , der das Kind den Apfel gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangEng: the woman that the child gives the apple
+TestLangGer: die Frau , die das Kind dem Apfel gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives him
+TestLangGer: die Frau , der das Kind ihn gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives him
+TestLangGer: die Frau , die das Kind ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives her
+TestLangGer: die Frau , der das Kind sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives her
+TestLangGer: die Frau , die das Kind ihr gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the woman that the child gives it
+TestLangGer: die Frau , der das Kind das gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives it
+TestLangGer: die Frau , der das Kind es gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the woman that the child gives it
+TestLangGer: die Frau , die das Kind dem gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives it
+TestLangGer: die Frau , die das Kind ihm gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the woman that the child gives them
+TestLangGer: die Frau , der das Kind die gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives them
+TestLangGer: die Frau , der das Kind sie gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the woman that the child gives them
+TestLangGer: die Frau , die das Kind denen gibt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the woman that the child gives them
+TestLangGer: die Frau , die das Kind ihnen gibt
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: who gives the woman the apple
+TestLangGer: wer gibt dem Apfel die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who gives the woman the apple
+TestLangGer: wer gibt dem Apfel die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: who gives the woman it
+TestLangGer: wer gibt dem die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: who gives the woman it
+TestLangGer: wer gibt ihm die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who gives the woman it
+TestLangGer: wer gibt dem die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who gives the woman it
+TestLangGer: wer gibt ihm die Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: who gives her the apple
+TestLangGer: wer gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: who gives her the apple
+TestLangGer: wer gibt sie dem Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: who gives her it
+TestLangGer: wer gibt sie dem
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
+TestLangEng: who gives her it
+TestLangGer: wer gibt sie ihm
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (UsePron she_Pron))))) NoVoc
+TestLangEng: who gives her it
+TestLangGer: wer gibt sie dem
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangEng: who gives her it
+TestLangGer: wer gibt sie ihm
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends the apple to the woman
+TestLangGer: das Kind schickt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to the woman
+TestLangGer: das Kind schickt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends it to the woman
+TestLangGer: das Kind schickt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends it to the woman
+TestLangGer: das Kind schickt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: the child sends it to the woman
+TestLangGer: das Kind schickt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: the child sends it to the woman
+TestLangGer: das Kind schickt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends him to the woman
+TestLangGer: das Kind schickt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron he_Pron))))) NoVoc
+TestLangEng: the child sends him to the woman
+TestLangGer: das Kind schickt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends her to the woman
+TestLangGer: das Kind schickt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: the child sends her to the woman
+TestLangGer: das Kind schickt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends them to the woman
+TestLangGer: das Kind schickt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child sends them to the woman
+TestLangGer: das Kind schickt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
+TestLangEng: the child sends them to the woman
+TestLangGer: das Kind schickt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron they_Pron))))) NoVoc
+TestLangEng: the child sends them to the woman
+TestLangGer: das Kind schickt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: the child sends the apple to her
+TestLangGer: das Kind schickt ihr den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to her
+TestLangGer: das Kind schickt ihr den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron he_Pron))))) NoVoc
+TestLangEng: the child sends the apple to him
+TestLangGer: das Kind schickt ihm den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to him
+TestLangGer: das Kind schickt ihm den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: the child sends the apple to it
+TestLangGer: das Kind schickt dem den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: the child sends the apple to it
+TestLangGer: das Kind schickt ihm den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to it
+TestLangGer: das Kind schickt dem den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to it
+TestLangGer: das Kind schickt ihm den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
+TestLangEng: the child sends the apple to them
+TestLangGer: das Kind schickt denen den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron they_Pron))))) NoVoc
+TestLangEng: the child sends the apple to them
+TestLangGer: das Kind schickt ihnen den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to them
+TestLangGer: das Kind schickt denen den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 send_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child sends the apple to them
+TestLangGer: das Kind schickt ihnen den Apfel
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumPl) (UseN woman_N))))))))) NoVoc
+TestLangEng: the apple that the child sends to the women
+TestLangGer: der Apfel , den das Kind den Frauen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 send_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that the child sends to her
+TestLangGer: der Apfel , den das Kind ihr schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumPl) (UseN woman_N))))))))) NoVoc
+TestLangEng: the apple that it sends to the women
+TestLangGer: der Apfel , den das den Frauen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumPl) (UseN woman_N))))))))) NoVoc
+TestLangEng: the apple that it sends to the women
+TestLangGer: der Apfel , den es den Frauen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to her
+TestLangGer: der Apfel , den das ihr schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to her
+TestLangGer: der Apfel , den es ihr schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to him
+TestLangGer: der Apfel , den das ihm schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to him
+TestLangGer: der Apfel , den es ihm schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it sends to it
+TestLangGer: der Apfel , den das dem schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to it
+TestLangGer: der Apfel , den das ihm schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the apple that it sends to it
+TestLangGer: der Apfel , den es dem schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to it
+TestLangGer: der Apfel , den es ihm schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it sends to them
+TestLangGer: der Apfel , den das denen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 send_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to them
+TestLangGer: der Apfel , den das ihnen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the apple that it sends to them
+TestLangGer: der Apfel , den es denen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 send_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the apple that it sends to them
+TestLangGer: der Apfel , den es ihnen schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangEng: the woman that the child sends the apple to
+TestLangGer: die Frau , der das Kind den Apfel schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangEng: the woman that the child sends him to
+TestLangGer: die Frau , der das Kind ihn schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangEng: the woman that the child sends her to
+TestLangGer: die Frau , der das Kind sie schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
+TestLangEng: the woman that the child sends it to
+TestLangGer: die Frau , der das Kind das schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (UsePron it_Pron)))))))) NoVoc
+TestLangEng: the woman that the child sends it to
+TestLangGer: die Frau , der das Kind es schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
+TestLangEng: the woman that the child sends them to
+TestLangGer: die Frau , der das Kind die schickt
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 send_V3 (UsePron they_Pron)))))))) NoVoc
+TestLangEng: the woman that the child sends them to
+TestLangGer: die Frau , der das Kind sie schickt
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who sends the apple to the woman
+TestLangGer: wer schickt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: who sends the apple to the woman
+TestLangGer: wer schickt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who sends it to the woman
+TestLangGer: wer schickt der Frau das
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: who sends it to the woman
+TestLangGer: wer schickt es der Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: who sends it to the woman
+TestLangGer: wer schickt der Frau das
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: who sends it to the woman
+TestLangGer: wer schickt es der Frau
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: who sends the apple to her
+TestLangGer: wer schickt ihr den Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: who sends the apple to her
+TestLangGer: wer schickt ihr den Apfel
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (DetNP (DetQuant DefArt NumSg))) (UsePron she_Pron))))) NoVoc
+TestLangEng: who sends it to her
+TestLangGer: wer schickt ihr das
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangEng: who sends it to her
+TestLangGer: wer schickt es ihr
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: who sends it to her
+TestLangGer: wer schickt ihr das
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
+TestLangEng: who sends it to her
+TestLangGer: wer schickt es ihr

--- a/tests/german/examples.eng2ger.out
+++ b/tests/german/examples.eng2ger.out
@@ -1,0 +1,250 @@
+the child gives her the apple
+das Kind gibt sie dem Apfel
+the child gives her the apple
+das Kind gibt sie dem Apfel
+the child gives him the apple
+das Kind gibt ihn dem Apfel
+the child gives him the apple
+das Kind gibt ihn dem Apfel
+the child gives it the apple
+das Kind gibt dem Apfel das
+the child gives it the apple
+das Kind gibt es dem Apfel
+the child gives it the apple
+das Kind gibt dem Apfel das
+the child gives it the apple
+das Kind gibt es dem Apfel
+the child gives them the apple
+das Kind gibt dem Apfel die
+the child gives them the apple
+das Kind gibt sie dem Apfel
+the child gives them the apple
+das Kind gibt dem Apfel die
+the child gives them the apple
+das Kind gibt sie dem Apfel
+the apple that the child gives her
+der Apfel , dem das Kind sie gibt
+the apple that the child gives her
+der Apfel , den das Kind ihr gibt
+the apple that it gives her
+der Apfel , dem das sie gibt
+the apple that it gives her
+der Apfel , den das ihr gibt
+the apple that it gives her
+der Apfel , dem es sie gibt
+the apple that it gives her
+der Apfel , den es ihr gibt
+the apple that it gives him
+der Apfel , dem das ihn gibt
+the apple that it gives him
+der Apfel , den das ihm gibt
+the apple that it gives him
+der Apfel , dem es ihn gibt
+the apple that it gives him
+der Apfel , den es ihm gibt
+the apple that it gives it
+der Apfel , dem das das gibt
+the apple that it gives it
+der Apfel , dem das es gibt
+the apple that it gives it
+der Apfel , den das dem gibt
+the apple that it gives it
+der Apfel , den das ihm gibt
+the apple that it gives it
+der Apfel , dem es das gibt
+the apple that it gives it
+der Apfel , dem es es gibt
+the apple that it gives it
+der Apfel , den es dem gibt
+the apple that it gives it
+der Apfel , den es ihm gibt
+the apple that it gives them
+der Apfel , dem das die gibt
+the apple that it gives them
+der Apfel , dem das sie gibt
+the apple that it gives them
+der Apfel , den das denen gibt
+the apple that it gives them
+der Apfel , den das ihnen gibt
+the apple that it gives them
+der Apfel , dem es die gibt
+the apple that it gives them
+der Apfel , dem es sie gibt
+the apple that it gives them
+der Apfel , den es denen gibt
+the apple that it gives them
+der Apfel , den es ihnen gibt
+the woman that the child gives the apple
+die Frau , der das Kind den Apfel gibt
+the woman that the child gives the apple
+die Frau , die das Kind dem Apfel gibt
+the woman that the child gives him
+die Frau , der das Kind ihn gibt
+the woman that the child gives him
+die Frau , die das Kind ihm gibt
+the woman that the child gives her
+die Frau , der das Kind sie gibt
+the woman that the child gives her
+die Frau , die das Kind ihr gibt
+the woman that the child gives it
+die Frau , der das Kind das gibt
+the woman that the child gives it
+die Frau , der das Kind es gibt
+the woman that the child gives it
+die Frau , die das Kind dem gibt
+the woman that the child gives it
+die Frau , die das Kind ihm gibt
+the woman that the child gives them
+die Frau , der das Kind die gibt
+the woman that the child gives them
+die Frau , der das Kind sie gibt
+the woman that the child gives them
+die Frau , die das Kind denen gibt
+the woman that the child gives them
+die Frau , die das Kind ihnen gibt
+who gives the woman the apple
+wer gibt dem Apfel die Frau
+who gives the woman the apple
+wer gibt dem Apfel die Frau
+who gives the woman it
+wer gibt dem die Frau
+who gives the woman it
+wer gibt ihm die Frau
+who gives the woman it
+wer gibt dem die Frau
+who gives the woman it
+wer gibt ihm die Frau
+who gives her the apple
+wer gibt sie dem Apfel
+who gives her the apple
+wer gibt sie dem Apfel
+who gives her it
+wer gibt sie dem
+who gives her it
+wer gibt sie ihm
+who gives her it
+wer gibt sie dem
+who gives her it
+wer gibt sie ihm
+the child sends the apple to the woman
+das Kind schickt der Frau den Apfel
+the child sends the apple to the woman
+das Kind schickt der Frau den Apfel
+the child sends it to the woman
+das Kind schickt der Frau das
+the child sends it to the woman
+das Kind schickt es der Frau
+the child sends it to the woman
+das Kind schickt der Frau das
+the child sends it to the woman
+das Kind schickt es der Frau
+the child sends him to the woman
+das Kind schickt ihn der Frau
+the child sends him to the woman
+das Kind schickt ihn der Frau
+the child sends her to the woman
+das Kind schickt sie der Frau
+the child sends her to the woman
+das Kind schickt sie der Frau
+the child sends them to the woman
+das Kind schickt der Frau die
+the child sends them to the woman
+das Kind schickt sie der Frau
+the child sends them to the woman
+das Kind schickt der Frau die
+the child sends them to the woman
+das Kind schickt sie der Frau
+the child sends the apple to her
+das Kind schickt ihr den Apfel
+the child sends the apple to her
+das Kind schickt ihr den Apfel
+the child sends the apple to him
+das Kind schickt ihm den Apfel
+the child sends the apple to him
+das Kind schickt ihm den Apfel
+the child sends the apple to it
+das Kind schickt dem den Apfel
+the child sends the apple to it
+das Kind schickt ihm den Apfel
+the child sends the apple to it
+das Kind schickt dem den Apfel
+the child sends the apple to it
+das Kind schickt ihm den Apfel
+the child sends the apple to them
+das Kind schickt denen den Apfel
+the child sends the apple to them
+das Kind schickt ihnen den Apfel
+the child sends the apple to them
+das Kind schickt denen den Apfel
+the child sends the apple to them
+das Kind schickt ihnen den Apfel
+the apple that the child sends to the women
+der Apfel , den das Kind den Frauen schickt
+the apple that the child sends to her
+der Apfel , den das Kind ihr schickt
+the apple that it sends to the women
+der Apfel , den das den Frauen schickt
+the apple that it sends to the women
+der Apfel , den es den Frauen schickt
+the apple that it sends to her
+der Apfel , den das ihr schickt
+the apple that it sends to her
+der Apfel , den es ihr schickt
+the apple that it sends to him
+der Apfel , den das ihm schickt
+the apple that it sends to him
+der Apfel , den es ihm schickt
+the apple that it sends to it
+der Apfel , den das dem schickt
+the apple that it sends to it
+der Apfel , den das ihm schickt
+the apple that it sends to it
+der Apfel , den es dem schickt
+the apple that it sends to it
+der Apfel , den es ihm schickt
+the apple that it sends to them
+der Apfel , den das denen schickt
+the apple that it sends to them
+der Apfel , den das ihnen schickt
+the apple that it sends to them
+der Apfel , den es denen schickt
+the apple that it sends to them
+der Apfel , den es ihnen schickt
+the woman that the child sends the apple to
+die Frau , der das Kind den Apfel schickt
+the woman that the child sends him to
+die Frau , der das Kind ihn schickt
+the woman that the child sends her to
+die Frau , der das Kind sie schickt
+the woman that the child sends it to
+die Frau , der das Kind das schickt
+the woman that the child sends it to
+die Frau , der das Kind es schickt
+the woman that the child sends them to
+die Frau , der das Kind die schickt
+the woman that the child sends them to
+die Frau , der das Kind sie schickt
+who sends the apple to the woman
+wer schickt der Frau den Apfel
+who sends the apple to the woman
+wer schickt der Frau den Apfel
+who sends it to the woman
+wer schickt der Frau das
+who sends it to the woman
+wer schickt es der Frau
+who sends it to the woman
+wer schickt der Frau das
+who sends it to the woman
+wer schickt es der Frau
+who sends the apple to her
+wer schickt ihr den Apfel
+who sends the apple to her
+wer schickt ihr den Apfel
+who sends it to her
+wer schickt ihr das
+who sends it to her
+wer schickt es ihr
+who sends it to her
+wer schickt ihr das
+who sends it to her
+wer schickt es ihr

--- a/tests/german/examples.neg.out
+++ b/tests/german/examples.neg.out
@@ -1,0 +1,75 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (PredetNP not_Predet (MassNP (UseN beer_N))))))) NoVoc
+TestLangGer: wir trinken nicht Bier
+TestLangEng: we drink not beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (PredetNP not_Predet (UsePron it_Pron)))))) NoVoc
+TestLangGer: wir trinken nicht es
+TestLangEng: we drink not it
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (PredetNP not_Predet (MassNP (AdjCN (PositA warm_A) (UseN beer_N)))))))) NoVoc
+TestLangGer: wir trinken nicht warmes Bier
+TestLangEng: we drink not warm beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (DetCN (DetQuant no_Quant NumSg) (AdjCN (PositA warm_A) (UseN beer_N))))))) NoVoc
+TestLangGer: wir trinken kein warmes Bier nicht
+TestLangEng: we don't drink no warm beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (UsePron he_Pron)))))) NoVoc
+TestLangGer: ich sehe nicht ihn
+TestLangEng: I see not him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet somebody_NP))))) NoVoc
+TestLangGer: ich sehe nicht jemanden
+TestLangEng: I see not somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN many_Det (AdjCN (PositA bad_A) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe viele schlechten Gründe
+TestLangEng: I see many bad reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN few_Det (AdjCN (PositA bad_A) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe wenige schlechten Gründe
+TestLangEng: I see few bad reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (PredetNP not_Predet somebody_NP))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we want to see not somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet somebody_NP)))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we want to see not somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) somebody_NP))))) NoVoc
+TestLangGer: wir wollen nicht jemanden sehen
+TestLangEng: we don't want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (PredetNP not_Predet (UsePron she_Pron)))))) NoVoc
+TestLangGer: ich schicke es nicht ihr
+TestLangEng: I send it to not her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (PredetNP not_Predet (UsePron she_Pron))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es nicht ihr
+TestLangEng: I send it to not her
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLangGer: wem gibt das Kind ihn nicht
+TestLangEng: whom doesn't it give child he
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: wem gibt das Kind ihn nicht
+TestLangEng: whom doesn't the child give him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLangGer: wem gibt das Kind ihn nicht
+TestLangEng: whom doesn't it give child he
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: wem gibt das Kind ihn nicht
+TestLangEng: whom doesn't the child give him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetNP (DetQuant IndefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN beer_N) (UsePron he_Pron))))))) NoVoc
+TestLangGer: ich klage einiger Biere ihn an
+TestLangEng: I accuse beers he of ones
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetNP somePl_Det)) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN beer_N) (UsePron he_Pron))))))) NoVoc
+TestLangGer: ich klage einiger Biere ihn an
+TestLangEng: I accuse beers he of some
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN reason_N))) (DetCN (DetQuant DefArt NumSg) (UseN student_N)))))) NoVoc
+TestLangGer: wir lehrten den Grund den Studenten
+TestLangEng: we taught the reason the student
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN reason_N))) (DetCN (DetQuant DefArt NumSg) (UseN student_N)))))) NoVoc
+TestLangGer: wir lehrten den Grund den Studenten
+TestLangEng: we taught the student the reason
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN student_N)))))) NoVoc
+TestLangGer: wir lehrten ihn die Studenten
+TestLangEng: we taught him the students
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN student_N)))))) NoVoc
+TestLangGer: wir lehrten ihn die Studenten
+TestLangEng: we taught the students him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN student_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn die Studenten
+TestLangEng: we taught the students him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN student_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn die Studenten
+TestLangEng: we taught him the students

--- a/tests/german/examples.pos.out
+++ b/tests/german/examples.pos.out
@@ -1,0 +1,870 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAP (PositA old_A)))))) NoVoc
+TestLangGer: ich bin nicht alt
+TestLangEng: I am not old
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAdv (PositAdvAdj old_A)))))) NoVoc
+TestLangGer: ich bin nicht alt
+TestLangEng: I am not oldly
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP UseCopula (PositAdvAdj old_A))))) NoVoc
+TestLangGer: ich bin nicht alt
+TestLangEng: I am not oldly
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAdv here_Adv))))) NoVoc
+TestLangGer: ich bin nicht hier
+TestLangEng: I am not here
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP UseCopula here_Adv)))) NoVoc
+TestLangGer: ich bin nicht hier
+TestLangEng: I am not here
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a know_V2) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: ich kenne dich nicht
+TestLangEng: I don't know you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a know_V2) (DetCN (DetQuant (PossPron youSg_Pron) NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich kenne deine Frau nicht
+TestLangEng: I don't know your woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (UseComp (CompNP (DetCN (DetQuant no_Quant NumSg) (UseN child_N))))))) NoVoc
+TestLangGer: ich bin kein Kind
+TestLangEng: I am no child
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP (UseV sleep_V) here_Adv)))) NoVoc
+TestLangGer: ich schlafe nicht hier
+TestLangEng: I don't sleep here
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich male es nicht blau
+TestLangEng: I don't paint it blue
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdVVP always_AdV (UseV sleep_V))))) NoVoc
+TestLangGer: ich schlafe nicht immer
+TestLangEng: I don't always sleep
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdVVP always_AdV (ComplSlash (SlashV2a know_V2) (UsePron youSg_Pron)))))) NoVoc
+TestLangGer: ich kenne dich nicht immer
+TestLangEng: I don't always know you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (AdVVPSlash always_AdV (SlashV2a know_V2)) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: ich kenne dich nicht immer
+TestLangEng: I don't always know you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplVV can8know_VV (UseV sleep_V))))) NoVoc
+TestLangGer: ich kann nicht schlafen
+TestLangEng: I can't sleep
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplVV can_VV (UseV sleep_V))))) NoVoc
+TestLangGer: ich kann nicht schlafen
+TestLangEng: I can't sleep
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (ImpersCl (ComplVA become_VA (UseComparA good_A))))) NoVoc
+TestLangGer: es wird nicht besser
+TestLangEng: it doesn't become better
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron it_Pron) (ComplVA become_VA (UseComparA good_A))))) NoVoc
+TestLangGer: es wird nicht besser
+TestLangEng: it doesn't become better
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (MassNP (UseN beer_N)))))) NoVoc
+TestLangGer: wir trinken Bier
+TestLangEng: we drink beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (MassNP (UseN beer_N)))))) NoVoc
+TestLangGer: wir trinken Bier nicht
+TestLangEng: we don't drink beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (UsePron it_Pron))))) NoVoc
+TestLangGer: wir trinken es nicht
+TestLangEng: we don't drink it
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (DetCN (DetQuant no_Quant NumSg) (UseN beer_N)))))) NoVoc
+TestLangGer: wir trinken kein Bier
+TestLangEng: we drink no beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (MassNP (AdjCN (PositA warm_A) (UseN beer_N))))))) NoVoc
+TestLangGer: wir trinken warmes Bier nicht
+TestLangEng: we don't drink warm beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a drink_V2) (DetCN (DetQuant no_Quant NumSg) (AdjCN (PositA warm_A) (UseN beer_N))))))) NoVoc
+TestLangGer: wir trinken kein warmes Bier
+TestLangEng: we drink no warm beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant DefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: ich sehe den Mann nicht
+TestLangEng: I don't see the man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant no_Quant NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: ich sehe keinen Mann
+TestLangEng: I see no man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich sehe ihn nicht
+TestLangEng: I don't see him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) somebody_NP)))) NoVoc
+TestLangGer: ich sehe jemanden nicht
+TestLangEng: I don't see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) nobody_NP)))) NoVoc
+TestLangGer: ich sehe niemanden
+TestLangEng: I see nobody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant IndefArt NumSg) (AdjCN (PositA bad_A) (UseN book_N))))))) NoVoc
+TestLangGer: ich lese ein schlechtes Buch nicht
+TestLangEng: I don't read a bad book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (AdjCN (PositA bad_A) (UseN book_N))))))) NoVoc
+TestLangGer: ich lese ein schlechtes Buch nicht
+TestLangEng: I don't read one bad book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a read_V2) (DetCN someSg_Det (AdjCN (PositA bad_A) (UseN book_N))))))) NoVoc
+TestLangGer: ich lese ein schlechtes Buch nicht
+TestLangEng: I don't read some bad book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant no_Quant NumSg) (AdjCN (PositA bad_A) (UseN book_N))))))) NoVoc
+TestLangGer: ich lese kein schlechtes Buch
+TestLangEng: I read no bad book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumPl) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe Gründe
+TestLangEng: I see reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumPl) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe Gründe nicht
+TestLangEng: I don't see reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (PredetNP not_Predet (DetCN (DetQuant IndefArt NumPl) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe nicht Gründe
+TestLangEng: I see not reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant no_Quant NumPl) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe keine Gründe
+TestLangEng: I see no reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 (pot0 n2)))))))) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe zwei Gründe
+TestLangEng: I see two reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 (pot0 n2)))))))) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe zwei Gründe nicht
+TestLangEng: I don't see two reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant no_Quant (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 (pot0 n2)))))))) (UseN reason_N)))))) NoVoc
+TestLangGer: ich sehe keine zwei Gründe
+TestLangEng: I see no two reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumPl) (AdjCN (PositA bad_A) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe schlechte Gründe
+TestLangEng: I see bad reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant IndefArt NumPl) (AdjCN (PositA bad_A) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe schlechte Gründe nicht
+TestLangEng: I don't see bad reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a see_V2) (DetCN (DetQuant no_Quant NumPl) (AdjCN (PositA bad_A) (UseN reason_N))))))) NoVoc
+TestLangGer: ich sehe keine schlechten Gründe
+TestLangEng: I see no bad reasons
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) somebody_NP)))) NoVoc
+TestLangGer: wir wollen jemanden sehen
+TestLangEng: we want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) somebody_NP))))) NoVoc
+TestLangGer: wir wollen jemanden sehen
+TestLangEng: we want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) somebody_NP)))) NoVoc
+TestLangGer: wir wollen jemanden nicht sehen
+TestLangEng: we don't want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))) NoVoc
+TestLangGer: wir warten nicht auf die Kinder
+TestLangEng: we don't wait for the children
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: wir warten nicht auf dich
+TestLangEng: we don't wait for you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TFut ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (UsePron youPl_Pron))))) NoVoc
+TestLangGer: wir werden nicht auf euch warten
+TestLangEng: we won't wait for you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (PredetNP all_Predet (DetCN (DetQuant IndefArt NumPl) (UseN child_N))))))) NoVoc
+TestLangGer: wir haben nicht auf alle Kinder gewartet
+TestLangEng: we haven't waited for all children
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (UsePron youPl_Pron))))) NoVoc
+TestLangGer: wir haben nicht auf euch gewartet
+TestLangEng: we haven't waited for you
+TestLang: PhrUtt NoPConj (UttAdv (SubjS because_Subj (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a wait_V2) (UsePron youPl_Pron))))))) NoVoc
+TestLangGer: weil wir nicht auf euch warten wollen
+TestLangEng: because we don't want to wait for you
+TestLang: PhrUtt NoPConj (UttAdv (SubjS because_Subj (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a wait_V2)) (UsePron youPl_Pron)))))) NoVoc
+TestLangGer: weil wir nicht auf euch warten wollen
+TestLangEng: because we don't want to wait for you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a wait_V2) (DetCN many_Det (UseN child_N)))))) NoVoc
+TestLangGer: wir warten nicht auf viele Kinder
+TestLangEng: we don't wait for many children
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau das Buch
+TestLangEng: I send the book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau das Buch
+TestLangEng: I send the book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send a book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send one book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN someSg_Det (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send some book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send a book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send one book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN someSg_Det (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau ein Buch
+TestLangEng: I send some book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch
+TestLangEng: I send the book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN someSg_Det (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (DetCN (DetQuant IndefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (DetCN someSg_Det (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (DetCN (DetQuant IndefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (DetCN someSg_Det (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN book_N))) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send a book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N))) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N))) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send one book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN someSg_Det (UseN book_N))) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN someSg_Det (UseN book_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN someSg_Det (UseN book_N))) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau ein Buch
+TestLangEng: I send some book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau das Buch nicht
+TestLangEng: I don't send the book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau das Buch nicht
+TestLangEng: I don't send the book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke einer Frau das Buch nicht
+TestLangEng: I don't send the book to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke ihr das Buch nicht
+TestLangEng: I don't send the book to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich schicke ihr das Buch nicht
+TestLangEng: I don't send the book to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es der Frau nicht
+TestLangEng: I don't send it to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es der Frau nicht
+TestLangEng: I don't send it to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es ihr nicht
+TestLangEng: I don't send it to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich schicke es ihr nicht
+TestLangEng: I don't send it to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau das Buch
+TestLangEng: I send the book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (DetCN (DetQuant no_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau das Buch
+TestLangEng: I send the book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant no_Quant NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke der Frau kein Buch
+TestLangEng: I send no book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN book_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke der Frau kein Buch
+TestLangEng: I send no book to the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant no_Quant NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke ihr kein Buch
+TestLangEng: I send no book to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN book_N))) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich schicke ihr kein Buch
+TestLangEng: I send no book to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send a book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN woman_N))) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send one book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN woman_N))) (DetCN someSg_Det (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send some book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN book_N))) (DetCN (DetQuant no_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send a book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN book_N))) (DetCN (DetQuant no_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send one book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN someSg_Det (UseN book_N))) (DetCN (DetQuant no_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke keiner Frau ein Buch
+TestLangEng: I send some book to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant no_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es keiner Frau
+TestLangEng: I send it to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant no_Quant NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es keiner Frau
+TestLangEng: I send it to no woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant IndefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron it_Pron)) (DetCN someSg_Det (UseN woman_N)))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to a woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant IndefArt (NumCard (NumNumeral (num (pot2as3 (pot1as2 (pot0as1 pot01))))))) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to one woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN someSg_Det (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangGer: ich schicke es einer Frau nicht
+TestLangEng: I don't send it to some woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: ich schicke ihr das Buch nicht
+TestLangEng: I don't send the book to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich schicke ihr das Buch nicht
+TestLangEng: I don't send the book to her
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))))) NoVoc
+TestLangGer: der Apfel , den das Kind der Frau gibt
+TestLangEng: the apple that it gives child the woman
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))) NoVoc
+TestLangGer: der Apfel , den das Kind der Frau gibt
+TestLangEng: the apple that the child gives the woman
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))))) NoVoc
+TestLangGer: der Apfel , den das Kind der Frau gibt
+TestLangEng: the apple , that it gives child the woman
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))) NoVoc
+TestLangGer: der Apfel , den das Kind der Frau gibt
+TestLangEng: the apple , that the child gives the woman
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron)))))))))) NoVoc
+TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangEng: the apple that it gives child she
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangEng: the apple that the child gives her
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron))))))))) NoVoc
+TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangEng: the apple , that it gives child she
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangEng: the apple , that the child gives her
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLangGer: der Apfel , den es ihr gibt
+TestLangEng: the apple that it gives her
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLangGer: der Apfel , den es ihr gibt
+TestLangEng: the apple , that it gives her
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLangGer: die Frau , der das Kind den Apfel nicht gibt
+TestLangEng: the woman that it doesn't give child the apple
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangGer: die Frau , der das Kind den Apfel nicht gibt
+TestLangEng: the woman that the child doesn't give the apple
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLangGer: die Frau , der das Kind den Apfel nicht gibt
+TestLangEng: the woman , that it doesn't give child the apple
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLangGer: die Frau , der das Kind den Apfel nicht gibt
+TestLangEng: the woman , that the child doesn't give the apple
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangGer: die Frau , der es den Apfel nicht gibt
+TestLangEng: the woman that it doesn't give the apple
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLangGer: die Frau , der es den Apfel nicht gibt
+TestLangEng: the woman , that it doesn't give the apple
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLangGer: die Frau , der das Kind ihn nicht gibt
+TestLangEng: the woman that it doesn't give child he
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangGer: die Frau , der das Kind ihn nicht gibt
+TestLangEng: the woman that the child doesn't give him
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLangGer: die Frau , der das Kind ihn nicht gibt
+TestLangEng: the woman , that it doesn't give child he
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLangGer: die Frau , der das Kind ihn nicht gibt
+TestLangEng: the woman , that the child doesn't give him
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLangGer: die Frau , der die Kinder den Apfel nicht geben
+TestLangEng: the woman that they don't give children the apple
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangGer: die Frau , der die Kinder den Apfel nicht geben
+TestLangEng: the woman that the children don't give the apple
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLangGer: die Frau , der die Kinder den Apfel nicht geben
+TestLangEng: the woman , that they don't give children the apple
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLangGer: die Frau , der die Kinder den Apfel nicht geben
+TestLangEng: the woman , that the children don't give the apple
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLangGer: die Frau , der die Kinder ihn nicht geben
+TestLangEng: the woman that they don't give children he
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangGer: die Frau , der die Kinder ihn nicht geben
+TestLangEng: the woman that the children don't give him
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLangGer: die Frau , der die Kinder ihn nicht geben
+TestLangEng: the woman , that they don't give children he
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLangGer: die Frau , der die Kinder ihn nicht geben
+TestLangEng: the woman , that the children don't give him
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangGer: die Frau , der sie ihn nicht geben
+TestLangEng: the woman that they don't give him
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLangGer: die Frau , der sie ihn nicht geben
+TestLangEng: the woman , that they don't give him
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangGer: die Frau , der es ihn gibt
+TestLangEng: the woman that it gives him
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLangGer: die Frau , der es ihn gibt
+TestLangEng: the woman , that it gives him
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLangGer: die Frau , der er ihn gibt
+TestLangEng: the woman that he gives him
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLangGer: die Frau , der er ihn gibt
+TestLangEng: the woman , that he gives him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangGer: wem gibt das Kind den Apfel nicht
+TestLangEng: whom doesn't it give child the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLangGer: wem gibt das Kind den Apfel nicht
+TestLangEng: whom doesn't the child give the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLangGer: wem gibt das Kind den Apfel nicht
+TestLangEng: whom doesn't it give child the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLangGer: wem gibt das Kind den Apfel nicht
+TestLangEng: whom doesn't the child give the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLangGer: wem gibt es den Apfel nicht
+TestLangEng: whom doesn't it give the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLangGer: wem gibt es den Apfel nicht
+TestLangEng: whom doesn't it give the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: wem gibt es ihn nicht
+TestLangEng: whom doesn't it give him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: wem gibt es ihn nicht
+TestLangEng: whom doesn't it give him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLangGer: wem gibt es nicht den Apfel
+TestLangEng: whom does it give not the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLangGer: wem gibt es nicht den Apfel
+TestLangEng: whom does it give not the apple
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLangGer: wen gibt es der Frau nicht
+TestLangEng: whom doesn't it give the woman
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLangGer: wen gibt es der Frau nicht
+TestLangEng: whom doesn't it give the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN man_N) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))))) NoVoc
+TestLangGer: ich klage die Männer des Biers an
+TestLangEng: I accuse them of men the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (ApposCN (UseN man_N) (DetNP (DetQuant DefArt NumSg))) (MassNP (UseN beer_N)))))))) NoVoc
+TestLangGer: ich klage die Männer des Biers an
+TestLangEng: I accuse them of men it beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetCN (DetQuant DefArt NumPl) (UseN man_N))) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))) NoVoc
+TestLangGer: ich klage die Männer des Biers an
+TestLangEng: I accuse the men of the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))) NoVoc
+TestLangGer: ich klage ihn des Biers an
+TestLangEng: I accuse him of the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetCN (DetQuant DefArt NumSg) (UseN beer_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich klage ihn des Biers an
+TestLangEng: I accuse him of the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (UsePron he_Pron)) (DetCN somePl_Det (UseN beer_N)))))) NoVoc
+TestLangGer: ich klage ihn einiger Biere an
+TestLangEng: I accuse him of some beers
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetCN somePl_Det (UseN beer_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich klage ihn einiger Biere an
+TestLangEng: I accuse him of some beers
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN man_N) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))))) NoVoc
+TestLangGer: ich klage die Männer des Biers nicht an
+TestLangEng: I don't accuse them of men the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (ApposCN (UseN man_N) (DetNP (DetQuant DefArt NumSg))) (MassNP (UseN beer_N)))))))) NoVoc
+TestLangGer: ich klage die Männer des Biers nicht an
+TestLangEng: I don't accuse them of men it beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetCN (DetQuant DefArt NumPl) (UseN man_N))) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))) NoVoc
+TestLangGer: ich klage die Männer des Biers nicht an
+TestLangEng: I don't accuse the men of the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN man_N) (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN beer_N))))))))) NoVoc
+TestLangGer: ich klage die Männer nicht des Biers an
+TestLangEng: I accuse them of men not the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (ApposCN (UseN man_N) (PredetNP not_Predet (DetNP (DetQuant DefArt NumSg)))) (MassNP (UseN beer_N)))))))) NoVoc
+TestLangGer: ich klage die Männer nicht des Biers an
+TestLangEng: I accuse them of men not it beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetCN (DetQuant DefArt NumPl) (UseN man_N))) (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN beer_N))))))) NoVoc
+TestLangGer: ich klage die Männer nicht des Biers an
+TestLangEng: I accuse the men of not the beer
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN music_N)))))) NoVoc
+TestLangGer: wir lehren ihn die Musik
+TestLangEng: we teach him the music
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN music_N)))))) NoVoc
+TestLangGer: wir lehren ihn die Musik
+TestLangEng: we teach the music him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN music_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn die Musik
+TestLangEng: we teach the music him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN music_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn die Musik
+TestLangEng: we teach him the music
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN student_N))) (DetCN (DetQuant DefArt NumSg) (UseN reason_N)))))) NoVoc
+TestLangGer: wir lehrten den Studenten den Grund
+TestLangEng: we taught the student the reason
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN student_N))) (DetCN (DetQuant DefArt NumSg) (UseN reason_N)))))) NoVoc
+TestLangGer: wir lehrten den Studenten den Grund
+TestLangEng: we taught the reason the student
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN reason_N)))))) NoVoc
+TestLangGer: wir lehrten ihn den Grund
+TestLangEng: we taught him the reason
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN reason_N)))))) NoVoc
+TestLangGer: wir lehrten ihn den Grund
+TestLangEng: we taught the reason him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN reason_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn den Grund
+TestLangEng: we taught the reason him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN reason_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehrten ihn den Grund
+TestLangEng: we taught him the reason
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 erinnern_an_V3 (DetCN (DetQuant DefArt NumSg) (UseN rain_N))) (DetCN (DetQuant DefArt NumSg) (UseN boy_N)))))) NoVoc
+TestLangGer: wir erinnern den Jungen nicht an den Regen
+TestLangEng: we don't remind the boy of the rain
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 erinnern_an_V3 (DetCN (DetQuant DefArt NumSg) (UseN boy_N))) (DetCN (DetQuant DefArt NumSg) (UseN rain_N)))))) NoVoc
+TestLangGer: wir erinnern den Jungen nicht an den Regen
+TestLangEng: we don't remind the boy of the rain
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 erinnern_an_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN boy_N)))))) NoVoc
+TestLangGer: wir erinnern den Jungen nicht an ihn
+TestLangEng: we don't remind the boy of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 erinnern_an_V3 (DetCN (DetQuant DefArt NumSg) (UseN boy_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir erinnern den Jungen nicht an ihn
+TestLangEng: we don't remind the boy of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 erinnern_an_V3 (UsePron he_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir erinnern ihn nicht an ihn
+TestLangEng: we don't remind him of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 erinnern_an_V3 (UsePron he_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir erinnern ihn nicht an ihn
+TestLangEng: we don't remind him of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 erinnern_an_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN boy_N)))))) NoVoc
+TestLangGer: wir haben den Jungen nicht an ihn erinnert
+TestLangEng: we haven't reminded the boy of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 erinnern_an_V3 (DetCN (DetQuant DefArt NumSg) (UseN boy_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir haben den Jungen nicht an ihn erinnert
+TestLangEng: we haven't reminded the boy of him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cheese_N))) (DetCN (DetQuant DefArt NumSg) (UseN cow_N)))))) NoVoc
+TestLangGer: wir danken der Kuh für den Käse
+TestLangEng: we thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cow_N))) (DetCN (DetQuant DefArt NumSg) (UseN cheese_N)))))) NoVoc
+TestLangGer: wir danken der Kuh für den Käse
+TestLangEng: we thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cheese_N))) (DetCN (DetQuant DefArt NumSg) (UseN cow_N)))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für den Käse
+TestLangEng: we don't thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cow_N))) (DetCN (DetQuant DefArt NumSg) (UseN cheese_N)))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für den Käse
+TestLangEng: we don't thank the cow for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN cow_N)))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für ihn
+TestLangEng: we don't thank the cow for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cow_N))) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir danken der Kuh nicht für ihn
+TestLangEng: we don't thank the cow for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN cheese_N)))))) NoVoc
+TestLangGer: wir danken ihr nicht für den Käse
+TestLangEng: we don't thank her for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN cheese_N))) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir danken ihr nicht für den Käse
+TestLangEng: we don't thank her for the cheese
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir danken ihr nicht für ihn
+TestLangEng: we don't thank her for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir danken ihr nicht für ihn
+TestLangEng: we don't thank her for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir danken ihr nicht für ihn
+TestLangEng: we don't thank her for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir danken ihr nicht für ihn
+TestLangEng: we don't thank her for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 talk_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: wir reden mit der Frau über den Mann
+TestLangEng: we talk to the woman about the man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 talk_V3 (DetCN (DetQuant DefArt NumSg) (UseN man_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: wir reden über den Mann mit der Frau
+TestLangEng: we talk to the woman about the man
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 talk_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir reden nicht mit ihr über ihn
+TestLangEng: we don't talk to her about him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youPl_Pron) (UseV aendern_rV)))) NoVoc
+TestLangGer: ihr ändert euch nicht
+TestLangEng: you don't change
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TFut ASimul) PNeg (PredVP (UsePron he_Pron) (UseV anstrengen_rV)))) NoVoc
+TestLangGer: er wird sich nicht anstrengen
+TestLangEng: he won't make an effort
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (UsePron he_Pron) (UseV anstrengen_rV)))) NoVoc
+TestLangGer: er hat sich nicht angestrengt
+TestLangEng: he hasn't made an effort
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youSg_Pron) (ComplSlash (SlashV2a ergeben_dat_rV2) (DetCN (DetQuant DefArt NumPl) (UseN enemy_N)))))) NoVoc
+TestLangGer: du ergibst dich den Feinden nicht
+TestLangEng: you don't surrender to the enemies
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (SlashV2a ergeben_dat_rV2) (PredetNP not_Predet (DetCN (DetQuant DefArt NumPl) (UseN enemy_N))))))) NoVoc
+TestLangGer: du ergibst dich nicht den Feinden
+TestLangEng: you surrender to not the enemies
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youSg_Pron) (ComplSlash (SlashV2a ergeben_dat_rV2) (UsePron i_Pron))))) NoVoc
+TestLangGer: du ergibst dich mir nicht
+TestLangEng: you don't surrender to me
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetCN (DetQuant DefArt NumSg) (UseN stick_N)))))) NoVoc
+TestLangGer: wir bedienen uns des Stocks
+TestLangEng: we use the stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir bedienen uns seiner
+TestLangEng: we use him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (UsePron it_Pron))))) NoVoc
+TestLangGer: wir bedienen uns seiner
+TestLangEng: we use it
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetNP (DetQuant (PossPron he_Pron) NumPl)))))) NoVoc
+TestLangGer: wir bedienen uns seiner
+TestLangEng: we use his
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetNP (DetQuant (PossPron it_Pron) NumPl)))))) NoVoc
+TestLangGer: wir bedienen uns seiner
+TestLangEng: we use its
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetCN (DetQuant DefArt NumSg) (UseN stick_N)))))) NoVoc
+TestLangGer: wir bedienen uns des Stocks nicht
+TestLangEng: we don't use the stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir bedienen uns seiner nicht
+TestLangEng: we don't use him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (UsePron it_Pron))))) NoVoc
+TestLangGer: wir bedienen uns seiner nicht
+TestLangEng: we don't use it
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetNP (DetQuant (PossPron he_Pron) NumPl)))))) NoVoc
+TestLangGer: wir bedienen uns seiner nicht
+TestLangEng: we don't use his
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashV2a bedienen_gen_rV2) (DetNP (DetQuant (PossPron it_Pron) NumPl)))))) NoVoc
+TestLangGer: wir bedienen uns seiner nicht
+TestLangEng: we don't use its
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a stuetzen_auf_rV2) (DetCN (DetQuant DefArt NumSg) (UseN stick_N)))))) NoVoc
+TestLangGer: ich stütze mich nicht auf den Stock
+TestLangEng: I don't rely on the stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a stuetzen_auf_rV2) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich stütze mich nicht auf ihn
+TestLangEng: I don't rely on him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN question_N)))))) NoVoc
+TestLangGer: ich entschuldige mich bei dir für die Frage
+TestLangEng: I apologize to you for the question
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron youSg_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich entschuldige mich bei dir für sie
+TestLangEng: I apologize to you for her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron youSg_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: ich entschuldige mich bei dir für sie
+TestLangEng: I apologize to you for them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN question_N)))))) NoVoc
+TestLangGer: ich entschuldige mich nicht bei dir für die Frage
+TestLangEng: I don't apologize to you for the question
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 entschuldigen_bei_fuer_rV3 (DetCN (DetQuant DefArt NumSg) (UseN question_N))) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: ich entschuldige mich für die Frage bei dir
+TestLangEng: I apologize to you for the question
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PNeg (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN stick_N))))))) NoVoc
+TestLangGer: hast du dich nicht bei ihm für den Stock entschuldigt
+TestLangEng: haven't you apologized to him for the stick
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PNeg (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN stick_N))))))) NoVoc
+TestLangGer: hast du dich nicht bei ihm für den Stock entschuldigt
+TestLangEng: haven't you apologized to it for the stick
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PPos (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron he_Pron)) (UsePron he_Pron)))))) NoVoc
+TestLangGer: hast du dich bei ihm für ihn entschuldigt
+TestLangEng: have you apologized to him for him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PPos (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash2V3 entschuldigen_bei_fuer_rV3 (UsePron it_Pron)) (UsePron he_Pron)))))) NoVoc
+TestLangGer: hast du dich bei ihm für ihn entschuldigt
+TestLangEng: have you apologized to it for him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PPos (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash3V3 entschuldigen_bei_fuer_rV3 (UsePron he_Pron)) (UsePron he_Pron)))))) NoVoc
+TestLangGer: hast du dich für ihn bei ihm entschuldigt
+TestLangEng: have you apologized to him for him
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres AAnter) PPos (QuestCl (PredVP (UsePron youSg_Pron) (ComplSlash (Slash3V3 entschuldigen_bei_fuer_rV3 (UsePron he_Pron)) (UsePron it_Pron)))))) NoVoc
+TestLangGer: hast du dich für ihn bei ihm entschuldigt
+TestLangEng: have you apologized to it for him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (DetCN every_Det (UseN stick_N)))))) NoVoc
+TestLangGer: ich merke mir jeden Stock
+TestLangEng: I remember every stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich merke ihn mir
+TestLangEng: I remember him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (DetCN every_Det (UseN stick_N)))))) NoVoc
+TestLangGer: ich merke mir jeden Stock nicht
+TestLangEng: I don't remember every stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (PredetNP not_Predet (DetCN every_Det (UseN stick_N))))))) NoVoc
+TestLangGer: ich merke mir nicht jeden Stock
+TestLangEng: I remember not every stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast AAnter) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (DetCN (DetQuant DefArt NumSg) (UseN stick_N)))))) NoVoc
+TestLangGer: ich hatte mir den Stock gemerkt
+TestLangEng: I had remembered the stick
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast AAnter) PPos (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a merken_rV2) (UsePron he_Pron))))) NoVoc
+TestLangGer: ich hatte ihn mir gemerkt
+TestLangEng: I had remembered him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: wir leihen uns das Buch von dir
+TestLangEng: we borrow the book from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: wir leihen uns das Buch von dir
+TestLangEng: we borrow the book from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 leihen_von_rV3 (PredetNP not_Predet (UsePron youSg_Pron))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: wir leihen uns das Buch nicht von dir
+TestLangEng: we borrow the book from not you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (PredetNP not_Predet (UsePron youSg_Pron)))))) NoVoc
+TestLangGer: wir leihen uns das Buch nicht von dir
+TestLangEng: we borrow the book from not you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: wir leihen uns das Buch nicht von dir
+TestLangEng: we don't borrow the book from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: wir leihen uns das Buch nicht von dir
+TestLangEng: we don't borrow the book from you
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash3V3 leihen_von_rV3 (PredetNP not_Predet (UsePron youSg_Pron))))))))) NoVoc
+TestLangGer: das Buch , das wir uns nicht von dir liehen
+TestLangEng: the book that we borrowed from not you
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron)))))))) NoVoc
+TestLangGer: das Buch , das wir uns nicht von dir liehen
+TestLangEng: the book that we didn't borrow from you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (UseRCl (TTAnt TPast ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash3V3 leihen_von_rV3 (PredetNP not_Predet (UsePron youSg_Pron)))))))) NoVoc
+TestLangGer: das Buch , das wir uns nicht von dir liehen
+TestLangEng: the book , that we borrowed from not you
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash3V3 leihen_von_rV3 (UsePron youSg_Pron))))))) NoVoc
+TestLangGer: das Buch , das wir uns nicht von dir liehen
+TestLangEng: the book , that we didn't borrow from you
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))) NoVoc
+TestLangGer: die Frau , von der wir uns das Buch nicht liehen
+TestLangEng: the woman that we didn't borrow the book from
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))) NoVoc
+TestLangGer: die Frau , von der wir uns das Buch nicht liehen
+TestLangEng: the woman , that we didn't borrow the book from
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPast ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (DetCN (DetQuant no_Quant NumSg) (UseN book_N))))))))) NoVoc
+TestLangGer: die Frau , von der wir uns kein Buch liehen
+TestLangEng: the woman that we borrowed no book from
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPast ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (DetCN (DetQuant no_Quant NumSg) (UseN book_N)))))))) NoVoc
+TestLangGer: die Frau , von der wir uns kein Buch liehen
+TestLangEng: the woman , that we borrowed no book from
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (UsePron it_Pron)))))))) NoVoc
+TestLangGer: die Frau , von der wir es uns nicht liehen
+TestLangEng: the woman that we didn't borrow it from
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (Slash2V3 leihen_von_rV3 (UsePron it_Pron))))))) NoVoc
+TestLangGer: die Frau , von der wir es uns nicht liehen
+TestLangEng: the woman , that we didn't borrow it from
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash3V4 mieten_von_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (DetCN (DetQuant DefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: du mietest den Wagen von der Frau für den Mann
+TestLangEng: you rent for the man from the woman the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash2V4 mieten_von_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN man_N)))))) NoVoc
+TestLangGer: du mietest den Wagen von der Frau für den Mann
+TestLangEng: you rent for the man the car from the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash4V4 mieten_von_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN man_N))) (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: du mietest den Wagen für den Mann von der Frau
+TestLangEng: you rent from the woman for the man the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash2V4 mieten_von_fuer_V4 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron i_Pron))))) NoVoc
+TestLangGer: du mietest ihn von der Frau für mich
+TestLangEng: you rent for me him from the woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash3V4 mieten_von_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron he_Pron)) (UsePron i_Pron))))) NoVoc
+TestLangGer: du mietest ihn von der Frau für mich
+TestLangEng: you rent for me from the woman him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash4V4 mieten_von_fuer_V4 (UsePron i_Pron)) (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: du mietest ihn für mich von der Frau
+TestLangEng: you rent from the woman for me him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash2V4 mieten_von_fuer_V4 (UsePron he_Pron)) (UsePron she_Pron)) (UsePron i_Pron))))) NoVoc
+TestLangGer: du mietest ihn von ihr für mich
+TestLangEng: you rent for me him from her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron youSg_Pron) (ComplSlash (ComplSlashSlash (Slash3V4 mieten_von_fuer_V4 (UsePron she_Pron)) (UsePron he_Pron)) (UsePron i_Pron))))) NoVoc
+TestLangGer: du mietest ihn von ihr für mich
+TestLangEng: you rent for me from her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAP (ComplA2 married_A2 (DetCN (DetQuant this_Quant NumSg) (UseN woman_N)))))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit dieser Frau
+TestLangEng: I am not married to this woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP (UseComp (CompAP (UseA2 married_A2))) (PrepNP by8means_Prep (DetCN (DetQuant this_Quant NumSg) (UseN woman_N))))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit dieser Frau
+TestLangEng: I am not married by this woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP (UseComp (CompAP (UseA2 married_A2))) (PrepNP with_Prep (DetCN (DetQuant this_Quant NumSg) (UseN woman_N))))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit dieser Frau
+TestLangEng: I am not married with this woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAP (ComplA2 married_A2 (UsePron she_Pron))))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit ihr
+TestLangEng: I am not married to her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP (UseComp (CompAP (UseA2 married_A2))) (PrepNP by8means_Prep (UsePron she_Pron)))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit ihr
+TestLangEng: I am not married by her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (AdvVP (UseComp (CompAP (UseA2 married_A2))) (PrepNP with_Prep (UsePron she_Pron)))))) NoVoc
+TestLangGer: ich bin nicht verheiratet mit ihr
+TestLangEng: I am not married with her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAP (ComplA2 neugierig_auf_A2 (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))) NoVoc
+TestLangGer: ich bin nicht neugierig auf das Buch
+TestLangEng: I am not curious about the book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (UseComp (CompAP (ComplA2 neugierig_auf_A2 (UsePron it_Pron))))))) NoVoc
+TestLangGer: ich bin nicht neugierig auf es
+TestLangEng: I am not curious about it
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (VPSlashPrep (UseComp (CompAP (UseA2 married_A2))) by8means_Prep) (DetCN (DetQuant this_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich bin nicht mit dieser Frau verheiratet
+TestLangEng: I am not married by this woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (VPSlashPrep (UseComp (CompAP (UseA2 married_A2))) with_Prep) (DetCN (DetQuant this_Quant NumSg) (UseN woman_N)))))) NoVoc
+TestLangGer: ich bin nicht mit dieser Frau verheiratet
+TestLangEng: I am not married with this woman
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (VPSlashPrep (UseComp (CompAP (UseA2 married_A2))) by8means_Prep) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich bin nicht mit ihr verheiratet
+TestLangEng: I am not married by her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (VPSlashPrep (UseComp (CompAP (UseA2 married_A2))) with_Prep) (UsePron she_Pron))))) NoVoc
+TestLangGer: ich bin nicht mit ihr verheiratet
+TestLangEng: I am not married with her

--- a/tests/german/examples.txt
+++ b/tests/german/examples.txt
@@ -1,0 +1,333 @@
+-- For regression tests using gf> eh regression-test.txt, HL 6/2019
+-- to test the ordering of objects and negation in simple clauses
+
+-- examples from ResGer.gf, 27/5/2012
+
+ich bin nicht alt                     -- accept
+ich bin nicht hier                    -- accept
+ich kenne dich nicht                  -- accept
+ich kenne deine Frau nicht            -- accept
+ich bin nicht ein Kind                -- dubious
+ich bin kein Kind                     -- accept, no_Quant
+ich schlafe nicht hier                -- accept
+ich sage nicht , dass es regnet ,     -- accept
+ich male es nicht blau                -- accept
+ich schlafe nicht immer               -- accept
+ich kenne dich nicht immer            -- accept
+ich kann nicht schlafen               -- accept
+es wird nicht besser                  -- accept
+
+-- simple sentences with V2 and (negated) indefinite objects, (-)iNP
+
+wir trinken Bier                      -- accept   
+wir trinken Bier nicht                -- accept   (v2fin < MassNP < neg)
+wir trinken es nicht                  -- accept   (v2fin < Pron < neg)
+wir trinken kein Bier                 -- accept   (v2fin < -MassNP)      via no_Quant
+wir trinken nicht Bier                -- reject   (v2fin < neg < MassNP) not_Predet
+wir trinken nicht es                  -- reject  *(v2fin < neg < Pron)   not_Predet
+
+wir trinken warmes Bier nicht         -- accept   (v2fin < MassNP < neg)
+wir trinken nicht warmes Bier         -- reject  *(v2fin < neg < MassNP)
+wir trinken kein warmes Bier          -- accept   (v2fin < -MassNP)
+wir trinken kein warmes Bier nicht    -- reject   (v2fin < -MassNP < neg; Bavarian: recognize)
+
+ich sehe den Mann nicht               -- accept   (v2fin < dNP < neg)
+ich sehe einen Mann nicht             -- dubious  (v2fin < iNP < neg), einen Mann nicht sehen
+ich sehe keinen Mann                  -- accept   (v2fin < -iNP) no_Quant
+ich sehe ihn nicht                    -- accept   (v2fin < Pron < neg)
+ich sehe nicht ihn                    -- reject  *(v2fin < neg < Pron); ok with emphasis?
+ich sehe jemanden nicht               -- accept, dubious   (v2fin < iPron < neg)
+ich sehe nicht jemanden               -- reject  *(v2fin < neg < iPron)
+ich sehe niemanden                    -- accept   (v2fin < -iPron)
+
+ich lese ein schlechtes Buch nicht    -- accept   (v2fin < iNP < neg), sentence negation
+ich lese kein schlechtes Buch         -- accept   (v2fin < -iNP)     
+
+ich sehe Gründe                       -- accept   (v2fin < iNP)
+ich sehe Gründe nicht                 -- dubious, accept  (v2fin < iNP < neg)
+ich sehe nicht Gründe                 -- dubious, accept  not_Predet
+ich sehe keine Gründe                 -- accept   (v2fin < -iNP)
+
+ich sehe zwei Gründe                  -- accept   (v2fin < dNP)
+ich sehe zwei Gründe nicht            -- accept   (v2fin < dNP < neg)
+ich sehe keine zwei Gründe            -- accept   (v2fin < -dNP)
+
+ich sehe schlechte Gründe             -- accept
+ich sehe schlechte Gründe nicht       -- accept   (v2fin < iNP < neg)
+ich sehe keine schlechten Gründe      -- accept   (v2fin < -iNP)
+ich sehe keine schlechte Gründe       -- reject AdjDekl
+
+ich sehe viele schlechte Gründe       -- accept   (v2fin < qNP)
+ich sehe viele schlechten Gründe      -- reject AdjDekl
+ich sehe viele schlechte Gründe nicht -- accept   (v2fin < qNP < neg)
+ich sehe nicht viele schlechte Gründe -- accept   (v2fin < neg < qNP) no_Predet
+ich sehe wenige schlechte Gründe      -- accept
+ich sehe wenige schlechten Gründe     -- reject AdjDekl
+
+-- with modal verb:
+
+wir wollen einen Mann nicht sehen     -- dubious
+wir wollen nicht einen Mann sehen     -- dubious
+wir wollen jemanden sehen             -- accept
+wir wollen nicht jemanden sehen       -- dubious, reject
+wir wollen jemanden nicht sehen       -- dubious, accept (niemanden sehen)
+     
+-- v2 with prep              (default order, Main: v2fin < neg < prep)
+
+wir warten nicht auf die Kinder           -- accept  (v2 < neg < prep) 
+wir warten nicht auf dich                 -- accept
+wir werden nicht auf euch warten          -- accept
+wir haben nicht auf alle Kinder gewartet  -- accept
+wir haben nicht auf euch gewartet         -- accept
+weil wir nicht auf euch warten wollen     -- accept
+wir warten nicht auf viele Kinder         -- accept  (prep ++ quantified np)?
+
+wir warten auf viele Kinder nicht         -- dubious (v2fin < prep + qNP < neg)
+wir haben auf viele Kinder nicht gewartet -- dubious
+wir haben auf alle Kinder nicht gewartet  -- reject  *(v2fin < prep < neg)
+
+wir warten auf die Kinder nicht           -- accept dubious
+wir warten auf dich nicht                 -- accept dubious
+wir haben auf euch nicht gewartet         -- accept dubious
+weil wir auf euch nicht warten wollen     -- accept dubious
+
+-- simple sentences with accdatV3 and definite/indefinite nonPron objects
+
+ich schicke der Frau das Buch         -- accept  (v3fin < dNP.dat < dNP.acc) 
+ich schicke der Frau ein Buch         -- accept  (v3fin < dNP.dat < iNP.acc) 
+ich schicke einer Frau das Buch       -- accept  (v3fin < iNP.dat < dNP.acc) 
+ich schicke einer Frau ein Buch       -- accept  (v3fin < iNP.dat < iNP.acc) 
+
+ich schicke das Buch der Frau         -- dubious (v3fin < dNP.acc < dNP.dat) 
+ich schicke ein Buch der Frau         -- reject *(v3fin < iNP.acc < dNP.dat) 
+ich schicke das Buch einer Frau       -- dubious (v3fin < dNP.acc < iNP.dat) 
+ich schicke ein Buch einer Frau       -- reject, dubious (v3fin < iNP.acc < iNP.dat) 
+
+-- simple sentences with accdatV3, negation and in/definite objects and Prons:
+
+-- (der Frau | ihr) (das | ein) Buch nicht schicken (v3fin < NP.dat < NP.acc < neg Vinf)
+
+ich schicke der Frau das Buch nicht   -- accept  (dNP.dat < dNP.acc < neg)
+ich schicke einer Frau das Buch nicht -- accept  (v3fin < iNP.dat < dNP.acc < neg)
+ich schicke ihr das Buch nicht        -- accept  (v3fin < Pron.dat < dNP.acc < neg)
+ich schicke es der Frau nicht         -- accept  (v3fin < Pron.acc < dNP.dat < neg)  
+ich schicke es einer Frau nicht       -- accept  (v3fin < Pron.acc < iNP.dat < neg)  
+ich schicke es ihr nicht              -- accept  (v3fin < Pron.acc < Pron.dat < neg)  
+ich schicke ihr es nicht              -- reject *(v3fin < Pron.dat < Pron.acc < neg)
+ich schicke es nicht ihr              -- reject *(v3fin < Pron.acc < neg < Pron.dat)
+
+ich schicke keiner Frau das Buch      -- accept  (v3fin < -iNP.dat < dNP.acc)
+ich schicke das Buch keiner Frau      -- accept  (v3fin < dNP.acc < -iNP.dat)
+ich schicke das Buch einer Frau nicht -- reject ?(v3fin < dNP.acc < iNP < neg)
+
+ich schicke der Frau kein Buch        -- accept  (v3fin < dNP.dat < -iNP.acc) 
+ich schicke ihr kein Buch             -- accept  (v3fin < Pron.dat < -iNP.acc) 
+ich schicke keiner Frau ein Buch      -- accept  (v3fin < -iNP.dat < iNP.acc)
+ich schicke es keiner Frau            -- accept  (v3fin < Pron.acc < -iNP.dat)
+ich schicke es einer Frau nicht       -- accept  (v3fin < Pron.acc < iNP.dat < neg)
+
+ich schicke ihr das Buch nicht        -- accept:  Pron.dat < dNP.acc < neg
+
+-- using Slash2V3, Slash3V3:
+
+-- provided that c2=dir-object, c3=indir-object in "give_V3 sb. sth."
+-- geben = v2{c2=acc,c3=dat}) == give = v2{c2=noP,c3=noP} !!
+
+der Apfel , den das Kind der Frau gibt ,          -- accept
+der Apfel , den das Kind ihr gibt ,               -- accept
+der Apfel , den ihr das Kind gibt ,               -- accept
+der Apfel , den es ihr gibt ,                     -- accept
+der Apfel , den ihr es gibt ,                     -- reject, Pron-order
+
+die Frau , der das Kind den Apfel nicht gibt ,    -- accept
+die Frau , der es den Apfel nicht gibt ,          -- accept
+die Frau , der das Kind ihn nicht gibt ,          -- accept
+die Frau , der ihn das Kind nicht gibt ,          -- accept
+die Frau , der die Kinder den Apfel nicht geben , -- accept
+die Frau , der die Kinder ihn nicht geben ,       -- accept ?
+die Frau , der sie ihn nicht geben ,              -- accept
+die Frau , der ihn die Kinder nicht geben ,       -- accept ?
+
+die Frau , der es ihn gibt ,                      -- accept
+die Frau , der er ihn gibt ,                      -- accept
+die Frau , welcher es ihn gibt ,                  -- accept
+die Frau , welcher er ihn gibt ,                  -- accept
+
+-- using QuestSlash and Slash3V3
+
+wem gibt das Kind den Apfel nicht                 -- accept
+wem gibt ihn das Kind nicht                       -- accept
+wem gibt das Kind ihn nicht                       -- reject, ?
+wem gibt es den Apfel nicht                       -- accept
+wem gibt es ihn nicht                             -- accept
+wem gibt es nicht den Apfel                       -- accept , no_Quant
+
+wen gibt es der Frau nicht                        -- accept
+wen gibt es ihr Frau nicht                        -- accept
+
+-- with dirV3 v gen = mkV3 v acc gen
+
+ich klage die Männer des Biers an  -- accept  (v3fin < dNP.acc < dNP.gen)
+ich klage ihn des Biers an         -- accept
+ich klage ihn einiger Biere an     -- accept
+ich klage des Biers ihn an         -- reject  (v3fin < NP.gen < Pron.acc)
+ich klage einiger Biere ihn an     -- reject  (v3fin < NP.gen < Pron.acc)
+
+ich klage die Männer des Biers nicht an  -- accept  (v3fin < dNP.acc < dNP.gen < neg )
+ich klage die Männer nicht des Biers an  -- accept  (v3fin < dNP.acc < neg < dNP.gen) not_Predet
+
+-- with mkV3 v acc acc
+
+wir lehren ihn die Musik              -- accept  (pron.acc(indir) < np.acc(dir))
+wir lehrten den Studenten den Grund   -- accept  (np.acc(indir) < np.acc(dir))
+wir lehrten den Grund den Studenten   -- reject  (np.acc(dir) < np.acc(indir))
+wir lehrten ihn den Grund             -- accept
+wir lehrten ihn die Studenten         -- reject 
+wir lehrten ihn sie                   -- dubious (pron.acc(indir) < pron.acc(dir))
+wir lehrten sie ihn                   -- dubious (pron.acc(dir) < pron.acc(indir)a)
+
+-- with dirV3 v prep:           (Main default order: vfin < acc < neg < prep < vinf)
+
+wir erinnern den Jungen nicht an den Regen -- accept
+wir erinnern den Jungen nicht an ihn       -- accept (daran)
+wir erinnern ihn nicht an ihn              -- accept
+wir haben den Jungen nicht an ihn erinnert -- accept
+
+wir danken der Kuh für den Käse            -- accept
+wir danken der Kuh nicht für den Käse      -- accept dubious
+wir danken der Kuh nicht für ihn           -- accept  (dafür nicht ?)
+wir danken ihr nicht für den Käse          -- accept
+wir danken ihr nicht für ihn               -- accept
+wir danken ihr nicht für ihn               -- accept
+
+-- with mkV3 v prep prep:  (implemented Main order: vfin < neg < prep < prep)
+--                          sometimes better:       vfin < prep < neg < prep)
+
+wir reden mit der Frau über den Mann       -- accept (Slash2V3)
+wir reden mit der Frau über den Mann nicht -- accept (Slash2V3)
+wir reden über den Mann mit der Frau       -- accept (Slash3V3)
+wir reden über den Mann mit der Frau nicht -- accept (Slash3V3)
+
+wir reden mit ihr über ihn nicht           -- accept
+wir reden nicht mit ihr über ihn           -- accept (not recognized)
+
+
+-- Reflexive verbs, to test Pron.acc < refl < Pron.dat|gen, nonPronNP:
+
+-- mkClause + PNeg gives (Main) "subj < vfin < refl < objs < neg < vinf", 
+-- but negation seems to come before prepositional objects.
+
+-- rV: refl.acc
+
+ihr ändert euch nicht                -- accept  (refl.acc < neg)
+er wird sich nicht anstrengen        -- accept 
+er hat sich nicht angestrengt        -- accept
+ihr ändert nicht euch                -- reject  (neg < refl.acc)
+er wird sich anstrengen nicht        -- reject
+er hat nicht sich angestrengt        -- reject
+
+-- rV2: refl.acc + dat
+
+du ergibst dich den Feinden nicht    -- accept  (refl.acc < np.dat < neg)
+du ergibst dich nicht den Feinden    -- accept  (refl.acc < neg, no_Predet)
+du ergibst dich mir nicht            -- accept  (refl.acc < pron.dat < neg)
+
+-- rV2: refl.acc + gen
+
+wir bedienen uns des Stockes         -- accept
+wir bedienen uns seiner              -- accept
+wir bedienen uns des Stockes nicht   -- accept  (refl.acc < np.gen < neg)
+wir bedienen uns seiner nicht        -- accept  (refl.acc < pron.gen < neg)
+
+-- rV2: refl.acc + prep
+
+ich stütze mich nicht auf den Stock  -- accept (refl.acc < neg < np.prep)
+ich stütze mich auf den Stock nicht  -- reject (refl.acc < np.prep < neg)
+ich stütze mich nicht auf ihn        -- accept (refl.acc < neg < pron.prep)
+ich stütze mich auf ihn nicht        -- reject (refl.acc < pron.prep < neg)
+
+-- rV3: refl.acc + prep + prep
+
+ich entschuldige mich bei dir für die Frage           -- accept, Slash2V3
+ich entschuldige mich bei dir für sie                 -- accept
+ich entschuldige mich bei dir für die Frage nicht     -- accept
+ich entschuldige mich bei dir nicht für die Frage     -- dubious (not recognized)
+ich entschuldige mich nicht bei dir für die Frage     -- accept  (not recognized)
+
+die Frage , für die ich mich bei ihr entschuldigte    -- accept, Slash2V3
+
+ich entschuldige mich für die Frage bei dir            -- accept, Slash3V3
+ich entschuldige mich für die Frage bei dir nicht      -- accept, Slash3V3
+die Frau , bei der ich mich für ihn nicht entschuldige -- accept, Slash3V3
+die Frau , bei der ich mich nicht für ihn entschuldige -- accept, Slash3V3 (not recognized)
+
+er hat sich bei mir für den Stock nicht entschuldigt   -- accept
+hast du dich bei ihm für den Stock nicht entschuldigt  -- accept (not recognized)
+hast du dich nicht bei ihm für den Stock entschuldigt  -- accept Inv: vfin ++ subj ++ obj1 ++ neg ++ obj2
+hast du dich bei ihm nicht für den Stock entschuldigt  -- dubious
+hast du dich bei ihm für ihn entschuldigt              -- accept (refl.acc < prep1 < prep2), Slash2V3
+hast du dich für ihn bei ihm entschuldigt              -- accept (refl.acc < prep2 < prep1), Slash3V3
+
+-- rV2: refl.dat + acc
+
+ich merke mir jeden Stock          -- accept
+ich merke jeden Stock mir          -- reject  (np.acc < refl.dat)
+ich merke ihn mir                  -- accept  (pron.acc < refl.dat)
+ich merke mir jeden Stock nicht    -- accept  (refl.dat < np.acc < neg)
+ich merke mir nicht jeden Stock    -- accept  (refl.dat < neg < np.acc), not_Predet
+ich hatte mir den Stock gemerkt    -- accept  (refl.dat < np.acc)
+ich hatte mir ihn gemerkt          -- reject  (refl.dat < pron.acc)
+ich hatte ihn mir gemerkt          -- accept  (pron.acc < refl.dat)
+
+-- rV3: refl.dat + acc + prep
+
+wir leihen uns das Buch von dir       -- accept
+wir leihen uns das Buch nicht von dir -- accept   (refl.dat < np.acc < neg < prep), Slash2V3,Slash3V3
+wir leihen uns das Buch von dir nicht -- dubious ?(refl.dat < np.acc < prep < neg), Slash2V3,Slash3V3
+
+das Buch , das wir uns nicht von dir liehen ,      -- accept  Slash3V3
+das Buch , das wir uns von dir nicht liehen ,      -- dubious, Slash3V3
+die Frau , von der wir uns das Buch nicht liehen , -- accept, Slash2V3
+die Frau , von der wir uns kein Buch liehen ,      -- accept, Slash2V3
+die Frau , von der wir es uns nicht liehen ,       -- accept  (prep < subj < pron.acc < refl.dat < neg < vfin)
+die Frau , von der wir uns es nicht liehen ,       -- reject *(prep < subj < refl.dat < pron.acc < neg < vfin)
+
+wir , die wir uns das Buch von dir liehen ,        -- accept (not recognized)
+wir , die sich das Buch von dir liehen ,           -- dubious (recognized, Slash2V3, Slash3V3)
+wir , die sich das Buch nicht von dir liehen ,     -- dubious (recognized, Slash2V3, Slash3V3)
+
+-- dirV4 v prep prep (mieten_von_fuer_V4)
+
+du mietest den Wagen von der Frau für den Mann        -- accept (Slash2V4,Slash3V4,ComplSlashSlash)
+du mietest den Wagen für den Mann von der Frau        -- accept (Slash4V4, ComplSlashSlash)
+du mietest den Wagen von der Frau für den Mann nicht  -- accept
+du mietest den Wagen für den Mann von der Frau nicht  -- accept (Slash4V4, ComplSlashSlash)
+du mietest den Wagen von der Frau für mich nicht      -- accept
+du mietest den Wagen für mich von der Frau nicht      -- dubious
+du mietest ihn von der Frau für mich                  -- accept
+du mietest den Wagen von ihr für mich nicht           -- accept
+du mietest ihn für mich von der Frau                  -- accept
+du mietest ihn von ihr für mich                       -- accept
+
+du mietest für mich von der Frau den Wagen        -- accept  (not recognized, order)
+du mietest für mich von der Frau den Wagen nicht  -- accept  (not recognized, order)
+du mietest für mich von ihr den Wagen             -- dubious (not recognized, order)
+
+-- predicative A2: neg + A2 + obj   (via insertAdj; better: obj + neg + A2)
+
+ich bin nicht verheiratet mit dieser Frau  -- accept (A2 < obj)
+ich bin nicht verheiratet mit ihr          -- accept (A2 < obj)
+ich bin nicht neugierig auf das Buch       -- accept
+ich bin nicht neugierig auf es             -- accept
+
+ich bin mit dieser Frau nicht verheiratet  -- dubious (using ComplSlashPrep)
+ich bin mit ihr nicht verheiratet          -- dubious
+ich bin auf das Buch nicht neugierig       -- dubious
+ich bin auf es nicht neugierig             -- dubious (prep < A2)
+
+ich bin nicht mit dieser Frau verheiratet  -- accept (not recognized, order)
+ich bin nicht mit ihr verheiratet          -- accept (not recognized)
+ich bin nicht auf ihn neugierig            -- reject
+
+-- done
+

--- a/tests/german/object-order.README
+++ b/tests/german/object-order.README
@@ -87,7 +87,7 @@ contained in examples.txt. (Definiteness seems to be relevant to order, too.)
              ich trinke warmes Bier nicht  [ ich trinke nicht Bier: via no_Predet ]
 
    The order  accPron < refl < (gen|dat)Pron < neg < nonpronNP  sometimes sounds
-   better, but expresses a different meaning (often available via no_Preded):
+   better, but expresses a different meaning (often available via no_Predet):
 
              sie hat sich nicht alle|viele|?mehrere Namen gemerkt
              sie hat sich alle?|viele|mehrere Namen nicht gemerkt
@@ -98,7 +98,10 @@ contained in examples.txt. (Definiteness seems to be relevant to order, too.)
         einige Lehrer haben jedem Studenten viele Bücher nicht geschickt|empfohlen
         =?= some teachers haven't sent|recommended many books to every student
         
-   For tests, see examples.txt and TestLangGer.
+   For tests, see examples.txt and how to do regression tests (see below).
+ 
+   Rem.: Having more nn-fields may be useful to put adverbs in between (with 
+         additional scope problems).
 
 4. For reflexive V2's (ich bediene mich einer Sache, ich merke mir eine Sache) or 
    reflexive V3's (ich entschuldige mich bei dat für acc, ich leihe mir acc bei dat), 
@@ -236,16 +239,14 @@ Also, singular mass-NPs behave different:
     ich trinke nicht *((kaltes) Bier) 
     ich trinke (kaltes) Bier nicht | ich trinke kein (kaltes) Bier
 
-PROBLEMS: do V2 + neg behave the same as V3 + neg? Can the scope of negation
-and quantifiers be fixed (or at least restricted) by intonation?
+PROBLEM: do V2 + neg behave the same as V3 + neg? Aren't the relative 
+scopes of negation and quantifiers fixed (or restricted) by intonation?
 
 ------------- Generating some example trees and linearize them (LangGer|Eng) -----------
 
 gr -tr -number=4 UseCl (TTAnt ? ?) ? (PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuant ? ?) (UseN man_N)))) | l
 
-gr -number=4 -tr UseCl (TTAnt ? ?) ? (PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuantOrd ? ? ?) (UseN man_N)))) | l
-
-Pronoun switch with V3 and Slash3V2 works:
+Pronoun switch with V3 and Slash?V2 works:
 
 l UseCl (TTAnt TPast AAnter) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 sell_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 I had sold the book to a woman
@@ -255,14 +256,26 @@ l UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3
 I wouldn't sell it to her
 ich würde es ihr nicht verkaufen
 
---------------------- Regression tests -----------------------------------
+------ Regression tests: use  gf --run < object-order.gfs  or  gf> eh object-order.gfs
 
-From Eng to Ger:
-Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="LangEng,LangGer" -treebank | wf -file=examples.eng.new
-Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l | wf -file=examples.eng2ger.new
+Form Ger to Eng: 
 
-From Ger to Eng: see examples.txt and object-order.gfs
+example.txt contains german example sentences marked "positive", "negative", "dubious",
+some with two marks. The marks may not always be convincing, as some orderings of negation 
+and quantified nps afford particular intonation and meaning. (Also, there are incorrect 
+parse trees due to misuse of MassNP etc., so it needs some inspection to see if the content
+of examples.*.out is as it ought to be.)
 
-(Some of these examples need german/TestLangGer|Eng)
+Part of examples.txt needs TestLangGer|Eng for parsing and translation, in particular
+those with reflexive ternary verbs or quaternary verbs (which are not in the RGL).
 
+From Eng to Ger: 
+
+examples.eng.txt could also be parsed using LangEng instead of TestLangEng|Ger.
+
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
+
+Using give_V3 is confusing, as both objects are connected with noPrep. The examples are
+repeated using send_V3, which attaches its indirect object with toPrep.
 -------------------------------------------------------------------------------------End

--- a/tests/german/object-order.README
+++ b/tests/german/object-order.README
@@ -1,0 +1,268 @@
+Implementing pronoun switch e.a. in LangGer        HL 13.6.2019 -- 20.3.2019
+-------------------------------------------
+Ternary verbs v:V3 with two objects of category NP order them
+depending on their being (personal) pronouns or not. Basically
+
+non-pronoun order:  NonPronNP.dat < NonPronNP.acc
+pronoun/nonpronoun: Pron < NonPronNP
+pronoun order:      Pron.acc < Pron.dat
+
+See also (section II):
+http://www.dartmouth.edu/~deutsch/Grammatik/WordOrder/WordOrder.html     
+
+What about verbs with other complement cases? Apparently we have
+- NP.acc < NP.gen: wir verdächtigen ihn|den Mann ihrer|der Tat
+- NP.acc[indir] < NonPronNP.acc[dir]: wir lehren ihn|den Studenten die Kunst
+- Pron.acc[dir] < Pron.acc[indir]:    wir lehren sie ihn (?)
+
+A collection of relevant example sentences to do some regression tests is
+contained in examples.txt. (Definiteness seems to be relevant to order, too.)
+
+============== Main changes made: (cf. discussion below) ======================
+
+1. Categories VP and VPSlash have nn : Agr => Str * Str * Str * Str, where now
+
+   nn.p1 contains refl+pron   (pron.acc < refl, refl < pron.dat, refl < pron.gen),
+   nn.p2 contains nonpron NPs (np.dat < np.acc | np.gen) (cf. insertObjNP below)
+   nn.p3 contains prep NPs
+   nn.p4 contains predicative A | CN | Adv (inserted by UseComp)
+
+   Note: keeping complements in 4 nn-fields may be useful to insert adverbs in between 
+        (not done yet), besides ordering them relative to negation (see below).
+
+   Note: become_VA is not treated like a copula (i.e. not using CompAP) (also in Eng):
+             "bin alt" = (UseComp (CompAP adj)) adds adj to nn.p3 (was:nn.p2), 
+           "werde alt" = (ComplVA become_VA adj), inserts adj into vp.adj
+         So there is no uniform treatment of copula verbs "sein", "werden", "bleiben".
+
+2. Pronoun switch is done by (insertObjectNP np vp.c vp), such that pron.acc < refl < pron.dat|gen:
+
+     (insertObjNP pron acc  vp).nn = <pron.acc ++ vp.nn.p1(refl),  vp.nn.p2, vp.nn.p3, vp.nn.p4>
+     (insertObjNP pron case vp).nn = <vp.nn.p1(refl) ++ pron!case, vp.nn.p2, vp.nn.p3, vp.nn.p4>
+
+   For other object np's, we enforce np.dat < np.acc|gen:   (this doesn't enforce np.acc < np.gen)
+
+     (insertObjNP np   dat  vp).nn = <vp.nn.p1,          np!dat ++ vp.nn.p2, vp.nn.p3, vp.nn.p4> 
+     (insertObjNP np   case vp).nn = <vp.nn.p1,         vp.nn.p2 ++ np!case, vp.nn.p3, vp.nn.p4> 
+
+   Object pp's are collected in nn.p3:
+
+     (insertObjNP np   prep vp).nn = <vp.nn.p1,    vp.nn.p2, vp.nn.p3 ++ app(prep,np), vp.nn.p4> 
+
+   Complements (AP|Adv|CN) are collected in vp.nn.p4, using the existing insertObj:
+     (insertObj   compl     vp).nn = <vp.nn.p1,            vp.nn.p2, vpnn.p3, compl ++ vp.nn.p4> 
+
+   For verbs v:V3 with 2 acc-arguments, "ich lehre ihn sie|die Mathematik", we can't distinguish 
+   direct object (acc: die Mathematik) from indirect object (acc: ihn), so we get two trees.
+  
+   Bug: ConstructionGer (mkVP have_V2 (mkNP n:N)) (for "Angst|Recht haben") puts n into nn.p2, 
+        which comes before negation. 
+       (Maybe we need np.isLight to prevent this and put n in nn.p3, or apply UseComp with n.)
+ 
+3. The ordering of objects, complements and negation in mkClause is changed !!!
+
+   The "default" order (if it exists) is subtle, depending on whether objects are 
+   definite, indefinite Sg, indefinitePl, pron, quantified, negated indefinite. We now have
+
+   (mkClause subj agr vp) : Clause = 
+   let
+      obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2; -- refl,pronouns < nonpronouns
+      obj2  = (vp.nn ! agr).p3 ;                    -- (prep + np)s
+      compl = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ; -- compl via useComp
+   in 
+      Main => subj ++ verb.fin ++ obj1 ++ neg ++ obj2 ++ compl ++ vp.infExt ++ infs ++ extra ;
+      Inv  => verb.fin ++ subj ++ obj1 ++ neg ++ obj2 ++ compl ++ vp.infExt ++ infs ++ extra ;
+      Sub  => subj ++ obj1 ++ neg ++ obj2 ++ compl ++ vp.infExt ++ inffin ++ extra
+
+   I have *removed* the difference between "light" and "heavy" complements, which gave the 
+   ordering  light < neg < heavy. It was using np.isPron=True as "light", but also set 
+   indefinite nps (and DetNPs) as heavy. But this ignored the number, which is also relevant: 
+
+             ich sehe den Mann nicht ; ich sehe nicht einen Mann
+   but       ich liebe Männer nicht  ; * ich liebe nicht Männer
+
+   The change now gives: nonpronNP < neg,
+
+             ich sehe einen Mann nicht     [ ich sehe keinen Mann:  via no_Predet ]
+             ich trinke warmes Bier nicht  [ ich trinke nicht Bier: via no_Predet ]
+
+   The order  accPron < refl < (gen|dat)Pron < neg < nonpronNP  sometimes sounds
+   better, but expresses a different meaning (often available via no_Preded):
+
+             sie hat sich nicht alle|viele|?mehrere Namen gemerkt
+             sie hat sich alle?|viele|mehrere Namen nicht gemerkt
+
+   The implemented order nonpronNP < neg gives negation narrow scope relative to the 
+   quantifiers in the objects (a meaning that cannot otherwise be expressed):
+
+        einige Lehrer haben jedem Studenten viele Bücher nicht geschickt|empfohlen
+        =?= some teachers haven't sent|recommended many books to every student
+        
+   For tests, see examples.txt and TestLangGer.
+
+4. For reflexive V2's (ich bediene mich einer Sache, ich merke mir eine Sache) or 
+   reflexive V3's (ich entschuldige mich bei dat für acc, ich leihe mir acc bei dat), 
+   some tests are in examples.txt and TestLangGer|Eng. We have enforced  refl < neg.
+
+   TestLangGer introduces ternary predicates VPSlashSlash. These can be built by
+   Slash2V4, Slash3V4, Slash4V4 from quaternary verbs v:V4 and a noun phrase np:NP. 
+   (A function SlashV3a : V3 -> VPSlashSlash is omitted to reduce ambiguities.)
+
+   SlashV2a turns a (DictVerbsGer-) verb_rV2:V2 into a reflexive VPSlash:
+
+     SlashV2a bedienen_gen_rV2 : VPSlash = sich einer Sache bedienen
+
+   A reflexive VPSlash can also be built from a V3 by
+
+     ReflVPSlash : V3 -> VPSlash,
+
+   but maybe this is unnecessary, as 
+
+    (ComplSlash (ReflVPSlash v3) np) = (ReflVP (Slash3V3 v3 np)).
+
+   Todo: Some of this ought to go to ExtraGer.gf.
+
+5. I changed ParadigmsGer.accdatV3 from "mkV3 v dat acc" to "mkV3 v acc dat"
+   = dirV3 v dat, so that it fits to "dirV3 v p" in Eng and gives the corresponding
+   trees for sentences with main verb v:V3.
+
+============= Motivating discussion of the situation in gf-3.9 / gf-rgl ==============
+
+LexiconGer has those V3s:
+  add_V3 = dirV3 (prefixV "hinzu" (regV "fügen")) zu_Prep ;
+  give_V3 = accdatV3 Irreg.geben_V ; 
+  sell_V3 = accdatV3 (no_geV (regV "verkaufen")) ;
+  send_V3 = accdatV3 (regV "schicken") ;
+  talk_V3 = mkV3 (regV "reden") datPrep von_Prep ;
+
+ParadigmsGer defines
+  mkV3 = overload {
+    mkV3 : V -> V3  = \v -> lin V3 (v ** {c2 = accPrep ; c3 = datPrep}) ;
+    mkV3 : V -> Prep -> Prep -> V3 = \v,c,d -> lin V3 (v ** {c2 = c ; c3 = d}) ;
+    } ;
+  dirV3 v p = mkV3 v accPrep p ;         -- v ** {c2=accPrep; c3=p} 
+  accdatV3 v = mkV3 v datPrep accPrep ;  -- v ** {c2=datPrep; c3=accPrep} 
+
+LexiconEng says, using, roughly, dirV3 v p = v ** {c2=noPrep ; c3=p}:
+  give_V3 = mkV3 give_V noPrep noPrep ;
+  sell_V3 = dirV3 (irregV "sell" "sold" "sold") toP ;
+  send_V3 = dirV3 (irregV "send" "sent" "sent") toP ;
+
+Apparently, the idea is: 
+  (Ger) direct object = acc = c2; indirect object = dat|gen = c3
+  (Eng) direct object = noPrep = c2; indirect object = toPrep = c3
+
+BUT then, accdatV3 v should be = dirV3 v datPrep = v**{c2=accPrep,c3=datPrep} !!
+
+Which object is bound "closer" to the verb? Is this regulated by using
+Slash2V3 versus Slash3V3, and does this binding strength manifest
+itself outside of extraction phenomena? 
+
+abstract/Verb.gf says:
+
+  ComplSlash : VPSlash -> NP -> VP ; -- love it
+  SlashV2a : V2        -> VPSlash ;  -- love (it)
+
+  Slash2V3 : V3  -> NP -> VPSlash ;  -- give it (to her)
+  Slash3V3 : V3  -> NP -> VPSlash ;  -- give (it) to her
+
+Roughly, gf-3.9/../VerbGer.gf has:
+
+  Slash2V3 v np = insertObjc np!v.c2 (predVc v) ** {c2 = v.c3}
+  Slash3V3 v np = insertObjc np!v.c3 (predVc v) ** {c2 = v.c2}
+
+So, regardless if any object comes with a preposition, 
+
+  Slash2V3 v np  binds   direct object c2 to the verb, 
+  Slash3V3 v np  binds indirect object c3 to the verb. 
+
+But which is direct, which indirect for acc+acc-verbs: 
+      sie lehrt ihn die Kunst, probably: c2=die Kunst, c3=ihn
+And which object is direct, which indirect, for prep+prep-verbs?
+      sie redet mit ihm über die Kunst:  c2=die Kunst, c3=ihm ?
+
+PROBLEM: who tells the user which argument is direct, which not?
+
+Eng: sell_V3 = dirV3 sell_V toP,              so c2="", c3="to"
+     talk_V3 = mkV3 (regV "talk") toP aboutP, so c2="to", c3="about"
+     (Isn't this inconsistent? Shouldn't we have "mkV3 v dir indir"?)
+Ger: sell_V3 = accdatV3 verkaufen_V
+             = mkV3 verkaufen_V datPrep accPrep, so c2=dat, c3=acc
+
+To get trees with similar meaning, I CHANGED accdatV3 to "mkV3 v acc dat"
+in ParadigmsGer (so that it fits to "dirV3 v p" in Eng).
+
+The best would be if mkV3 (with acc-obj) were only available through
+dirV3 v p, so one could not use (mkV3 v datPrep accPrep) etc.
+
+---------------- word order in ResGer.mkClause in gf-rgl -------------------
+
+In gf-3.9 resp. gf-rgl, VP.nn : Str*Str collects the nominal (and
+adjectival) objects; those object-NPs with flag
+
+  isPron = True ; --- means: this is not a heavy NP, but comes before negation
+
+are put before the negation in mkClause:
+
+    obj0  = (vp.nn ! agr).p1 ;
+    obj   = (vp.nn ! agr).p2 ;
+    compl = obj0 ++ neg  ++ vp.adj ++ obj ++ vp.a2 ; -- adj added
+    inf   = vp.inf ++ verb.inf.p1 ; -- not used for linearisation of Main/Inv
+    extra = vp.ext ;
+    inffin : Str = case <a,vp.isAux> of {                       
+	           <Anter,True> => verb.fin ++ inf ; -- double inf   --# notpresent
+                   _            => inf ++ verb.fin   --- or just auxiliary vp
+            } ;   
+  in case o of {
+    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
+    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
+    Sub  => subj ++ compl ++ vp.infExt ++ inffin ++ extra
+
+This is too simple:
+
+DetCN creates an NP with
+    isPron = det.isDef ;   -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
+
+i.e. (definite article + CN | pronoun) are put in nn.p1, to come before negation
+ 
+    ich sehe ihn nicht, ich sehe den Mann nicht:  compl = (nn.p1 + neg + ..)
+    ich sehe nicht einen Mann                  :  compl = neg ++ nn.p2
+    =? ich sehe keinen Mann 
+
+But: plural indefinite NPs behave different:
+    I don't see men:      ich sehe Männer nicht
+                          ich sehe *(nicht Männer) | keine Männer
+Also, singular mass-NPs behave different:    
+    ich trinke nicht *((kaltes) Bier) 
+    ich trinke (kaltes) Bier nicht | ich trinke kein (kaltes) Bier
+
+PROBLEMS: do V2 + neg behave the same as V3 + neg? Can the scope of negation
+and quantifiers be fixed (or at least restricted) by intonation?
+
+------------- Generating some example trees and linearize them (LangGer|Eng) -----------
+
+gr -tr -number=4 UseCl (TTAnt ? ?) ? (PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuant ? ?) (UseN man_N)))) | l
+
+gr -number=4 -tr UseCl (TTAnt ? ?) ? (PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) (DetCN (DetQuantOrd ? ? ?) (UseN man_N)))) | l
+
+Pronoun switch with V3 and Slash3V2 works:
+
+l UseCl (TTAnt TPast AAnter) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 sell_V3 (DetCN (DetQuant IndefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+I had sold the book to a woman
+ich hatte einer Frau das Buch verkauft
+
+l UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 sell_V3 (UsePron she_Pron)) (UsePron it_Pron)))
+I wouldn't sell it to her
+ich würde es ihr nicht verkaufen
+
+--------------------- Regression tests -----------------------------------
+
+From Eng to Ger:
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="LangEng,LangGer" -treebank | wf -file=examples.eng.new
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l | wf -file=examples.eng2ger.new
+
+From Ger to Eng: see examples.txt and object-order.gfs
+
+(Some of these examples need german/TestLangGer|Eng)
+
+-------------------------------------------------------------------------------------End

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -1,0 +1,30 @@
+--# Use gf --run < obj-order.gfs  or  gf> eh object-order.gfs 
+? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+i TestLangGer.gf TestLangEng.gf
+-- Remark: examples in examples.eng.txt need only LangEng,LangGer
+? echo "parsing from examples.eng and writing trees to examples.eng.new:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
+? echo "diff examples.eng.out examples.eng.new"
+? diff examples.eng.out examples.eng.new
+? echo "parsing from examples.eng and writing source and translation to examples.eng2ger.new:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
+? echo "diff examples.eng2ger.out examples.eng2ger.new"
+? diff examples.eng2ger.out examples.eng2ger.new
+
+? echo "extracting positive, negative and dubious examples from examples.txt ..."
+? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.pos.txt
+? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.neg.txt
+? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.dub.txt
+
+? echo "parsing negative examples ...; storing trees in examples.neg.new ..."
+rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.new"
+? echo "diff examples.neg.out examples.neg.new:"
+? diff examples.neg.out examples.neg.new
+? echo "parsing dubious examples ...; storing trees in examples.dub.new ..."
+rf -lines -file="examples.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.dub.new"
+? echo "diff examples.dub.out examples.dub.new:"
+? diff examples.dub.out examples.dub.new
+? echo "parsing positive examples ...; storing trees in examples.pos.new ..."
+rf -lines -file="examples.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.pos.new"
+? echo "diff examples.pos.out examples.pos.new:"
+? diff examples.pos.out examples.pos.new


### PR DESCRIPTION
In Ger, Pron.acc comes before Pron.dat|gen, while generally NP.dat comes before NP.acc. These are now
enforced (but not NP.acc before NP.gen), and that Refl < Pron < NP < neg < PP | AP | CN | Adv.

accdatV3 is changed (to c2=acc, c3=dat) to fit to Eng (c2=dir, c3=indir). Tests are under src/tests/german.