### PR TITLE
(Ger) Readjusting accdatV3 in ParadigmsGer and modifying V3-examples …

### DIFF
--- a/src/german/LexiconGer.gf
+++ b/src/german/LexiconGer.gf
@@ -169,8 +169,8 @@ lin
   sea_N = reg2N "Meer" "Meere" neuter ;
   seek_V2 = dirV2 (regV "suchen") ;
   see_V2 = dirV2 Irreg.sehen_V ;
-  sell_V3 = accdatV3 (no_geV (regV "verkaufen")) ;
-  send_V3 = accdatV3 (regV "schicken") ;
+  sell_V3 = mkV3 (no_geV (regV "verkaufen")) ;    -- Eng: mkV3 v noPrep toPrep
+  send_V3 = mkV3 (regV "schicken") ; -- Ger mkV3 v = Ger: mkV3 v accPrep datPrep
   sheep_N = reg2N "Schaf" "Schafe" neuter ;
   ship_N = reg2N "Schiff" "Schiffe" neuter ;
   shirt_N = reg2N "Hemd" "Hemden" neuter ; ---- infl
@@ -316,7 +316,8 @@ lin
   flow_V = seinV (Irreg.fließen_V) ; 
   fly_V = seinV (Irreg.fliegen_V) ; 
   freeze_V = Irreg.frieren_V ; 
-  give_V3 = accdatV3 Irreg.geben_V ; 
+  give_V3 = accdatV3 Irreg.geben_V ; -- c2=datPrep, c3=accPrep, to fit
+             -- to Eng ditransitive: give sb(indir) sth(dir) (no preposition)
   laugh_V = regV "lachen" ;
   lie_V = Irreg.lügen_V ; 
   play_V = regV "spielen" ;

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -286,11 +286,11 @@ mkV2 : overload {
 -- Three-place (ditransitive) verbs need two prepositions, of which
 -- the first one or both can be absent.
 
-  accdatV3 : V -> V3 ;                  -- geben + dat + acc (no prepositions)
+  accdatV3 : V -> V3 ;                  -- geben + dat(c2) + acc(c3) (Eng: no prepositions)
   dirV3    : V -> Prep -> V3 ;          -- senden + acc + nach (preposition on second arg)
 
   mkV3 : overload {
-    mkV3     : V ->                 V3 ;  -- geben + dat + acc
+    mkV3     : V ->                 V3 ;  -- geben + dat(c3) + acc(c2) (Eng: give sth to-sb)
     mkV3     : V -> Prep -> Prep -> V3 ;  -- sprechen + mit + über
     } ;
 
@@ -588,9 +588,8 @@ mkV2 : overload {
     } ;
 
   dirV3 v p = mkV3 v accPrep p ;        -- accPrep sets isPrep=False
---  accdatV3 v = mkV3 v datPrep accPrep ; 
-  accdatV3 v = dirV3 v datPrep ;        -- to fit to Eng: direct obj = c2, HL 6/2019
-
+  accdatV3 v = mkV3 v datPrep accPrep ; -- to fit to Eng ditransitives (no preposition): 
+                                        -- give sb(indir) sth(dir) = geben jmdm(dat) etwas(acc)
   mkVS v = v ** {lock_VS = <>} ;
   mkVQ v = v ** {lock_VQ = <>} ;
   mkVV v = v ** {isAux = False ; lock_VV = <>} ;

--- a/tests/german/examples.dub.out
+++ b/tests/german/examples.dub.out
@@ -91,6 +91,9 @@ TestLangEng: we want to see not somebody
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) somebody_NP))))) NoVoc
 TestLangGer: wir wollen nicht jemanden sehen
 TestLangEng: we don't want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) somebody_NP)))) NoVoc
+TestLangGer: wir wollen jemanden nicht sehen
+TestLangEng: we don't want to see somebody
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
 TestLangGer: wir lehrten ihn sie
 TestLangEng: we taught her him

--- a/tests/german/examples.eng.out
+++ b/tests/german/examples.eng.out
@@ -1,195 +1,237 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives the woman the apple
+TestLangGer: das Kind gibt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman the apple
+TestLangGer: das Kind gibt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron he_Pron))))) NoVoc
+TestLangEng: the child gives the woman him
+TestLangGer: das Kind gibt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman him
+TestLangGer: das Kind gibt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: the child gives the woman her
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman her
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron they_Pron))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt sie der Frau
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives her the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
 TestLangEng: the child gives her the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives him the apple
-TestLangGer: das Kind gibt ihn dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron he_Pron))))) NoVoc
 TestLangEng: the child gives him the apple
-TestLangGer: das Kind gibt ihn dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt dem Apfel das
+TestLangGer: das Kind gibt dem den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt es dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt dem Apfel das
+TestLangGer: das Kind gibt dem den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron it_Pron))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt es dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt dem Apfel die
+TestLangGer: das Kind gibt denen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihnen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt dem Apfel die
+TestLangGer: das Kind gibt denen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron they_Pron))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihnen den Apfel
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that the child gives her
-TestLangGer: der Apfel , dem das Kind sie gibt
+TestLangGer: der Apfel , den das Kind ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that the child gives her
-TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangGer: der Apfel , dem das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , dem das sie gibt
+TestLangGer: der Apfel , den das ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , den das ihr gibt
+TestLangGer: der Apfel , dem das sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , dem es sie gibt
+TestLangGer: der Apfel , den es ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , den es ihr gibt
+TestLangGer: der Apfel , dem es sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , dem das ihn gibt
+TestLangGer: der Apfel , den das ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , den das ihm gibt
+TestLangGer: der Apfel , dem das ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , dem es ihn gibt
+TestLangGer: der Apfel , den es ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , den es ihm gibt
+TestLangGer: der Apfel , dem es ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem das das gibt
+TestLangGer: der Apfel , den das dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem das es gibt
+TestLangGer: der Apfel , den das ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den das dem gibt
+TestLangGer: der Apfel , dem das das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den das ihm gibt
+TestLangGer: der Apfel , dem das es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem es das gibt
+TestLangGer: der Apfel , den es dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem es es gibt
+TestLangGer: der Apfel , den es ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den es dem gibt
+TestLangGer: der Apfel , dem es das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den es ihm gibt
+TestLangGer: der Apfel , dem es es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem das die gibt
+TestLangGer: der Apfel , den das denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem das sie gibt
+TestLangGer: der Apfel , den das ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den das denen gibt
+TestLangGer: der Apfel , dem das die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den das ihnen gibt
+TestLangGer: der Apfel , dem das sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem es die gibt
+TestLangGer: der Apfel , den es denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem es sie gibt
+TestLangGer: der Apfel , den es ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den es denen gibt
+TestLangGer: der Apfel , dem es die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den es ihnen gibt
+TestLangGer: der Apfel , dem es sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangEng: the woman that the child gives the apple
-TestLangGer: die Frau , der das Kind den Apfel gibt
+TestLangGer: die Frau , die das Kind dem Apfel gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangEng: the woman that the child gives the apple
-TestLangGer: die Frau , die das Kind dem Apfel gibt
+TestLangGer: die Frau , der das Kind den Apfel gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives him
-TestLangGer: die Frau , der das Kind ihn gibt
+TestLangGer: die Frau , die das Kind ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives him
-TestLangGer: die Frau , die das Kind ihm gibt
+TestLangGer: die Frau , der das Kind ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives her
-TestLangGer: die Frau , der das Kind sie gibt
+TestLangGer: die Frau , die das Kind ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives her
-TestLangGer: die Frau , die das Kind ihr gibt
+TestLangGer: die Frau , der das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , der das Kind das gibt
+TestLangGer: die Frau , die das Kind dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , der das Kind es gibt
+TestLangGer: die Frau , die das Kind ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , die das Kind dem gibt
+TestLangGer: die Frau , der das Kind das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , die das Kind ihm gibt
+TestLangGer: die Frau , der das Kind es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , der das Kind die gibt
+TestLangGer: die Frau , die das Kind denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , der das Kind sie gibt
+TestLangGer: die Frau , die das Kind ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , die das Kind denen gibt
+TestLangGer: die Frau , der das Kind die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , die das Kind ihnen gibt
+TestLangGer: die Frau , der das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: who gives the woman the apple
-TestLangGer: wer gibt dem Apfel die Frau
+TestLangGer: wer gibt der Frau den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman the apple
-TestLangGer: wer gibt dem Apfel die Frau
+TestLangGer: wer gibt der Frau den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt dem die Frau
+TestLangGer: wer gibt der Frau das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt ihm die Frau
+TestLangGer: wer gibt es der Frau
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt dem die Frau
+TestLangGer: wer gibt der Frau das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt ihm die Frau
+TestLangGer: wer gibt es der Frau
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: who gives her the apple
-TestLangGer: wer gibt sie dem Apfel
+TestLangGer: wer gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her the apple
-TestLangGer: wer gibt sie dem Apfel
+TestLangGer: wer gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie dem
+TestLangGer: wer gibt ihr das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie ihm
+TestLangGer: wer gibt es ihr
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie dem
+TestLangGer: wer gibt ihr das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie ihm
+TestLangGer: wer gibt es ihr
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: the child sends the apple to the woman
 TestLangGer: das Kind schickt der Frau den Apfel

--- a/tests/german/examples.eng.txt
+++ b/tests/german/examples.eng.txt
@@ -1,0 +1,88 @@
+-- ditransitive give: give sb(indir=c2) sth(dir=c3)
+the child gives the woman the apple
+the child gives the woman it
+the child gives the woman him
+the child gives the woman her
+the child gives the woman them
+
+the child gives the apple to her
+the child gives the apple to him
+the child gives the apple to it
+the child gives the apple to them
+
+the child gives her the apple
+the child gives him the apple
+the child gives it the apple 
+the child gives them the apple
+
+the apple that the child gives to the women
+the apple that the child gives her
+the apple that it gives to the women
+the apple that it gives her
+the apple that it gives him
+the apple that it gives it
+the apple that it gives them
+
+the woman that the child gives the apple
+the woman that the child gives him
+the woman that the child gives her
+the woman that the child gives it
+the woman that the child gives them
+
+the woman that the child gives the apple to
+the woman that the child gives him to
+the woman that the child gives her to
+the woman that the child gives it to 
+the woman that the child gives them to 
+
+who gives the woman the apple
+who gives the woman it
+who gives it to the woman
+who gives her the apple
+who gives her it
+
+-- v3 = mkV3 v noPrep toPrep: send sth(dir=c2) to sb(indir=c3)
+the child sends the apple to the woman
+the child sends it to the woman
+the child sends him to the woman
+the child sends her to the woman
+the child sends them to the woman
+
+the child sends the apple to her
+the child sends the apple to him
+the child sends the apple to it
+the child sends the apple to them
+
+the child sends to her the apple
+the child sends to him the apple
+the child sends to it the apple 
+the child sends to them the apple
+
+the apple that the child sends to the women
+the apple that the child sends to her
+the apple that it sends to the women
+the apple that it sends to her
+the apple that it sends to him
+the apple that it sends to it
+the apple that it sends to them
+
+the woman that the child sends the apple to
+the woman that the child sends him to
+the woman that the child sends her to
+the woman that the child sends it to
+the woman that the child sends them to
+
+the woman who the child sends the apple to
+the woman who the child sends him to
+the woman who the child sends her to
+the woman who the child sends it to
+the woman who the child sends them to
+
+who sends to the woman the apple
+who sends to the woman it
+who sends to her the apple
+who sends to her it
+who sends the apple to the woman
+who sends it to the woman
+who sends the apple to her
+who sends it to her 

--- a/tests/german/examples.eng2ger.out
+++ b/tests/german/examples.eng2ger.out
@@ -1,131 +1,159 @@
+the child gives the woman the apple
+das Kind gibt der Frau den Apfel
+the child gives the woman the apple
+das Kind gibt der Frau den Apfel
+the child gives the woman it
+das Kind gibt der Frau das
+the child gives the woman it
+das Kind gibt es der Frau
+the child gives the woman it
+das Kind gibt der Frau das
+the child gives the woman it
+das Kind gibt es der Frau
+the child gives the woman him
+das Kind gibt ihn der Frau
+the child gives the woman him
+das Kind gibt ihn der Frau
+the child gives the woman her
+das Kind gibt sie der Frau
+the child gives the woman her
+das Kind gibt sie der Frau
+the child gives the woman them
+das Kind gibt der Frau die
+the child gives the woman them
+das Kind gibt sie der Frau
+the child gives the woman them
+das Kind gibt der Frau die
+the child gives the woman them
+das Kind gibt sie der Frau
 the child gives her the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihr den Apfel
 the child gives her the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihr den Apfel
 the child gives him the apple
-das Kind gibt ihn dem Apfel
+das Kind gibt ihm den Apfel
 the child gives him the apple
-das Kind gibt ihn dem Apfel
+das Kind gibt ihm den Apfel
 the child gives it the apple
-das Kind gibt dem Apfel das
+das Kind gibt dem den Apfel
 the child gives it the apple
-das Kind gibt es dem Apfel
+das Kind gibt ihm den Apfel
 the child gives it the apple
-das Kind gibt dem Apfel das
+das Kind gibt dem den Apfel
 the child gives it the apple
-das Kind gibt es dem Apfel
+das Kind gibt ihm den Apfel
 the child gives them the apple
-das Kind gibt dem Apfel die
+das Kind gibt denen den Apfel
 the child gives them the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihnen den Apfel
 the child gives them the apple
-das Kind gibt dem Apfel die
+das Kind gibt denen den Apfel
 the child gives them the apple
-das Kind gibt sie dem Apfel
-the apple that the child gives her
-der Apfel , dem das Kind sie gibt
+das Kind gibt ihnen den Apfel
 the apple that the child gives her
 der Apfel , den das Kind ihr gibt
-the apple that it gives her
-der Apfel , dem das sie gibt
+the apple that the child gives her
+der Apfel , dem das Kind sie gibt
 the apple that it gives her
 der Apfel , den das ihr gibt
 the apple that it gives her
-der Apfel , dem es sie gibt
+der Apfel , dem das sie gibt
 the apple that it gives her
 der Apfel , den es ihr gibt
-the apple that it gives him
-der Apfel , dem das ihn gibt
+the apple that it gives her
+der Apfel , dem es sie gibt
 the apple that it gives him
 der Apfel , den das ihm gibt
 the apple that it gives him
-der Apfel , dem es ihn gibt
+der Apfel , dem das ihn gibt
 the apple that it gives him
 der Apfel , den es ihm gibt
-the apple that it gives it
-der Apfel , dem das das gibt
-the apple that it gives it
-der Apfel , dem das es gibt
+the apple that it gives him
+der Apfel , dem es ihn gibt
 the apple that it gives it
 der Apfel , den das dem gibt
 the apple that it gives it
 der Apfel , den das ihm gibt
 the apple that it gives it
-der Apfel , dem es das gibt
+der Apfel , dem das das gibt
 the apple that it gives it
-der Apfel , dem es es gibt
+der Apfel , dem das es gibt
 the apple that it gives it
 der Apfel , den es dem gibt
 the apple that it gives it
 der Apfel , den es ihm gibt
-the apple that it gives them
-der Apfel , dem das die gibt
-the apple that it gives them
-der Apfel , dem das sie gibt
+the apple that it gives it
+der Apfel , dem es das gibt
+the apple that it gives it
+der Apfel , dem es es gibt
 the apple that it gives them
 der Apfel , den das denen gibt
 the apple that it gives them
 der Apfel , den das ihnen gibt
 the apple that it gives them
-der Apfel , dem es die gibt
+der Apfel , dem das die gibt
 the apple that it gives them
-der Apfel , dem es sie gibt
+der Apfel , dem das sie gibt
 the apple that it gives them
 der Apfel , den es denen gibt
 the apple that it gives them
 der Apfel , den es ihnen gibt
-the woman that the child gives the apple
-die Frau , der das Kind den Apfel gibt
+the apple that it gives them
+der Apfel , dem es die gibt
+the apple that it gives them
+der Apfel , dem es sie gibt
 the woman that the child gives the apple
 die Frau , die das Kind dem Apfel gibt
-the woman that the child gives him
-die Frau , der das Kind ihn gibt
+the woman that the child gives the apple
+die Frau , der das Kind den Apfel gibt
 the woman that the child gives him
 die Frau , die das Kind ihm gibt
-the woman that the child gives her
-die Frau , der das Kind sie gibt
+the woman that the child gives him
+die Frau , der das Kind ihn gibt
 the woman that the child gives her
 die Frau , die das Kind ihr gibt
-the woman that the child gives it
-die Frau , der das Kind das gibt
-the woman that the child gives it
-die Frau , der das Kind es gibt
+the woman that the child gives her
+die Frau , der das Kind sie gibt
 the woman that the child gives it
 die Frau , die das Kind dem gibt
 the woman that the child gives it
 die Frau , die das Kind ihm gibt
-the woman that the child gives them
-die Frau , der das Kind die gibt
-the woman that the child gives them
-die Frau , der das Kind sie gibt
+the woman that the child gives it
+die Frau , der das Kind das gibt
+the woman that the child gives it
+die Frau , der das Kind es gibt
 the woman that the child gives them
 die Frau , die das Kind denen gibt
 the woman that the child gives them
 die Frau , die das Kind ihnen gibt
+the woman that the child gives them
+die Frau , der das Kind die gibt
+the woman that the child gives them
+die Frau , der das Kind sie gibt
 who gives the woman the apple
-wer gibt dem Apfel die Frau
+wer gibt der Frau den Apfel
 who gives the woman the apple
-wer gibt dem Apfel die Frau
+wer gibt der Frau den Apfel
 who gives the woman it
-wer gibt dem die Frau
+wer gibt der Frau das
 who gives the woman it
-wer gibt ihm die Frau
+wer gibt es der Frau
 who gives the woman it
-wer gibt dem die Frau
+wer gibt der Frau das
 who gives the woman it
-wer gibt ihm die Frau
+wer gibt es der Frau
 who gives her the apple
-wer gibt sie dem Apfel
+wer gibt ihr den Apfel
 who gives her the apple
-wer gibt sie dem Apfel
+wer gibt ihr den Apfel
 who gives her it
-wer gibt sie dem
+wer gibt ihr das
 who gives her it
-wer gibt sie ihm
+wer gibt es ihr
 who gives her it
-wer gibt sie dem
+wer gibt ihr das
 who gives her it
-wer gibt sie ihm
+wer gibt es ihr
 the child sends the apple to the woman
 das Kind schickt der Frau den Apfel
 the child sends the apple to the woman

--- a/tests/german/examples.neg.out
+++ b/tests/german/examples.neg.out
@@ -37,16 +37,16 @@ TestLangEng: I send it to not her
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (PredetNP not_Predet (UsePron she_Pron))) (UsePron it_Pron))))) NoVoc
 TestLangGer: ich schicke es nicht ihr
 TestLangEng: I send it to not her
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't it give child he
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't the child give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't it give child he
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't the child give him
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetNP (DetQuant IndefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN beer_N) (UsePron he_Pron))))))) NoVoc

--- a/tests/german/examples.pos.out
+++ b/tests/german/examples.pos.out
@@ -379,142 +379,142 @@ TestLangEng: I don't send the book to her
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron she_Pron))))) NoVoc
 TestLangGer: ich schicke ihr das Buch nicht
 TestLangEng: I don't send the book to her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple that it gives child the woman
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple that the child gives the woman
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple , that it gives child the woman
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple , that the child gives the woman
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron)))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple that it gives child she
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple that the child gives her
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple , that it gives child she
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple , that the child gives her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangGer: der Apfel , den es ihr gibt
 TestLangEng: the apple that it gives her
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron))))))) NoVoc
 TestLangGer: der Apfel , den es ihr gibt
 TestLangEng: the apple , that it gives her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman that it doesn't give child the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman that the child doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman , that it doesn't give child the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman , that the child doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der es den Apfel nicht gibt
 TestLangEng: the woman that it doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der es den Apfel nicht gibt
 TestLangEng: the woman , that it doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman that it doesn't give child he
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman that the child doesn't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman , that it doesn't give child he
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman , that the child doesn't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman that they don't give children the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman that the children don't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman , that they don't give children the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman , that the children don't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman that they don't give children he
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman that the children don't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman , that they don't give children he
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman , that the children don't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der sie ihn nicht geben
 TestLangEng: the woman that they don't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der sie ihn nicht geben
 TestLangEng: the woman , that they don't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der es ihn gibt
 TestLangEng: the woman that it gives him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der es ihn gibt
 TestLangEng: the woman , that it gives him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der er ihn gibt
 TestLangEng: the woman that he gives him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der er ihn gibt
 TestLangEng: the woman , that he gives him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't it give child the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't the child give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't it give child the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't the child give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt es den Apfel nicht
 TestLangEng: whom doesn't it give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt es den Apfel nicht
 TestLangEng: whom doesn't it give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt es ihn nicht
 TestLangEng: whom doesn't it give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt es ihn nicht
 TestLangEng: whom doesn't it give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: wem gibt es nicht den Apfel
 TestLangEng: whom does it give not the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: wem gibt es nicht den Apfel
 TestLangEng: whom does it give not the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
 TestLangGer: wen gibt es der Frau nicht
 TestLangEng: whom doesn't it give the woman
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
 TestLangGer: wen gibt es der Frau nicht
 TestLangEng: whom doesn't it give the woman
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN man_N) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))))) NoVoc

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -12,9 +12,9 @@ rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=ex
 ? diff examples.eng2ger.out examples.eng2ger.new
 
 ? echo "extracting positive, negative and dubious examples from examples.txt ..."
-? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.pos.txt
-? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.neg.txt
-? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.dub.txt
+? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.pos.txt
+? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.neg.txt
+? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.dub.txt
 
 ? echo "parsing negative examples ...; storing trees in examples.neg.new ..."
 rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.new"


### PR DESCRIPTION
…in LexiconGer instead

ParadigmsGer had two constructions of verbs v:V3 with dat- and acc-object nps,

(1)      mkV3 : V -> V3 = \v -> mkV3 v accPrep datPrep ;
(2)  accdatV3 : V -> V3 = \v -> mkV3 v datPrep accPrep ;  -- (no prepositions)

In a previous patch, I had replaced (accdatV3 v) to (mkV3 v accPrep datPrep), as the
name suggested. (This actually was the meaning of accdatV3 in gf-3.2, which had only
a non-overloaded mkV3 : V -> Prep -> Prep -> V3.)

The reason for having two constructions for dat+acc-verbs in Ger seems to be *Eng*:
for English, ditransitive V3-verbs are defined by

(2')     mkV3 : V -> V3 = \v -> mkV3 v noPrep noPrep ;

like "to give sb sth", where the indirect argument comes first (c2=indir), the direct
second (c3=dir), corresponding to c2=datPrep, c3=accPrep in Ger; apparently, this was
meant by the comment (no prepositions) in (2). Other V3-verbs in Eng are defined by

(1')    mkV3 : V -> Prep -> V3 = \v,p -> mkV3 v noPrep p ;

like "to give sth to sb", so that (c2=dir), (c3=indir-with preposition),
corresponding to c2=acc,c3=dat in Ger, i.e. (1).

In order to get trees with equal meaning in Ger and Eng, the direct and indirect
arguments of corresponding verbs must match. Therefore, some V3-verbs in Ger have to
be defined using (1), others using (2), although they syntactically behave similar.

This patch therefore reinstalls (1) and (2), and changes the V3 in LexiconGer to:

  give_V3 = accdatV3 Irreg.geben_V ; -- c2=datPrep, c3=accPrep, to fit
             -- to Eng ditransitive: give sb(indir) sth(dir) (no preposition)

  sell_V3 = mkV3 (no_geV (regV "verkaufen")) ;    -- Eng: mkV3 v noPrep toPrep
  send_V3 = mkV3 (regV "schicken") ; -- Ger mkV3 v = Ger: mkV3 v accPrep datPrep