### PR TITLE
Passives

### DIFF
--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -89,7 +89,7 @@ concrete CatGer of Cat =
     V, VS, VQ = ResGer.Verb ; -- = {s : VForm => Str} ;
     VV = Verb ** {isAux : Bool} ;
     V2, VA, V2A, V2S, V2Q = Verb ** {c2 : Preposition} ;
-    V2V = Verb ** {c2 : Preposition ; isAux : Bool} ;
+    V2V = Verb ** {c2 : Preposition ; isAux : Bool ; ctrl : Control} ;
     V3 = Verb ** {c2, c3 : Preposition} ;
 
     A  = {s : Degree => AForm => Str} ;

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -106,7 +106,7 @@ concrete CatGer of Cat =
     Tense = {s : Str ; t : ResGer.Tense ; m : Mood} ;
 
   linref
-    NP = \np -> np.s!(NPC Nom) ++ np.adv ++ np.ext ++ np.rc ; -- HL 6/2019
+    NP = \np -> np.s!(NPC Nom) ++ np.ext ++ np.rc ; -- HL 6/2019
     CN = \cn -> cn.s ! Strong ! Pl ! Nom ++ cn.adv ++ cn.ext ++ cn.rc ! Pl ;
 
     SSlash = \ss -> ss.s ! Main ++ ss.c2.s  ;

--- a/src/german/DictGer.gf
+++ b/src/german/DictGer.gf
@@ -16980,7 +16980,7 @@ lin
   heldin_N = mkN  "Heldin" "Heldinnen" feminine ;
   heldisch_A = mk3A "heldisch" "heldischer" "heldischste" ;
   helena_N = mkN  "Helena" "Helenas" feminine ;
-  helfen_V = irregV "helfen" "helft" "half" "hälfe" "geholfen" ; 
+  helfen_V = irregV "helfen" "hilft" "half" "hälfe" "geholfen" ; 
   helfensteiner_N = mkN  "Helfensteiner" "Helfensteiner" masculine ;
   helfer_N = mkN  "Helfer" "Helfer" masculine ;
   helferlein_N = mkN  "Helferlein" "Helferlein" neuter ;
@@ -26112,7 +26112,7 @@ lin
   nachgruebeln_V = prefixV "nach" (regV "grübeln") ;
   nachhaken_5_V = prefixV "nach" (regV "haken") ;
   nachhaltig_A = mk3A "nachhaltig" "nachhaltiger" "nachhaltigste" ;
-  nachhelfen_6_V = prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen") ; 
+  nachhelfen_6_V = prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen") ; 
   nachher_Adv = mkAdv "nachher" ;
   nachhilfe_N = mkN  "Nachhilfe" "Nachhilfen" feminine ;
   nachhut_N = mkN  "Nachhut" "Nachhuten" feminine ;

--- a/src/german/DictVerbsGer.gf
+++ b/src/german/DictVerbsGer.gf
@@ -1032,8 +1032,8 @@ lin
   aussortieren_V2 = dirV2 (prefixV "aus" (regV "sortieren"))  ;
   ausspeichern_V2 = dirV2 (prefixV "aus" (regV "speichern"))  ;
   ausspionieren_V2 = dirV2 (prefixV "aus" (regV "spionieren"))  ;
-  aussprechen_V2 = dirV2 (prefixV "aus" (irregV "sprechen" "sprecht" "sprach" "spräche" "gesprochen"))  ;
-  aussprechen_VS = mkVS (prefixV "aus" (irregV "sprechen" "sprecht" "sprach" "spräche" "gesprochen"))  ;
+  aussprechen_V2 = dirV2 (prefixV "aus" (irregV "sprechen" "spricht" "sprach" "spräche" "gesprochen"))  ;
+  aussprechen_VS = mkVS (prefixV "aus" (irregV "sprechen" "spricht" "sprach" "spräche" "gesprochen"))  ;
   ausspucken_vor_V2 = prepV2 (prefixV "aus" (regV "spucken")) (mkPrep "vor" dative) ;
   ausspucken_V = prefixV "aus" (regV "spucken") ;
   ausstatten_mit_V3 = dirV3 (prefixV "aus" (regV "statten")) mit_Prep ;
@@ -1358,8 +1358,8 @@ lin
   besorgen_dat_V3 = accdatV3 (regV "besorgen")  ;
   besorgen_V2 = dirV2 (regV "besorgen")  ;
   bespassen_V2 = dirV2 (regV "bespaßen")  ;
-  besprechen_mit_V3 = dirV3 (irregV "besprechen" "besprecht" "besprach" "bespräche" "besprochen") mit_Prep ;
-  besprechen_plV2 = pldirV2 (irregV "besprechen" "besprecht" "besprach" "bespräche" "besprochen")  ;
+  besprechen_mit_V3 = dirV3 (irregV "besprechen" "bespricht" "besprach" "bespräche" "besprochen") mit_Prep ;
+  besprechen_plV2 = pldirV2 (irregV "besprechen" "bespricht" "besprach" "bespräche" "besprochen")  ;
   bespruehen_mit_V3 = dirV3 (regV "besprühen") mit_Prep ;
   bespruehen_V2 = dirV2 (regV "besprühen")  ;
   besseren_rV = reflV (regV "besseren") accusative ;
@@ -2146,8 +2146,8 @@ lin
   entsichern_V2 = dirV2 (irregV "entsichern" "entsichert" "entsicherte" "entsicherte" "entsichert")  ;
   entsorgen_V2 = dirV2 (irregV "entsorgen" "entsorgt" "entsorgte" "entsorgte" "entsorgt")  ;
   entspannen_rV = reflV (irregV "entspannen" "entspannt" "entspannte" "entspannte" "entspannt") accusative ;
-  entsprechen_dat_V2 = mkV2 (irregV "entsprechen" "entsprecht" "entsprach" "entspräche" "entsprochen") datPrep ;
-  entsprechen_rcV = reciV (irregV "entsprechen" "entsprecht" "entsprach" "entspräche" "entsprochen") dative ;
+  entsprechen_dat_V2 = mkV2 (irregV "entsprechen" "entspricht" "entsprach" "entspräche" "entsprochen") datPrep ;
+  entsprechen_rcV = reciV (irregV "entsprechen" "entspricht" "entsprach" "entspräche" "entsprochen") dative ;
   entspringen_loc_V2 = prepV2 (irregV "entspringen" "entspringt" "entsprang" "entspränge" "entsprungen") loc_Prep ;
   entstaatlichen_V2 = dirV2 (irregV "entstaatlichen" "entstaatlicht" "entstaatlichte" "entstaatlichte" "entstaatlicht")  ;
   entstammen_gen_V2 = mkV2 (irregV "entstammen" "entstammt" "entstammte" "entstammte" "entstammt") genPrep ;
@@ -3019,8 +3019,8 @@ lin
   heissen_V3 = dirV3 (irregV "heißen" "heißt" "hieß" "hieße" "geheißen") accPrep ;
   heizen_V2 = dirV2 (regV "heizen")  ;
   heizen_V = regV "heizen" ;
+  helfen_dat_V2V = mkV2V (irregV "helfen" "hilft" "half" "hälfe" "geholfen") datPrep ;
   helfen_dat_bei_V3 = mkV3 (irregV "helfen" "hilft" "half" "hülfe" "geholfen") datPrep bei_Prep ;
---  helfen_V = irregV "helfen" "helft" "half" "hälfe" "geholfen" ;
   hellen_es_esV = esV (regV "hellen")  ;
   hellenisieren_V2 = dirV2 (regV "hellenisieren")  ;
   hemmen_sV2 = dassV2 (regV "hemmen") accPrep ;
@@ -4142,8 +4142,8 @@ lin
   nachgruebeln_ueber_V2 = prepV2 (prefixV "nach" (regV "grübeln")) (mkPrep "über" dative) ;
   nachhaken_bei_V2 = prepV2 (prefixV "nach" (regV "haken")) bei_Prep ;
   nachhaken_V = prefixV "nach" (regV "haken") ;
-  nachhelfen_dat_V2 = mkV2 (prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen")) datPrep ;
-  nachhelfen_dat_V2V = mkV2V (prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen")) datPrep ;
+  nachhelfen_dat_V2 = mkV2 (prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen")) datPrep ;
+  nachhelfen_dat_V2V = mkV2V (prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen")) datPrep ;
   nachkarten_V = prefixV "nach" (regV "karten") ;
   nachlassen_dat_V3 = accdatV3 (prefixV "nach" (irregV "lassen" "lasst" "ließ" "ließe" "gelassen"))  ;
   nachlassen_im_V2 = prepV2 (prefixV "nach" (irregV "lassen" "lasst" "ließ" "ließe" "gelassen")) (mkPrep "in" dative) ;
@@ -6492,7 +6492,7 @@ lin
   verspielen_rV = reflV (irregV "verspielen" "verspielt" "verspielte" "verspielte" "verspielt") accusative ;
   verspielen_V2 = dirV2 (irregV "verspielen" "verspielt" "verspielte" "verspielte" "verspielt")  ;
   verspotten_V2 = dirV2 (irregV "verspotten" "verspottet" "verspottete" "verspotte" "verspottet")  ;
-  versprechen_dat_V2V = mkV2V (irregV "versprechen" "versprecht" "versprach" "verspräche" "versprochen") datPrep ;
+  versprechen_dat_V2V = mkV2V (irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") datPrep ;
   versprengen_V2 = dirV2 (irregV "versprengen" "versprengt" "versprengte" "versprengte" "versprengt")  ;
   verspueren_V2 = dirV2 (irregV "verspüren" "verspürt" "verspürte" "verspürte" "verspürt")  ;
   verstaatlichen_V2 = dirV2 (irregV "verstaatlichen" "verstaatlicht" "verstaatlichte" "verstaatlichte" "verstaatlicht")  ;

--- a/src/german/DictVerbsGerAbs.gf
+++ b/src/german/DictVerbsGerAbs.gf
@@ -2882,6 +2882,7 @@ fun
   heissen_V3 : V3 ;
   heizen_V2 : V2 ;
   heizen_V : V ;
+  helfen_dat_V2V : V2V ;
   helfen_dat_bei_V3 : V3 ;
   hellen_es_esV : V ;
   hellenisieren_V2 : V2 ;

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -141,17 +141,27 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          inf   = vp.inf ++ verb.inf ;
+          inf   = vp.inf ++ verb.inf ++ verb.inf2 ;
           extra = vp.ext ;
-          inffin : Str = 
-            case <a,vp.isAux> of {                       
-	           <Anter,True> => verb.fin ++ inf ; -- double inf   --# notpresent
-             _            => inf ++ verb.fin              --- or just auxiliary vp
-            }                                            
+          infE : Str =                              -- HL 30/6/2019
+            case <t,a,vp.isAux> of {
+              <Fut|Cond,Simul,True> => inf ;                           --# notpresent
+              <Fut|Cond,Anter,True> -- Duden 318: kommen wollen haben => haben kommen wollen --# notpresent
+                => verb.inf2 ++ vp.inf ++ verb.inf ;                   --# notpresent
+              <_,Anter,True> => inf ;                                  --# notpresent
+              _ => verb.inf ++ verb.inf2 ++ vp.inf } ;
+          inffin : Str =
+            case <t,a,vp.isAux> of {
+	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
+                     => verb.fin ++ verb.inf2 ++ vp.inf ++ verb.inf ;  --# notpresent
+	           <_,Anter,True>                                      --# notpresent
+                     => verb.fin ++ inf ;            -- double inf     --# notpresent
+                   _ => inf ++ verb.fin              --- or just auxiliary vp
+            } ;
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ inf ++ extra ;
-	    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ inf ++ extra ;
+	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ infE ++ extra ;
+	    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ infE ++ extra ;
 	    Sub  => subj ++ compl ++ vp.infExt ++ inffin ++ extra
           }
     } ;

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -13,7 +13,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     ConjVPI = conjunctDistrTable Bool ;
 
     ComplVPIVV v vpi = 
-        insertInf (vpi.s ! v.isAux) (
+--        insertInf (vpi.s ! v.isAux) (
+      insertInf {s=(vpi.s ! v.isAux);isAux=v.isAux;ctrl=SubjC} ( -- HL ??
             predVGen v.isAux v) ; ----
 {-
       insertExtrapos vpi.p3 (
@@ -42,15 +43,19 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     DetNPMasc det = {
       s = \\c => det.sp ! Masc ! c ; ---- genders
       a = agrP3 det.n ;
-      isPron = False ;
-      ext, adv, rc = []
+      -- isPron = False ;
+      -- isLight = True ; 
+      w = WLight ;
+      ext, rc = []
       } ;
 
     DetNPFem det = {
       s = \\c => det.sp ! Fem ! c ; ---- genders
       a = agrP3 det.n ;
-      isPron = False ;
-      ext, adv, rc = []
+      -- isPron = False ;
+      -- isLight = True ; 
+      w = WLight ;
+      ext, rc = []
       } ;
 
     EmptyRelSlash slash = {
@@ -133,7 +138,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           m = tm.m ;
           subj  = [] ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
-          neg   = tm.s ++ p.s ++ vp.a1 ! b ;
+          neg   = tm.s ++ p.s ++ vp.a1 ++ negation ! b ; -- HL 8/19 ++ vp.a1 ! b ;
           -- obj1  = (vp.nn ! agr).p1 ;
           -- obj   = (vp.nn ! agr).p2 ; 
           -- compl = obj1 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
@@ -248,9 +253,12 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
 	esSubj : NP = lin NP {
 		s = \\_ => "es" ; 
-		rc, ext, adv = [] ;
+		rc, ext = [] ;
 		a = Ag Neutr Sg P3 ;
-		isPron = True} ;
+                -- isLight = True ; 
+		-- isPron = True
+                w = WPron
+          } ;
 
 	DisToCl : Str -> Agr -> FClause -> Clause = \subj,agr,vp ->  
 	  let vps = useVP vp in {
@@ -261,7 +269,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
             _ => False
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
-          neg   = vp.a1 ! b ;
+          neg   = vp.a1 ++ negation ! b ; -- HL 8/19 vp.a1 ! b ;
           obj1  = (vp.nn ! agr).p1 ;
           obj2  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ;
           compl = obj1 ++ neg  ++ vp.adj ++ obj2 ++ vp.a2 ; -- adj added

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -208,7 +208,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
   lin
 	EsVV vv vp = predV vv ** {
-		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1 , n.p2 , n.p3, n.p4> ;
+		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1, n.p2, n.p3, n.p4, n.p5, n.p6> ;
 		inf = vp.s.s ! (VInf True) ++ vp.inf ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
 		a1 = vp.a1 ;
 		a2 = vp.a2 ;
@@ -217,7 +217,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 		adj = vp.adj } ;
 		
 	EsV2A v2a ap s = predV v2a ** {
-		nn = \\_ => <"es",[],[],[]> ; 
+		nn = \\_ => <"es",[],[],[],[],[]> ; 
 		adj = ap.s ! APred ; 
 		ext = "," ++ "dass" ++ s.s ! Sub} ;
 

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -78,7 +78,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       in insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommenPass) ** { subjc = PrepNom ; c2 = v.c2 } ;      
 
     PastPartAP vp = {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf ++ 
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf.s ++ 
                   vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
@@ -89,7 +89,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     let agent = appPrepNP P.von_Prep np
     in {
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ agent ++ 
-                   vp.inf ++ 
+                   vp.inf.s ++ 
                    vp.c2.s ++ --- junk if not TV
                    vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
@@ -141,19 +141,19 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          inf   = vp.inf ++ verb.inf ++ verb.inf2 ;
+          inf   = vp.inf.s ++ verb.inf ++ verb.inf2 ;
           extra = vp.ext ;
           infE : Str =                              -- HL 30/6/2019
             case <t,a,vp.isAux> of {
               <Fut|Cond,Simul,True> => inf ;                           --# notpresent
               <Fut|Cond,Anter,True> -- Duden 318: kommen wollen haben => haben kommen wollen --# notpresent
-                => verb.inf2 ++ vp.inf ++ verb.inf ;                   --# notpresent
+                => verb.inf2 ++ vp.inf.s ++ verb.inf ;                   --# notpresent
               <_,Anter,True> => inf ;                                  --# notpresent
-              _ => verb.inf ++ verb.inf2 ++ vp.inf } ;
+              _ => verb.inf ++ verb.inf2 ++ vp.inf.s } ;
           inffin : Str =
             case <t,a,vp.isAux> of {
 	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => verb.fin ++ verb.inf2 ++ vp.inf ++ verb.inf ;  --# notpresent
+                     => verb.fin ++ verb.inf2 ++ vp.inf.s ++ verb.inf ;  --# notpresent
 	           <_,Anter,True>                                      --# notpresent
                      => verb.fin ++ inf ;            -- double inf     --# notpresent
                    _ => inf ++ verb.fin              --- or just auxiliary vp
@@ -209,7 +209,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
   lin
 	EsVV vv vp = predV vv ** {
 		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1, n.p2, n.p3, n.p4, n.p5, n.p6> ;
-		inf = vp.s.s ! (VInf True) ++ vp.inf ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
+		inf = vp.inf ** {s = vp.s.s ! (VInf True) ++ vp.inf.s} ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
 		a1 = vp.a1 ;
 		a2 = vp.a2 ;
 		ext = vp.ext ;
@@ -232,7 +232,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
   		let vp = predV werdenPass ;
 		in vp ** {
 			subj = esSubj ; 
-			inf = v.s ! VPastPart APred } ; -- construct the formal clause
+			inf = vp.inf ** {s = v.s ! VPastPart APred } } ; -- construct the formal clause
 
 	AdvFor adv fcl = fcl ** {a2 = adv.s} ;
 	
@@ -265,7 +265,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           obj1  = (vp.nn ! agr).p1 ;
           obj2  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ;
           compl = obj1 ++ neg  ++ vp.adj ++ obj2 ++ vp.a2 ; -- adj added
-          inf   = vp.inf ++ verb.inf ; -- not used for linearisation of Main/Inv
+          inf   = vp.inf.s ++ verb.inf ; -- not used for linearisation of Main/Inv
           extra = vp.ext ;
           inffin : Str = 
             case <a,vp.isAux> of {                       
@@ -274,8 +274,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
             }                                            
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
-	    Inv  => verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
+	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
+	    Inv  => verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
 	    Sub  => compl ++ vp.infExt ++ inffin ++ extra }
     		} ; 
 		

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -63,7 +63,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     PassVPSlash vp = 
 		let c = case <vp.c2.c,vp.c2.isPrep> of {
                <NPC Acc,False> => NPC Nom ;
-                                    _ => vp.c2.c}
+               _ => vp.c2.c}
 			in insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
 				{subjc = vp.c2 ** {c= c}} ;
 		-- regulates passivised object: accusative objects -> nom; all others: same case
@@ -72,6 +72,10 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
     PassAgentVPSlash vp np = ---- "von" here, "durch" in StructuralGer
       insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
+
+    Pass3V3 v = -- HL 7/19
+      let bekommenPass : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") 
+      in insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommenPass) ** { subjc = PrepNom ; c2 = v.c2 } ;      
 
     PastPartAP vp = {
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf ++ 

--- a/src/german/ExtraGerAbs.gf
+++ b/src/german/ExtraGerAbs.gf
@@ -26,4 +26,5 @@ abstract ExtraGerAbs = Extra [
   	AdvFor : Adv -> FClause -> FClause ; -- es wird heute gelacht - addition of adverbs
   	FtoCl : FClause -> Cl ;  -- embedding FClause within the RGL, to allow generation of S, Utt, etc.
 
+     Pass3V3 : V3 -> VPSlash ; -- wir bekommen den Beweis erklärt
 }

--- a/src/german/LexiconGer.gf
+++ b/src/german/LexiconGer.gf
@@ -169,8 +169,8 @@ lin
   sea_N = reg2N "Meer" "Meere" neuter ;
   seek_V2 = dirV2 (regV "suchen") ;
   see_V2 = dirV2 Irreg.sehen_V ;
-  sell_V3 = accdatV3 (no_geV (regV "verkaufen")) ;
-  send_V3 = accdatV3 (regV "schicken") ;
+  sell_V3 = mkV3 (no_geV (regV "verkaufen")) ;    -- Eng: mkV3 v noPrep toPrep
+  send_V3 = mkV3 (regV "schicken") ; -- Ger mkV3 v = Ger: mkV3 v accPrep datPrep
   sheep_N = reg2N "Schaf" "Schafe" neuter ;
   ship_N = reg2N "Schiff" "Schiffe" neuter ;
   shirt_N = reg2N "Hemd" "Hemden" neuter ; ---- infl
@@ -316,7 +316,8 @@ lin
   flow_V = seinV (Irreg.fließen_V) ; 
   fly_V = seinV (Irreg.fliegen_V) ; 
   freeze_V = Irreg.frieren_V ; 
-  give_V3 = accdatV3 Irreg.geben_V ; 
+  give_V3 = accdatV3 Irreg.geben_V ; -- c2=datPrep, c3=accPrep, to fit
+             -- to Eng ditransitive: give sb(indir) sth(dir) (no preposition)
   laugh_V = regV "lachen" ;
   lie_V = Irreg.lügen_V ; 
   play_V = regV "spielen" ;

--- a/src/german/MorphoGer.gf
+++ b/src/german/MorphoGer.gf
@@ -20,7 +20,7 @@ oper
   mkPrep : Str -> PCase -> Preposition = \s,c -> 
     {s = s ; s2 = [] ; c = c ; isPrep = True} ;
 
-  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; --isLight,
+  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; isLight,
                                           isPron : Bool ; ext,rc : Str} = \name -> heavyNP {
       s = \\c => usePrepC c (\k -> name.s ! k) ;
       a = agrP3 Sg 

--- a/src/german/MorphoGer.gf
+++ b/src/german/MorphoGer.gf
@@ -20,8 +20,10 @@ oper
   mkPrep : Str -> PCase -> Preposition = \s,c -> 
     {s = s ; s2 = [] ; c = c ; isPrep = True} ;
 
-  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; isLight,
-                                          isPron : Bool ; ext,rc : Str} = \name -> heavyNP {
+  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; 
+                                          -- isLight, isPron : Bool ; 
+                                          w : Weight ;
+                                          ext,rc : Str} = \name -> heavyNP {
       s = \\c => usePrepC c (\k -> name.s ! k) ;
       a = agrP3 Sg 
       } ;

--- a/src/german/MorphoGer.gf
+++ b/src/german/MorphoGer.gf
@@ -20,10 +20,10 @@ oper
   mkPrep : Str -> PCase -> Preposition = \s,c -> 
     {s = s ; s2 = [] ; c = c ; isPrep = True} ;
 
-  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; isPron : Bool ; ext,adv,rc : Str} = \name -> heavyNP {
+  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; --isLight,
+                                          isPron : Bool ; ext,rc : Str} = \name -> heavyNP {
       s = \\c => usePrepC c (\k -> name.s ! k) ;
-      a = agrP3 Sg ;
-	  ext, adv, rc = [] -- added
+      a = agrP3 Sg 
       } ;
 
   detLikeAdj : Bool -> Number -> Str -> 

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -9,7 +9,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       s = \\c => det.s ! cn.g ! c ++ 
                  (let k = (prepC c).c in cn.s ! adjfCase det.a k ! det.n ! k ++ cn.adv) ;
       a = agrgP3 cn.g det.n ;  
---      isLight = det.isDef ;  -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
+      isLight = det.isDef ;  -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
       isPron = False ;       -- HL 6/2019 (but:) sehe (die|einige) Männer nicht
       rc = cn.rc ! det.n ;   --                  don't see a|no man = sehe keinen Mann
       ext = cn.ext 
@@ -18,7 +18,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     DetNP det = {
       s = \\c => det.sp ! Neutr ! c ; -- more genders in ExtraGer -- HL: der+er,den+en ; der drei,den drei+en
       a = agrP3 det.n ;
---      isLight = det.isDef ;   
+      isLight = det.isDef ;
       isPron = False ; -- HL 6/2019: don't apply pronoun switch: ich gebe ihr das  vs. ich gebe es ihr
       rc, ext = []
       } ;
@@ -26,7 +26,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     UsePN pn = {
       s = \\c => usePrepC c (\k -> pn.s ! k) ;
       a = agrgP3 pn.g Sg ;
---      isLight = True ;  -- means: this is not a heavy NP, but comes before negation
+      isLight = True ;  -- means: this is not a heavy NP, but comes before negation
       isPron = False ;  -- HL 6/2019: to regulate Pron/NonPronNP order 
       rc, ext = []
       } ;
@@ -34,7 +34,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     UsePron pron = {
       s = \\c => usePrepC c (\k -> pron.s ! NPCase k) ;
       a = pron.a ;
---      isLight = True ;
+      isLight = True ;
       isPron = True ;
       rc, ext = []
       } ;
@@ -45,26 +45,27 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
           let c = case pred.c.k of {NoCase => c0 ; PredCase k => k} in
           pred.s ! numberAgr ag ! genderAgr np.a ! c0 ++ pred.c.p ++ np.s ! c ; 
         a = ag ;
---        isLight = False ;
+        isLight = False ;
         isPron = False
         } ;
 
     PPartNP np v2 = np ** {
       s = \\c => np.s ! c ++ embedInCommas (v2.s ! VPastPart APred) ; --- invar part
-      isPron = False 
+      isPron = False
       } ;
-	{- "eine erfolgreiche Frau, geliebt von vielen,"  "der Mond, gerade aufgegangen,"
-	 but only with v2 not possible in German? -}
+	{- "eine erfolgreiche Frau, geliebt von vielen,"  but only with v2 not possible in German?
+            HL: PPartNP np vps|vp: "der Autor, heute vergessen" , "der Mond, gerade aufgegangen,"
+         -}
 	
     AdvNP np adv = np ** {
       s = \\c => np.s ! c ++ adv.s ;
---      isLight = False ;
+      isLight = False ;
       isPron = False
       } ;
 
     ExtAdvNP np adv = np ** {
       s = \\c => np.s ! c ++ embedInCommas adv.s ;
---      isLight = False ;
+      isLight = False ;
       isPron = False
       } ;
 
@@ -157,10 +158,10 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     MassNP cn = {
       s = \\c => usePrepC c (\k -> cn.s ! Strong ! Sg ! k) ++ cn.adv ;
       a = agrgP3 cn.g Sg ;
---      isLight = True ;  -- ich trinke Bier nicht vs. ich trinke kein Bier
+      isLight = True ;  -- ich trinke Bier nicht vs. ich trinke kein Bier
       isPron = False ;
 	  rc = cn.rc ! Sg ;
-	  ext = cn.ext 
+	  ext = cn.ext
       } ;
 
     UseN, UseN2 = \n -> {

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -2,39 +2,41 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
 
   flags optimize=all_subs ;
 
+-- isLight makes ResGer.insertObjNP too expensive, for ComplSlash, SlashVP
+
   lin
     DetCN det cn = {
       s = \\c => det.s ! cn.g ! c ++ 
-                 (let k = (prepC c).c in cn.s ! adjfCase det.a k ! det.n ! k) ;
+                 (let k = (prepC c).c in cn.s ! adjfCase det.a k ! det.n ! k ++ cn.adv) ;
       a = agrgP3 cn.g det.n ;  
---      isPron = det.isDef ;   -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
+--      isLight = det.isDef ;  -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
       isPron = False ;       -- HL 6/2019 (but:) sehe (die|einige) Männer nicht
       rc = cn.rc ! det.n ;   --                  don't see a|no man = sehe keinen Mann
-      adv = cn.adv ;
       ext = cn.ext 
       } ;
 
     DetNP det = {
       s = \\c => det.sp ! Neutr ! c ; -- more genders in ExtraGer -- HL: der+er,den+en ; der drei,den drei+en
       a = agrP3 det.n ;
-      -- isPron = det.isDef ;   
+--      isLight = det.isDef ;   
       isPron = False ; -- HL 6/2019: don't apply pronoun switch: ich gebe ihr das  vs. ich gebe es ihr
-      rc, adv, ext = []
+      rc, ext = []
       } ;
 
     UsePN pn = {
       s = \\c => usePrepC c (\k -> pn.s ! k) ;
       a = agrgP3 pn.g Sg ;
---      isPron = True ; --- means: this is not a heavy NP, but comes before negation
+--      isLight = True ;  -- means: this is not a heavy NP, but comes before negation
       isPron = False ;  -- HL 6/2019: to regulate Pron/NonPronNP order 
- 	  rc, adv, ext = []
+      rc, ext = []
       } ;
 
     UsePron pron = {
       s = \\c => usePrepC c (\k -> pron.s ! NPCase k) ;
       a = pron.a ;
+--      isLight = True ;
       isPron = True ;
-	  rc, adv, ext = []
+      rc, ext = []
       } ;
 
     PredetNP pred np = 
@@ -43,24 +45,26 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
           let c = case pred.c.k of {NoCase => c0 ; PredCase k => k} in
           pred.s ! numberAgr ag ! genderAgr np.a ! c0 ++ pred.c.p ++ np.s ! c ; 
         a = ag ;
+--        isLight = False ;
         isPron = False
         } ;
 
     PPartNP np v2 = np ** {
-      s = \\c => np.s ! c ++ v2.s ! VPastPart APred ; --- invar part
-      isPron = False
+      s = \\c => np.s ! c ++ embedInCommas (v2.s ! VPastPart APred) ; --- invar part
+      isPron = False 
       } ;
-	{- possibly structures such as
-		"sie ist eine erfolgreiche Frau geliebt von vielen"
+	{- "eine erfolgreiche Frau, geliebt von vielen,"  "der Mond, gerade aufgegangen,"
 	 but only with v2 not possible in German? -}
 	
     AdvNP np adv = np ** {
-      adv = np.adv ++ adv.s ;
+      s = \\c => np.s ! c ++ adv.s ;
+--      isLight = False ;
       isPron = False
       } ;
 
     ExtAdvNP np adv = np ** {
-      adv = np.adv ++ embedInCommas adv.s ;
+      s = \\c => np.s ! c ++ embedInCommas adv.s ;
+--      isLight = False ;
       isPron = False
       } ;
 
@@ -151,11 +155,11 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       } ;
 
     MassNP cn = {
-      s = \\c => usePrepC c (\k -> cn.s ! Strong ! Sg ! k) ;
+      s = \\c => usePrepC c (\k -> cn.s ! Strong ! Sg ! k) ++ cn.adv ;
       a = agrgP3 cn.g Sg ;
+--      isLight = True ;  -- ich trinke Bier nicht vs. ich trinke kein Bier
       isPron = False ;
 	  rc = cn.rc ! Sg ;
-	  adv = cn.adv ;
 	  ext = cn.ext 
       } ;
 
@@ -182,8 +186,6 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
        } ;
       g = f.g ; 
       c2 = f.c3 ;
-	  rc = \\_ => [] ;
-	  ext,adv = [] 
       } ;
 
     Use2N3 f = f ;

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -286,11 +286,11 @@ mkV2 : overload {
 -- Three-place (ditransitive) verbs need two prepositions, of which
 -- the first one or both can be absent.
 
-  accdatV3 : V -> V3 ;                  -- geben + dat + acc (no prepositions)
+  accdatV3 : V -> V3 ;                  -- geben + dat(c2) + acc(c3) (Eng: no prepositions)
   dirV3    : V -> Prep -> V3 ;          -- senden + acc + nach (preposition on second arg)
 
   mkV3 : overload {
-    mkV3     : V ->                 V3 ;  -- geben + dat + acc
+    mkV3     : V ->                 V3 ;  -- geben + dat(c3) + acc(c2) (Eng: give sth to-sb)
     mkV3     : V -> Prep -> Prep -> V3 ;  -- sprechen + mit + über
     } ;
 
@@ -588,9 +588,8 @@ mkV2 : overload {
     } ;
 
   dirV3 v p = mkV3 v accPrep p ;        -- accPrep sets isPrep=False
---  accdatV3 v = mkV3 v datPrep accPrep ; 
-  accdatV3 v = dirV3 v datPrep ;        -- to fit to Eng: direct obj = c2, HL 6/2019
-
+  accdatV3 v = mkV3 v datPrep accPrep ; -- to fit to Eng ditransitives (no preposition): 
+                                        -- give sb(indir) sth(dir) = geben jmdm(dat) etwas(acc)
   mkVS v = v ** {lock_VS = <>} ;
   mkVQ v = v ** {lock_VQ = <>} ;
   mkVV v = v ** {isAux = False ; lock_VV = <>} ;

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -302,7 +302,7 @@ mkV2 : overload {
   mkV0  : V -> V0 ; --%
   mkVS  : V -> VS ;
 
-  mkV2V : overload { -- with zu
+  mkV2V : overload { -- with zu; object-control
     mkV2V : V -> V2V ;
     mkV2V : V -> Prep -> V2V ;
     } ;
@@ -310,6 +310,7 @@ mkV2 : overload {
     auxV2V : V -> V2V ;
     auxV2V : V -> Prep -> V2V ;
     } ;
+  subjV2V : V2V -> V2V ; -- force subject-control
   mkV2A : overload {
     mkV2A : V -> V2A ; 
     mkV2A : V -> Prep -> V2A ;
@@ -602,18 +603,20 @@ mkV2 : overload {
 
   mkV0  v = v ** {lock_V = <>} ;
 
-  mkV2V = overload {
+  mkV2V = overload { -- default: object-control
     mkV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = False ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
     mkV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = False ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
     } ;
   auxV2V = overload {
     auxV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = True ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
     auxV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = True ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
     } ;
+  subjV2V v = v ** {ctrl = SubjC} ;
+
   mkV2A = overload {
     mkV2A : V -> V2A 
       = \v -> dirV2 v ** {isAux = False ; lock_V2A = <>} ;

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -311,6 +311,7 @@ mkV2 : overload {
     auxV2V : V -> Prep -> V2V ;
     } ;
   subjV2V : V2V -> V2V ; -- force subject-control
+
   mkV2A : overload {
     mkV2A : V -> V2A ; 
     mkV2A : V -> Prep -> V2A ;
@@ -597,7 +598,6 @@ mkV2 : overload {
   auxVV v = v ** {isAux = True ; lock_VV = <>} ;
 
   V0 : Type = V ;
---  V2S, V2V, V2Q : Type = V2 ;
   AS, A2S, AV : Type = A ;
   A2V : Type = A2 ;
 

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -74,13 +74,23 @@ resource ResGer = ParamX ** open Prelude in {
 
 -- Predeterminers sometimes require a case ("ausser mir"), sometimes not ("nur ich").
 -- A number is sometimes inherited ("alle Menschen"), 
--- sometimes forced ("jeder von Mwnschen").
+-- sometimes forced ("jeder von den Menschen").
 
   param 
     PredetCase = NoCase | PredCase PCase ;
     PredetAgr = PAg Number | PAgNone ;
   oper
     noCase : {p : Str ; k : PredetCase} = {p = [] ; k = NoCase} ;
+
+-- Pronominal nps are ordered differently, and light nps come before negation in clauses.
+-- (To save space, reduce isPron * isLight = 4 values to the following three.) HL 9/19
+  param
+    Weight = WPron | WLight | WHeavy ;  
+  oper
+    isPron : {w : Weight} -> Bool = \np -> 
+      case np.w of {WPron => True ; _ => False} ;
+    isLight : {w : Weight} -> Bool = \np -> 
+      case np.w of {WHeavy => False ; _ => True} ;
 
 --2 For $Adjective$
 
@@ -114,6 +124,10 @@ resource ResGer = ParamX ** open Prelude in {
 
   param VType = VAct | VRefl Case ;
 
+-- Implicit subject of embedded vp equals subject resp. object of matrix verb v:V2V:
+
+  param Control = SubjC | ObjC | NoC ; -- NoC : verb without infinite vp-complement
+
 -- The order of a sentence depends on whether it is used as a main
 -- clause, inverted, or subordinate.
 
@@ -124,10 +138,6 @@ resource ResGer = ParamX ** open Prelude in {
 -- Not relevant for $Fut$. ---
 
     Mood = MIndic | MConjunct ;
-
--- Implicit subject of embedded vp equals subject resp. object of matrix verb v:V2V:
-
-    Control = SubjC | ObjC | NoC ; 
 
 --2 For $Relative$
  
@@ -243,12 +253,13 @@ resource ResGer = ParamX ** open Prelude in {
 
   NP : Type = {
      s : PCase => Str ;
-     rc : Str ; -- die Frage , [rc die ich gestellt habe]
+     rc : Str ;  -- die Frage , [rc die ich gestellt habe]
      ext : Str ; -- die Frage , [sc wo sie schläft] ; die Regel , [vp kein Fleisch zu essen] | [s dass ...]
-     --	 adv : Str ; -- die Frage [a von Max]  -- HL: cannot be extracted, so no need for separate field
+     --	 adv : Str ; -- die Frage [a von Max]  -- HL: cannot be extracted
      a : Agr ;
-     isLight : Bool ;  -- light NPs come before negation in simple clauses (expensive)
-     isPron : Bool } ; -- to put accPron before datPron
+     -- isLight : Bool ;  -- light NPs come before negation in simple clauses (expensive)
+     -- isPron : Bool } ; -- needed to put accPron before datPron
+     w : Weight } ;
 
   mkN  : (x1,_,_,_,_,x6,x7 : Str) -> Gender -> Noun = 
     \Mann, Mannen, Manne, Mannes, Maenner, Maennern, Mann_, g -> {
@@ -403,9 +414,9 @@ resource ResGer = ParamX ** open Prelude in {
 
 -- Prepositions for complements indicate the complement case.
 
-  Preposition : Type = {s : Str ; s2 : Str ; c : PCase ; isPrep : Bool} ; -- s2 is postposition
+  Preposition : Type = {s : Str ; s2 : Str ; c : PCase ; isPrep : Bool} ;
 
-  -- HL 7/19: There are very few circumpositions: um (Gen) Willen, von (Adv) an|ab|aus
+  -- HL 7/19: German has very few circumpositions: um (Gen) Willen, von (Adv) an|ab|aus
   -- ? bis (Adv) hin|her. So maybe we should skip s2 (and save readings with empty preps).
 
 -- To apply a preposition to a complement.
@@ -417,10 +428,9 @@ resource ResGer = ParamX ** open Prelude in {
     	prep.s ++ np.s ! prep.c ++ bigNP np ++ prep.s2 ;
 	-- revised appPrep for discontinuous NPs
 
-  	bigNP : NP -> Str = \np -> --np.adv ++ 
-          np.ext ++ np.rc ;
+  bigNP : NP -> Str = \np -> np.ext ++ np.rc ;
 
--- To build a preposition from just a case.
+-- To build a preposition from just a case.  -- HL 9/19: no longer used in RGL
 
   noPreposition : Case -> Preposition = \c -> 
     {s,s2 = [] ; c = NPC c ; isPrep = False} ;
@@ -518,22 +528,20 @@ resource ResGer = ParamX ** open Prelude in {
    VP : Type = {
       s  : Verb ;                         -- HL 6/2019: <refl|pron,NP,PP,AP|CN|Adv,ObjInf,EmbedInfs>
       nn : Agr => Str * Str * Str * Str   --            <sich|ihr,deine Frau,an sie,gut,
-                      * Str * Str ;       -- splitInfExt (versprechen:) jmdm, sich zu bemühen ++ , an sich zu glauben> 
-      a1 : Str ;              -- adv before negation
---      a1 : Polarity => Str ;  -- nicht = adV
+                      * Str * Str ;       -- splitInfExt: (rate) dir, dich zu bemühen mir zu helfen> 
+      a1 : Str ;              -- adv before negation, adV
       a2 : Str ;              -- heute = adv
-      adj : Str ;             -- space for adjectival complements ("ich finde dich schön")
+      adj : Str ;             -- adjectival complement ("ich finde dich schön")
       isAux : Bool ;          -- is a double infinitive
-      inf : {s:Str ; isAux:Bool ; ctrl:Control} ;  -- infinitival complement of wollen,versuchen:VV | bitten,versprechen:V2V
+      inf : {s:Str ; isAux:Bool ; ctrl:Control} ; -- infinitival complement of VV or V2V
       ext : Str ;             -- dass sie kommt
-      infExt : Str ;		  -- infinitival complements of inf e.g. ich hoffe [ihr zu helfen] zu versuchen 
-	  subjc : Preposition     -- determines case of "subj"
-	} ;
+      infExt : Str ;	      -- infinitival complements of inf 
+                              -- e.g. ich hoffe [ihr zu helfen] zu versuchen 
+      subjc : Preposition     -- case of subject
+     } ;
 
-  predV : Verb -> VPSlash = predVGen False ;
-
-  predVc : Verb ** {c2 : Preposition} -> VPSlash = \v ->
-    predV v ** {c2 = v.c2} ;
+  VPSlash = VP ** {c2 : Preposition ; 
+                   objCtrl : Bool } ; -- True = embedded reflexives agree with object 
 
   useVP : VP -> VPC = \vp ->
     let
@@ -588,6 +596,11 @@ resource ResGer = ParamX ** open Prelude in {
       }
     } ;
 
+  predV : Verb -> VPSlash = predVGen False ;
+
+  predVc : Verb ** {c2 : Preposition} -> VPSlash = \v -> 
+    predV v ** {c2 = v.c2 ; objCtrl = False} ;
+
   predVGen : Bool -> Verb -> VPSlash = \isAux, verb -> {
     s = {
      s = verb.s ;
@@ -596,19 +609,18 @@ resource ResGer = ParamX ** open Prelude in {
      aux = verb.aux ;
      vtype = verb.vtype
      } ;
---    a1  : Polarity => Str = negation ;
     a1,a2  : Str = [] ;
     nn  : Agr => Str * Str * Str * Str * Str * Str = case verb.vtype of {
       VAct => \\_ => <[],[],[],[],[],[]> ;
       VRefl c => \\a => <reflPron ! a ! c,[],[],[],[],[]>
       } ;
     isAux = isAux ; ----
-    inf = {s=[]; isAux=True; ctrl=NoC} ; -- default infinitive complement (isAux=True => no endcomma)
-    ext,infExt,adj : Str = [] ;
+    inf = {s=[]; isAux=True; ctrl=NoC} ; -- default infinitive complement 
+    ext,infExt,adj : Str = [] ;          -- (isAux=True => no endcomma)
     subjc = PrepNom ;
     -- Dummy values for subtyping.
-    c2 = noPreposition Nom ;
-    ctrl = NoC -- default
+    c2 = PrepNom ; 
+    objCtrl = False 
     } ;
 
   auxPerfect : Verb -> VForm => Str = \verb ->
@@ -668,11 +680,10 @@ resource ResGer = ParamX ** open Prelude in {
       Neg => "nicht"
       } ;
 
-  VPSlash = VP ** {c2 : Preposition ; ctrl : Control } ;
-
   -- IL 24/04/2018 Fixing the scope of reflexives
   objAgr : { a : Agr } -> VP -> VP = \obj,vp -> vp ** {
-    nn = \\a => vp.nn ! obj.a } ;  -- todo HL: maybe restrict to p1-p4
+    nn = \\a => vp.nn ! obj.a } ;  
+  -- HL: if reflexive only: <vp.nn.p1 ! np.a, vp.nn.p1 ! a, ..>
 
 -- Extending a verb phrase with new constituents.
 
@@ -681,7 +692,7 @@ resource ResGer = ParamX ** open Prelude in {
               in  <vpnn.p1, vpnn.p2, vpnn.p3, obj ! a ++ vpnn.p4, vpnn.p5, vpnn.p6> } ;
 
   insertObjc : (Agr => Str) -> VPSlash -> VPSlash = \obj,vp ->
-    insertObj obj vp ** {c2 = vp.c2 ; ctrl = vp.ctrl } ;
+    insertObj obj vp ** {c2 = vp.c2 ; objCtrl = vp.objCtrl } ;
 
   insertObjNP : NP -> Preposition -> VPSlash -> VPSlash = \np,prep,vp ->
     let c = case prep.c of { NPC cc => cc ; _ => Nom } ;
@@ -692,41 +703,36 @@ resource ResGer = ParamX ** open Prelude in {
 {- less expensive if isLight is removed from NPs:
        case <np.isPron,prep.isPrep,c> of {
           -- (assuming v.c2=acc) nonPron: dat < acc|gen  (acc < gen not enforced)
-          <True, False,Acc> => 
-            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <es|ihn sich,  np, pp, comp, _,_>
-          <True, False,_  > => 
-            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <sich ihm,     np, pp, comp>
-          <False,False,Dat> => 
-            <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <prons, dat ++ np, pp, comp>
-          <False,False,_  > => 
-            <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <prons, np ++ gen|acc, pp, comp>
-          <_,    True,_   > => 
-            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6>   -- <prons, np, pp++pp, compl>
+          <True, False,Acc> => -- <es|ihn sich,  np, pp, comp, _,_>
+            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <True, False,_  > => -- <sich ihm,     np, pp, comp>
+            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <False,False,Dat> => -- <prons, dat ++ np, pp, comp>
+            <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <False,False,_  > => -- <prons, np ++ gen|acc, pp, comp>
+            <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
+          <_,    True,_   > => -- <prons, np, pp++pp, compl>
+            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6>
         }
 -}
 -- expensive:  -- vfin < accPron < refl < (gen|dat)Pron < lightNP < neg < heavyNP|PP < vinf|comp
-        case <prep.isPrep,np.isPron,c> of { 
-          <True, _,_> => -- all pp-objects come after negation
-            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> ;  -- <prons, light, heavy++pp, compl,_,_>
-          <False,True, Acc> => -- Pron: acc < gen|dat
-            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <ihn sich,  np, pp, comp, _,_>
-          <False,True, _  > => 
-            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; -- <sich ihm,  np, pp, comp>
-          <False,False,Dat> => -- (assuming v.c2=acc) nonPron: dat < acc|gen  (acc < gen not enforced)
-            case np.isLight of {
-              True =>  -- <prons, dat ++ np, heavy, comp>
-                <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
-              False => -- <prons, light, dat ++ np, comp>
-                <vpnn.p1, vpnn.p2, obj ! a ++ vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> } ; 
-          <False,False,_  > => 
-            case np.isLight of {
-              True => -- <prons, np ++ gen|acc, heavy, comp>
-                <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
-              False => -- <prons, light, dat ++ hnp, comp>
-                <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> } 
-        }
---}
-} ;    -- the ordering of objects of v:V3 (and v:V4) is also determined by Slash?V3 (and Slash?V4)
+        case <prep.isPrep, np.w, c> of { 
+          <True, _,_> =>       -- <prons, light, heavy++pp, compl,_,_>
+            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> ;
+          <False,WPron, Acc> => -- <ihn ++ sich, light, heavy, comp, _,_>
+            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
+          <False,WPron, _  > => -- <sich ++ ihm|seiner, light, heavy, comp>
+            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <False,WLight,Dat> => -- (assuming v.c2=acc) nonPron: dat < acc|gen  
+                                -- <prons, dat ++ np, heavy, comp>
+            <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
+          <False,WHeavy,Dat> => -- <prons, light, dat ++ np, comp>
+            <vpnn.p1, vpnn.p2, obj ! a ++ vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <False,WLight,_  > => -- <prons, np ++ gen|acc, heavy, comp>
+            <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+          <False,WHeavy,_  > => -- <prons, light, dat ++ np, comp>
+            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> } 
+    } ; -- the ordering of objects of v:V3 (and v:V4) is also determined by Slash?V3 (and Slash?V4)
 
   insertObjRefl : VPSlash -> VPSlash = \vp -> -- HL 6/2019, to order reflPron < neg < prep+reflPron
     let prep = vp.c2 ;
@@ -741,9 +747,8 @@ resource ResGer = ParamX ** open Prelude in {
           False => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> }
     } ;
 
-  insertAdV : Str -> VP -> VP = \adv,vp -> vp ** {
---    a1 = \\a => adv ++ vp.a1 ! a } ; -- immer nicht
-    a1 = adv ++ vp.a1 } ;
+  insertAdV : Str -> VP -> VP = \adv,vp -> vp ** { -- not used in RGL, so VP.a1 can be skipped
+    a1 = adv ++ vp.a1 } ;                          -- cf. AdvVP(Slash),AdVVP(Slash)
 
   insertAdv : Str -> VP -> VP = \adv,vp -> vp ** {
     a2 = vp.a2 ++ adv } ;
@@ -753,16 +758,15 @@ resource ResGer = ParamX ** open Prelude in {
 
   insertInfExt : Str -> VPSlash -> VPSlash = \infExt,vp -> vp ** {
 	infExt = vp.infExt ++ infExt } ;
-  -- to be changed to handle infExt in ComplVV and SlashVV, SlashV2V
+
+  -- HL: to handle infExt in ComplVV and SlashVV, SlashV2V
   insertInfExtraObj : (Agr => Str) -> VPSlash -> VPSlash = \objs,vp -> vp ** { 
     nn = \\a => let vpnn = vp.nn ! a in
       <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, objs ! a ++ vpnn.p5, vpnn.p6> 
     } ;
-
   insertInfExtraInf : (Agr => Str) -> VPSlash -> VPSlash = \inf,vp -> vp ** { 
     nn = \\a => let vpnn = vp.nn ! a in
       <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6 ++ inf ! a>   
-      -- embedded inf + modalInf / nonmodalInf + embedded inf ?
     } ;
 
   insertInf : {s:Str;isAux:Bool;ctrl:Control} -> VPSlash -> VPSlash = \inf,vp -> vp ** {
@@ -770,8 +774,9 @@ resource ResGer = ParamX ** open Prelude in {
 
   insertAdj : Str -> Str * Str -> Str -> VPSlash -> VPSlash = \adj,c,ext,vp -> vp ** {
     nn = \\a => 
-      let vpnn = vp.nn ! a in <vpnn.p1, vpnn.p2 ++ c.p1, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;  -- ihr? | der Frau treu
-    adj = vp.adj ++ adj ++ c.p2 ;                                             -- neugierig auf das Buch
+      let vpnn = vp.nn ! a in <vpnn.p1, vpnn.p2 ++ c.p1, -- der Frau treu
+                               vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;  
+    adj = vp.adj ++ adj ++ c.p2 ;                        -- neugierig auf das Buch
     ext = vp.ext ++ ext} ;           
 
 --------------------------------------------
@@ -792,44 +797,56 @@ resource ResGer = ParamX ** open Prelude in {
             _ => False
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
---          neg   = vp.a1 ! b ;
           neg = negation ! b ;
           obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ light nps
           obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects and heavy nps
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          -- leave inf-complement of +auxV(2)V in place, extract infzu-complement of -auxV(2)V: (ComplVV, SlashV2V)
-          infExt = case vp.inf.isAux of { True => (vp.nn! agr).p6 ; _ => [] } ;
-          extra = case vp.inf.isAux of { True => [] ; _ => (vp.nn! agr).p6 } ++ vp.ext ; -- bindComma todo: no comma if .p6 = [] 
-          infCompls = (vp.nn ! agr).p5 ++ infExt ++ vp.inf.s ; -- mich tun lassen / mir [zu tun] versprechen 
-          comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} ;
---          inf   = "{" ++ vp.inf.s ++ verb.inf ++ verb.inf2 ++ "}" ;   -- zu kommen gebeten haben , but: Duden 318
-          --            haben (zu tun) versprechen wollen <= * versprechen (gewollt|wollen) haben
-          inf2  = verb.inf2 ++ infExt ++ vp.inf.s ++ verb.inf ; 
-          infE : Str =
+          -- leave inf-complement of +auxV(2)V in place, 
+          -- extract infzu-complement of -auxV(2)V: (ComplVV, SlashV2V)
+          infExt : Str * Str = case vp.inf.isAux of 
+            { True => <(vp.nn!agr).p6,[]> ; _ => <[],(vp.nn!agr).p6> } ;
+          extra = infExt.p2 ++ vp.ext ;
+          infCompls = -- () tun | ihn (es tun) lassen | ihm [es zu tun] versprechen 
+            (vp.nn ! agr).p5 ++ infExt.p1 ++ vp.inf.s ; 
+          comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {
+            True => [] ; _ => bindComma} ;
+          inf : Str =
             case <t,a,vp.isAux> of {
-              <Fut|Cond,Anter,True>  => (vp.nn ! agr).p5 ++ inf2 ;              --# notpresent
-              <_,       Anter,True>  => infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent
-              <Fut|Cond,Simul,True>  => infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent  -- infCompls ++ wollen ++ haben
-              <Fut|Cond,Anter,False> => verb.inf ++ verb.inf2 ++ comma ++ infCompls ; --# notpresent -- gebeten haben , mich tun zu lassen
+              <Fut|Cond,Anter,True>  =>                 --# notpresent   
+                --     haben () tun wollen | 
+                -- ihn haben (es tun) lassen wollen () |
+                -- ihm haben () versprechen wollen (, es zu tun)  
+                (vp.nn ! agr).p5 ++ verb.inf2 ++ infExt.p1 ++ vp.inf.s ++ verb.inf ; --# notpresent
+              <_,       Anter,True>  =>                 --# notpresent
+                -- tun wollen [] | ihn (es tun) lassen wollen [] | 
+                -- ihm () versprechen wollen [] (, es zu tun)
+                infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent
+              <Fut|Cond,Simul,True>  =>                 --# notpresent
+                infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent
+              <Fut|Cond,Anter,False> =>                 --# notpresent
+              -- gebeten haben , es zu tun () | gebeten haben , ihn (es tun) zu lassen
+                verb.inf ++ verb.inf2 ++ comma ++ infCompls ; --# notpresent 
               _                      => verb.inf2 ++ verb.inf ++ comma ++ infCompls } ;
           inffin : Str =
             case <t,a,vp.isAux> of {
 	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => (vp.nn ! agr).p5 ++ verb.fin ++ inf2 ;                  --# notpresent
-	           <Pres|Past,Anter,True>                                       --# notpresent
-                     => (vp.nn ! agr).p5 ++ infExt ++ verb.fin ++ vp.inf.s ++ verb.inf ++ verb.inf2 ; -- double inf --# notpresent
+                     => (vp.nn ! agr).p5 ++ verb.fin                      --# notpresent
+                     ++ verb.inf2 ++ infExt.p1 ++ vp.inf.s ++ verb.inf ;  --# notpresent
+	           <Pres|Past,Anter,True>                                 --# notpresent
+                     => (vp.nn ! agr).p5 ++ infExt.p1 ++ verb.fin         --# notpresent
+                     ++ vp.inf.s ++ verb.inf ++ verb.inf2 ; -- double inf --# notpresent
                    <_, _          ,True> 
                      => infCompls ++ verb.inf ++ verb.inf2 ++ verb.fin ;  -- or just auxiliary vp
                    <_, _          ,False>
-                     => verb.inf ++ verb.inf2 ++ verb.fin ++ bindComma ++ infCompls 
+                     => verb.inf ++ verb.inf2 ++ verb.fin ++ comma ++ infCompls
             } ;
         in
         case o of { 
-	    Main => subj ++ verb.fin ++ compl ++ infE ++ extra ;
-	    Inv  => verb.fin ++ subj ++ compl ++ infE ++ extra ;
-	    Sub  =>             subj ++ compl ++ inffin ++ extra
-          }
+	  Main => subj ++ verb.fin ++ compl ++ inf ++ extra ;
+	  Inv  => verb.fin ++ subj ++ compl ++ inf ++ extra ;
+	  Sub  =>             subj ++ compl ++ inffin ++ extra
+        }
     } ;
 
 {-
@@ -862,7 +879,7 @@ resource ResGer = ParamX ** open Prelude in {
     let vpi = infVP isAux vp in
     vpi.p1 ! agrP3 Sg ++ vpi.p3 ++ vpi.p2 ++ vpi.p4 ;
 
-  infzuVP : Bool -> Control -> Anteriority -> Polarity -> VP
+  infzuVP : Bool -> Control -> Anteriority -> Polarity -> VP  -- HL 
     -> { objs:(Agr => Str) ; pred:{s:Str;isAux:Bool;ctrl:Control} ; inf:Str ; ext:Str } =
       \isAux, ctrl, ant, pol, vp -> let vps = useVP vp in
       { objs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ negation ! pol ++ (vp.nn ! agr).p3
@@ -930,8 +947,8 @@ resource ResGer = ParamX ** open Prelude in {
   infPart : Bool -> Str = \b -> if_then_Str b [] "zu" ;
 
   heavyNP : 
-    {s : PCase => Str ; a : Agr} -> {s : PCase => Str ; a : Agr ; isLight,isPron : Bool ; ext,rc : Str} = \np ->
-    np ** {isLight,isPron = False; ext,rc = []} ; -- this could be wrong
+    {s : PCase => Str ; a : Agr} -> {s : PCase => Str ; a : Agr ; w : Weight ; ext,rc : Str} = \np ->
+    np ** {w = WHeavy ; ext,rc = []} ; -- this could be wrong
 
   relPron :  RelGenNum => Case => Str = \\rgn,c =>
     case rgn of {
@@ -947,14 +964,12 @@ resource ResGer = ParamX ** open Prelude in {
     } ;
 
 -- Function that allows the construction of non-nominative subjects.
-	mkSubj : NP -> Preposition -> Str * Agr = \np, subjc -> 
-		let 
-		  sub = subjc ;
-		  agr = case sub.c of {
-			   NPC Nom => np.a ;
-		        _ => Ag Masc Sg P3 } ;
-          subj = appPrepNP sub np
-        in <subj , agr> ;
+  mkSubj : NP -> Preposition -> Str * Agr = \np, subjc -> 
+    let 
+      sub = subjc ;
+      agr = case sub.c of { NPC Nom => np.a ; _ => Ag Masc Sg P3 } ;
+      subj = appPrepNP sub np
+    in <subj , agr> ;
 
 }
 

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -29,7 +29,8 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
           inf  = vp.inf.s ++ verb.inf ;  -- HL .nn
           obj  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4
         in
-        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
+--        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
+        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ++ negation ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
     } ; 
 
     SlashVP np vp = 

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -26,7 +26,7 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
             } ;
           agr  = Ag Fem (numImp n) ps.p1 ; --- g does not matter
           verb = vps.s ! False ! agr ! VPImperat ps.p3 ;
-          inf  = vp.inf ++ verb.inf ;  -- HL .nn
+          inf  = vp.inf.s ++ verb.inf ;  -- HL .nn
           obj  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4
         in
         verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -13,8 +13,7 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
 			"uns graut" "*uns grauen"
 	   allows pre/post-positions in subjects -->
 	 		"nach mir wurde gedürstet" "*mir wurde gedürstet" 
-			can't think of case of postpositions in subject 
-                        HL: "des Geldes wegen wird gearbeitet"  -}
+			can't think of case of postpositions in subject -}
 
     PredSCVP sc vp = mkClause sc.s (agrP3 Sg) vp ;
 
@@ -50,7 +49,7 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
 			(insertExtrapos (conjThat ++ slash.s ! Sub) (predV vs)) **
         			{c2 = slash.c2} ;
 
-    EmbedS  s  = {s = conjThat ++ s.s ! Sub} ;
+    EmbedS  s  = {s = conjThat ++ s.s ! Sub} ;  -- no leading comma, if sentence-initial
     EmbedQS qs = {s = qs.s ! QIndir} ;
     EmbedVP vp = {s = useInfVP False vp} ;
 

--- a/src/german/SymbolGer.gf
+++ b/src/german/SymbolGer.gf
@@ -11,21 +11,27 @@ lin
   CNIntNP cn i = {
     s = \\c => cn.s ! Weak ! Sg ! Nom ++ i.s ;
     a = agrP3 Sg ;
-    isPron = False ;
-	ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
   CNSymbNP det cn xs = let g = cn.g in {
     s = \\c => det.s ! g ! c ++ 
                (let k = (prepC c).c in cn.s !  adjfCase det.a k ! det.n ! k) ++ xs.s ; 
     a = agrP3 det.n ;
-    isPron = False ;
-    ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
   CNNumNP cn i = {
     s = \\c => artDefContr (GSg cn.g) c ++ cn.s ! Weak ! Sg ! Nom ++ i.s ! Neutr ! (prepC c).c ;
     a = agrP3 Sg ;
-    isPron = False ;
-	ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
 
   SymbS sy = {s = \\_ => sy.s} ;

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -15,22 +15,47 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
           insertInf vpi.p2 (
             insertObjc vpi.p1 vps))) ;
 -}
+    ComplVV v vp = -- will|wage (es ([]|zu) tun [] | ihn [es tun] ([]|zu) lassen
+      let
+        vps = predVGen v.isAux v ;
+        vpi = infzuVP v.isAux SubjC Simul Pos vp ;
+        -- { objs: ihm ; pred: []/zu versprechen, objInf: sich/es zu tun }
+        -- (ich) vfin:werde (ihm ([]/zu) versprechen) vinf:(wollen/gewagt haben) (, es zu tun)
+        -- (ich) vfin:werde (ihn (es tun) lassen)/[]  vinf:(wollen/gewagt haben) []/(, ihn (es tun) zu lassen)
+        extInfzu = case <vp.isAux,vp.inf.isAux> of {<True,False> => (vp.nn!(Ag Masc Sg P3)).p6 ; _ => []} ;
+        comma = case vp.inf.ctrl of { NoC => [] ; _ => bindComma} ; -- es (zu) tun
+        embeddedInf : Agr => Str =
+          case <vp.isAux,vp.inf.isAux> of { -- vv + vp + [embeddedInf]
+            -- will [es lesen] können | will ihn [es lesen] lassen
+            <True,True>  => \\agr => (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;
+            -- will ihn [euch (extInfzu) bitten] lassen
+            <True,False> => \\agr => (vp.nn!agr).p5 ++ vpi.inf ; -- ++ (vp.nn!agr).p6 => extInfzu
+            -- will es lesen [] | will ihn bitten [, es zu lesen] | will ihn bitten [, sie es lesen zu lassen]
+            <False,True>  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;
+            -- will ihn bitten [, ihr zu helfen, es zu lesen]
+            <False,False> => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }
+      in
+      insertExtrapos (extInfzu ++ vpi.ext) ( -- vps.ext   <- vp's extracted embedded infzu + vp's object-sentence
+        insertInf vpi.pred (                 -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (       -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
+
     ComplVS v s = 
       insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predV v) ;
     ComplVQ v q = 
       insertExtrapos (comma ++ q.s ! QIndir) (predV v) ;
     ComplVA v ap = insertAdj (v.c2.s ++ ap.s ! APred) ap.c ap.ext (predV v) ; -- changed
 
-    SlashV2a v = (predVc v) ** {missingAdv = True} ; -- HL 12/6/2019 for reflexive verbs with objects, rV2:V2, rV3:V3
+    SlashV2a v = (predVc v) ** {ctrl = SubjC} ; -- HL 12/6/2019 for reflexive verbs with objects, rV2:V2, rV3:V3
       
-    Slash2V3 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; missingAdv = True} ; 
-    Slash3V3 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True} ;
+    Slash2V3 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; ctrl = SubjC} ;
+    Slash3V3 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; ctrl = SubjC} ;
 
     SlashV2S v s = 
       insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predVc v) ;
     SlashV2Q v q = 
       insertExtrapos (comma ++ q.s ! QIndir) (predVc v) ;
-{- to be redone in tests/german/TestLangGer.gf:
+{-
     SlashV2V v vp = 
       let 
         vpi = infVP v.isAux vp ;
@@ -39,35 +64,47 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
        insertExtrapos vpi.p4 ( -- inplace vp; better extract it!
         insertInfExt vpi.p3 (
           insertInf vpi.p2 (
-            insertObjc vpi.p1 vps))) ; -- glues all vp.nn-fields into nn.p4; except vp.nn.p1 for reflVP?
+            insertObjc vpi.p1 vps))) ;
 -}
+    SlashV2V v vp =   -- warnen, (\agr => sich!agr das Buch zu merken)
+      let
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; ctrl = v.ctrl } ;
+        vpi = infzuVP v.isAux v.ctrl Simul Pos vp ;
+        comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = case vp.inf.isAux of {
+          True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
+          False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
 
-
-    SlashV2A v ap = 
+    SlashV2A v ap =
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
 
     ComplSlash vps np =
       let vp = insertObjNP np vps.c2 vps ;
-       in case vp.missingAdv of {
-        True  => vp ;
-        False => objAgr np vp } ; -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of the object introduced by ComplSlash.
+          -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of np.
+      in case vp.ctrl of { ObjC => objAgr np vp ; _  => vp } ;
 
-    SlashVV v vp = 
-      let 
+    SlashVV v vp =
+      let
         vpi = infVP v.isAux vp ;
-        vps = predVGen v.isAux v ** {c2 = vp.c2 ; missingAdv = vp.missingAdv} ; -- mAdv added, HL 23.7.19
-      in vps **                                                        -- to preserve reflexiveness of vp
+        vps = predVGen v.isAux v ** {c2 = vp.c2 ; ctrl = vp.ctrl} ; -- SubjC ? preserve reflexiveness of vp?
+      in vps **
       insertExtrapos vpi.p3 (
-        insertInf {s=vpi.p2;isAux=v.isAux;ctrl=SubjC} (
+        insertInf {s=vpi.p2;isAux=vp.isAux;ctrl=SubjC} (
           insertObj vpi.p1 vps)) ;
-{- save space, HL 29.7.19
+
+{-
     SlashV2VNP v np vp =
       let 
         vpi = infVP v.isAux vp ;
         vps = predVGen v.isAux v ** {c2 = v.c2} ;
       in vps **
       insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
+        insertInf {s=vpi.p2;isAux=v.isAux;ctrl=v.ctrl} (
           insertObj vpi.p1 (
             insertObj (\\_ => appPrepNP v.c2 np) vps))) ;
 -}
@@ -123,6 +160,6 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
 
    but nothing like "die Stadt wir leben in".
 -}
-    VPSlashPrep vp prep = vp ** {c2 = prep ; missingAdv = True} ;
+    VPSlashPrep vp prep = vp ** {c2 = prep ; ctrl = SubjC} ;
 
 }

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -34,10 +34,14 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       let 
         vpi = infVP v.isAux vp ;
         vps = predVGen v.isAux v ** {c2 = v.c2} ;
-      in vps **
-      insertExtrapos vpi.p3 (  -- comma ++ vpi.p3 ?
-        insertInf vpi.p2 (
-          insertObj vpi.p1 vps)) ;
+      in vps ** 
+       insertExtrapos vpi.p4 ( -- inplace vp; better extract it!
+        insertInfExt vpi.p3 (
+          insertInf vpi.p2 (
+            insertObjc vpi.p1 vps))) ; -- glues all vp.nn-fields into nn.p4; except vp.nn.p1 for reflVP?
+      -- insertExtrapos (vpi.p3 ++ vpi.p4) (  -- comma ++ vpi.p3 ?
+      --   insertInf vpi.p2 (
+      --     insertObj vpi.p1 vps)) ;
 
     SlashV2A v ap = 
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
@@ -51,8 +55,8 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     SlashVV v vp = 
       let 
         vpi = infVP v.isAux vp ;
-        vps = predVGen v.isAux v ** {c2 = vp.c2} ;
-      in vps **
+        vps = predVGen v.isAux v ** {c2 = vp.c2 ; missingAdv = vp.missingAdv} ; -- mAdv added, HL 23.7.19
+      in vps **                                                        -- to preserve reflexiveness of vp
       insertExtrapos vpi.p3 (
         insertInf vpi.p2 (
           insertObj vpi.p1 vps)) ;

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -4,7 +4,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
 
   lin
     UseV = predV ;
-
+{-
     ComplVV v vp = 
       let 
         vpi = infVP v.isAux vp ;
@@ -14,7 +14,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInfExt vpi.p3 (
           insertInf vpi.p2 (
             insertObjc vpi.p1 vps))) ;
-
+-}
     ComplVS v s = 
       insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predV v) ;
     ComplVQ v q = 
@@ -30,6 +30,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predVc v) ;
     SlashV2Q v q = 
       insertExtrapos (comma ++ q.s ! QIndir) (predVc v) ;
+{- to be redone in tests/german/TestLangGer.gf:
     SlashV2V v vp = 
       let 
         vpi = infVP v.isAux vp ;
@@ -42,7 +43,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       -- insertExtrapos (vpi.p3 ++ vpi.p4) (  -- comma ++ vpi.p3 ?
       --   insertInf vpi.p2 (
       --     insertObj vpi.p1 vps)) ;
-
+-}
     SlashV2A v ap = 
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
 
@@ -58,9 +59,9 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         vps = predVGen v.isAux v ** {c2 = vp.c2 ; missingAdv = vp.missingAdv} ; -- mAdv added, HL 23.7.19
       in vps **                                                        -- to preserve reflexiveness of vp
       insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
+        insertInf {s=vpi.p2;isAux=v.isAux;ctrl=SubjC} (
           insertObj vpi.p1 vps)) ;
-
+{- save space, HL 29.7.19
     SlashV2VNP v np vp =
       let 
         vpi = infVP v.isAux vp ;
@@ -71,7 +72,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
           insertObj vpi.p1 (
             insertObj (\\_ => appPrepNP v.c2 np) vps))) ;
 --            insertObjNP v.c2 np vps))) ;
-
+-}
     UseComp comp =
        insertExtrapos comp.ext (insertObj comp.s (predV sein_V)) ; -- agr not used
     -- adj slot not used here for e.g. "ich bin alt" but same behaviour as NPs?

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -27,15 +27,15 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     Slash3V3 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True} ;
 
     SlashV2S v s = 
-      insertExtrapos (conjThat ++ s.s ! Sub) (predVc v) ;
+      insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predVc v) ;
     SlashV2Q v q = 
-      insertExtrapos (q.s ! QIndir) (predVc v) ;
+      insertExtrapos (comma ++ q.s ! QIndir) (predVc v) ;
     SlashV2V v vp = 
       let 
         vpi = infVP v.isAux vp ;
         vps = predVGen v.isAux v ** {c2 = v.c2} ;
       in vps **
-      insertExtrapos vpi.p3 (
+      insertExtrapos vpi.p3 (  -- comma ++ vpi.p3 ?
         insertInf vpi.p2 (
           insertObj vpi.p1 vps)) ;
 
@@ -98,8 +98,28 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     --   (\\k => usePrepC k (\c -> reflPron ! a ! c))) vp ;
     ReflVP vp = insertObjRefl vp ; -- HL, 19/06/2019
 
-    PassV2 v = insertInf (v.s ! VPastPart APred) (predV werdenPass) ;
+    PassV2 v = insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
 
+{- HL: The construction VPSlashPrep : VP -> Prep -> VPSlash does not exist
+   in German. In abstract/Verb.gf, the example
+
+    VPSlashPrep : VP -> Prep -> VPSlash ;  -- live in (it)
+
+   (with live_V:V) indicates that, here, you consider Prep=AdvSlash,
+   so to speak, for building a compact version of relative clauses:
+
+        the city we live in : NP
+
+   from  "we live (in the city : Adv) : Cl"
+
+   But in German we cannot move the NP part of an Adv, we only have the
+   full relative clauses like
+
+        die Stadt, in der wir leben,
+        die Stadt, worin wir leben,    --contracted Prep+Rel
+
+   but nothing like "die Stadt wir leben in".
+-}
     VPSlashPrep vp prep = vp ** {c2 = prep ; missingAdv = True} ;
 
 }

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -40,10 +40,9 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInfExt vpi.p3 (
           insertInf vpi.p2 (
             insertObjc vpi.p1 vps))) ; -- glues all vp.nn-fields into nn.p4; except vp.nn.p1 for reflVP?
-      -- insertExtrapos (vpi.p3 ++ vpi.p4) (  -- comma ++ vpi.p3 ?
-      --   insertInf vpi.p2 (
-      --     insertObj vpi.p1 vps)) ;
 -}
+
+
     SlashV2A v ap = 
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
 
@@ -71,7 +70,6 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInf vpi.p2 (
           insertObj vpi.p1 (
             insertObj (\\_ => appPrepNP v.c2 np) vps))) ;
---            insertObjNP v.c2 np vps))) ;
 -}
     UseComp comp =
        insertExtrapos comp.ext (insertObj comp.s (predV sein_V)) ; -- agr not used
@@ -81,7 +79,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     UseCopula = predV sein_V ;
 
     CompAP ap = {s = \\_ => ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ; ext = ap.ext} ;
-    CompNP np = {s = \\_ => np.s ! NPC Nom ++ np.adv ++ np.rc ; ext = np.ext} ;
+    CompNP np = {s = \\_ => np.s ! NPC Nom ++ np.rc ; ext = np.ext} ;
     CompAdv a = {s = \\_ => a.s ; ext = []} ;
 
     CompCN cn = {s = \\a => case numberAgr a of {

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -24,4 +24,6 @@ abstract TestLang =
 
     Pass3V3 : V3 -> NP -> VP ;  -- den Beweis erklärt bekommen
     Pass2V3 : V3 -> NP -> VP ;  -- uns erklärt werden ; Eng give_V3[indir,dir]: we are given the book
+
+    Pass2V4 : V4 -> NP -> VPSlash ; -- bei dir (für Gold) gekauft werden
   } ;

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -2,7 +2,7 @@ abstract TestLang =
   Grammar, 
   Lexicon
   , TestLexiconGerAbs
-  , Construction
+--  , Construction
   ** {    
   flags startcat=Phr ;
   cat 

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -1,7 +1,6 @@
 abstract TestLang = 
   Grammar, 
-  Lexicon
-  , TestLexiconGerAbs
+  TestLexiconGerAbs
 --  , Construction
   ** {    
   flags startcat=Phr ;

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -5,6 +5,9 @@ abstract TestLang =
 --  , Construction
   ** {    
   flags startcat=Phr ;
+
+  fun
+    SlashV2Vneg : V2V -> VP -> VPSlash ; -- negative use of VP: promise, not to vp
   cat 
     VPSlashSlash ;
   fun

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -22,6 +22,10 @@ abstract TestLang =
     PastPartAP  : VPSlash -> AP ;  -- lost (opportunity) ; (opportunity) lost in space
     PassVPSlash : VPSlash -> VP ;  -- from ExtraGer, to be corrected
 
+    PassV2S : V2S -> S -> VP ;
+    PassV2Q : V2Q -> QS -> VP ;
+    PassV2V : V2V -> VP -> VP ;
+
     Pass3V3 : V3 -> NP -> VP ;  -- den Beweis erklärt bekommen
     Pass2V3 : V3 -> NP -> VP ;  -- uns erklärt werden ; Eng give_V3[indir,dir]: we are given the book
 

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -17,4 +17,11 @@ abstract TestLang =
     Slash4V4 : V4 -> NP -> VPSlashSlash ;
 
     ComplSlashSlash: VPSlashSlash -> NP -> VPSlash ;
+
+    -- Passive
+    PastPartAP  : VPSlash -> AP ;  -- lost (opportunity) ; (opportunity) lost in space
+    PassVPSlash : VPSlash -> VP ;  -- from ExtraGer, to be corrected
+
+    Pass3V3 : V3 -> NP -> VP ;  -- den Beweis erklärt bekommen
+    Pass2V3 : V3 -> NP -> VP ;  -- uns erklärt werden ; Eng give_V3[indir,dir]: we are given the book
   } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -4,7 +4,7 @@
 concrete TestLangEng of TestLang = 
   GrammarEng
   , TestLexiconEng
-  , ConstructionEng
+--  , ConstructionEng
   ** open (R=ResEng),(P=ParadigmsEng),Prelude
 , (E=ExtendEng)
   in {

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -5,8 +5,7 @@ concrete TestLangEng of TestLang =
   GrammarEng
   , TestLexiconEng
 --  , ConstructionEng
-  ** open (R=ResEng),(P=ParadigmsEng),Prelude
-, (E=ExtendEng)
+  ** open (R=ResEng), (P=ParadigmsEng), Prelude, (E=ExtendEng)
   in {
 
   flags 
@@ -21,11 +20,15 @@ concrete TestLangEng of TestLang =
   lin 
     ReflVPSlash v3 = (R.predVc ((P.reflV (lin V v3)) ** {c2 = v3.c3 ; missingAdv = True})); 
 
-    ComplSlashSlash vpss np = R.insertObjc (appPrep vpss.c2 (lin NP np)) (vpss ** {c2 = vpss.c3 ; missingAdv = True }) ;
+    ComplSlashSlash vpss np = R.insertObjc 
+      (appPrep vpss.c2 (lin NP np)) (vpss ** {c2 = vpss.c3 ; missingAdv = True }) ;
 
-    Slash2V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c2 (lin NP np)) (R.predVc v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
-    Slash3V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c3 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
-    Slash4V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c4 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
+    Slash2V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c2 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
+    Slash3V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c3 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
+    Slash4V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c4 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
 
   oper
     appPrep : Str -> NP -> (R.Agr => Str) = \p,np -> \\_ => p ++ np.s ! R.NPAcc ;
@@ -45,6 +48,8 @@ concrete TestLangEng of TestLang =
 
     Pass2V4 v np =
       let vpss = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3 ; c3 = v.c4} 
-      in R.insertObj (\\_ => vpss.c3 ++ np.s ! R.NPAcc) vpss ** {c2 = vpss.c2 ; missingAdv = True ; gapInMiddle = False } ;
+      in R.insertObj (\\_ => vpss.c3 ++ np.s ! R.NPAcc) vpss ** {c2 = vpss.c2 ; 
+                                                                 missingAdv = True ; 
+                                                                 gapInMiddle = False } ;
 
 } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -6,7 +6,9 @@ concrete TestLangEng of TestLang =
   LexiconEng
   , TestLexiconEng
   , ConstructionEng
-  ** open (R=ResEng),(P=ParadigmsEng),Prelude in {
+  ** open (R=ResEng),(P=ParadigmsEng),Prelude
+, (E=ExtendEng)
+  in {
 
   flags 
     startcat = Phr ; unlexer = text ; lexer = text ;
@@ -24,4 +26,17 @@ concrete TestLangEng of TestLang =
 
   oper
     appPrep : Str -> NP -> (R.Agr => Str) = \p,np -> \\_ => p ++ np.s ! R.NPAcc ;
+
+    -- Passive
+  lin
+    Pass2V3 v np = 
+      let vps = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3} 
+      in R.insertObj (\\_ => vps.c2 ++ np.s ! R.NPAcc) vps ;
+
+    Pass3V3 v np = 
+      let vps = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c2} 
+      in R.insertObj (\\_ => vps.c2 ++ np.s ! R.NPAcc) vps ;
+
+    PastPartAP = E.PastPartAP ;
+    PassVPSlash = E.PassVPSlash ;
 } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -2,8 +2,7 @@
 -- --# -path=.:../abstract:../common:../api:../prelude
 
 concrete TestLangEng of TestLang = 
-  GrammarEng,
-  LexiconEng
+  GrammarEng
   , TestLexiconEng
   , ConstructionEng
   ** open (R=ResEng),(P=ParadigmsEng),Prelude

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -39,4 +39,9 @@ concrete TestLangEng of TestLang =
 
     PastPartAP = E.PastPartAP ;
     PassVPSlash = E.PassVPSlash ;
+
+    Pass2V4 v np =
+      let vpss = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3 ; c3 = v.c4} 
+      in R.insertObj (\\_ => vpss.c3 ++ np.s ! R.NPAcc) vpss ** {c2 = vpss.c2 ; missingAdv = True ; gapInMiddle = False } ;
+      
 } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -12,6 +12,10 @@ concrete TestLangEng of TestLang =
   flags 
     startcat = Phr ; unlexer = text ; lexer = text ;
 
+  lin
+    SlashV2Vneg v vp = 
+      R.insertObjc (\\a => v.c3 ++ R.infVP v.typ vp False R.Simul (R.CNeg True) a) (R.predVc v) ;
+
   lincat
     VPSlashSlash = VPSlash ** {c3 : Str} ;
   lin 
@@ -42,5 +46,5 @@ concrete TestLangEng of TestLang =
     Pass2V4 v np =
       let vpss = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3 ; c3 = v.c4} 
       in R.insertObj (\\_ => vpss.c3 ++ np.s ! R.NPAcc) vpss ** {c2 = vpss.c2 ; missingAdv = True ; gapInMiddle = False } ;
-      
+
 } ;

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -1,29 +1,32 @@
 --# -path=.:../../src/abstract:../../src/common:../../src/api:../../src/prelude:../../src/german
--- --# -path=.:../abstract:../common:../api:../prelude
+-- use the modified files in gf-rgl/src/german
 
 concrete TestLangGer of TestLang = 
-  GrammarGer - [PassV2] -- to improve these ,ComplVV,SlashVV,SlashV2V
-  , TestLexiconGer
---  , ConstructionGer
+  GrammarGer - [PassV2] -- to improve these ,ComplVV,SlashVV,SlashV2V,SlashV2VNP
+  , TestLexiconGer - [helfen_V2V, warnen_V2V, versprechen_dat_V2V, lassen_V2V]
+--  , ConstructionGer -- needs SlashV2VNP of VerbGer
   ** open ResGer,Prelude,(P=ParadigmsGer) in {
 
-flags startcat = Phr ; unlexer = text ; lexer = text ;
+  flags startcat = Phr ; unlexer = text ; lexer = text ;
+        optimize=all_subs ;
+{-
   lincat
     VPSlashSlash = CatGer.VPSlash ** {c3 : Preposition} ;
   lin 
-    ReflVPSlash v3 = (insertObjRefl (predVc v3) ** {c2 = v3.c3 ; ctrl = SubjC}); -- reflexive use of v:V3, untested
+    SlashV3a v = (predVc v) ** {c3 = v.c3} ;
 
-    -- SlashV3a v = (predVc v) ** {c3 = v.c3} ;
-{- save time:
-    Slash2V4 v np = (lin VPSlash (insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
-    Slash3V4 v np = (lin VPSlash (insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
-    Slash4V4 v np = (lin VPSlash (insertObjNP np v.c4 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
-
---    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
-time saved -}
+    Slash2V4 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; c3 = v.c4 } ; 
+    Slash3V4 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; c3 = v.c4 } ;
+    Slash4V4 v np = insertObjNP np v.c4 (predV v) ** {c2 = v.c2 ; c3 = v.c3 } ;
+    
+    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3} ;
     -- linref
     --   V4 = \v -> useInfVP False (predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
-{- save time
+-}
+  lin
+    ReflVPSlash v3 = -- reflexive use of v:V3, untested
+      (insertObjRefl (predVc v3) ** {c2 = v3.c3}); 
+
     PassV2 v = -- insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
       let c = case <v.c2.c, v.c2.isPrep> of {
             <NPC Acc, False> => NPC Nom ; _ => v.c2.c} -- acc object -> nom; all others: same PCase
@@ -49,7 +52,7 @@ time saved -}
           vp2 = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
             ** { subjc = v.c2 ** {c = c} } 
       in insertExtrapos (bindComma ++ (useInfVP False vp)) vp2 ; -- misses subject agr for vp = ReflVP vps
-
+{-
     PassVPSlash vp = 
       let c = case <vp.c2.c,vp.c2.isPrep> of {
             <NPC Acc, False> => NPC Nom ; _ => vp.c2.c}
@@ -69,18 +72,18 @@ time saved -}
       adj = [] ;
       ext = vp.ext 
       } ;
-
+-}
     Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
-      let vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+      let vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
             ** { subjc = PrepNom ; c2 = v.c3 }
       in insertObjNP np vps.c2 vps ;
 
     Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
       let bekommen : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
-          vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
+          vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
             ** { subjc = PrepNom ; c2 = v.c2 } 
       in insertObjNP np vps.c2 vps ;
-      
+{-      
     Pass2V4 v np = 
       let vps = -- : VPSlashSlash = 
             insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
@@ -90,9 +93,9 @@ time saved -}
     -- Todo: Pass?V2S, Pass?V2Q, PassVS, PassVQ Pass?V2V
 -}
 
-    SlashV2Vneg v vp =   -- warnen, (\agr => sich!agr das Buch nicht zu merken) 
+    SlashV2Vneg v vp =   -- versprechen, (\agr => sich!agr es nicht zu merken) 
       let 
-        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; ctrl = v.ctrl } ;
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 } ; --; ctrl = v.ctrl } ;
         vpi = infzuVP v.isAux v.ctrl Simul Neg vp ;
         comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} ;
         embeddedInf : Agr => Str = case vp.inf.isAux of {
@@ -104,4 +107,67 @@ time saved -}
           insertInfExtraObj vpi.objs (
             insertInfExtraInf embeddedInf vps))) ;
 
+    lin -- with param Control in ../../src/german/ParadigmsGer.gf
+      helfen_V2V = P.mkV2V (P.irregV "helfen" "hilft" "half" "hälfe" "geholfen") P.datPrep ; 
+      warnen_V2V = P.mkV2V (P.regV "warnen") P.accPrep ;
+      versprechen_dat_V2V = 
+        P.subjV2V (P.mkV2V (P.irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") P.datPrep) ;
+      lassen_V2V = P.auxV2V (P.irregV "lassen" "lasst" "ließ" "ließe" "gelassen") P.accPrep ;  -- lasse dich (*zu) arbeiten
+
+-- SlashV2VNP : V2V -> NP -> VPSlash -> VPSlash ; -- beg me to buy
+-- -- (the book) that (she (begged:V2V me:NP (to buy ()):VPSlash):VPSlash):ClSlash
+
+-- very expensive:
+-- + SlashV2V 2332800 (6480,40)
+-- + SlashV2VNP 2267481600 (4320,270) vs. (1080,90) in VerbGer, 305460 msec
+-- Languages: TestLangGer
+-- 623657 msec
+{- 
+    SlashV2VNP v np vp =  
+      let
+        vps = (predVGen v.isAux v) ** { c2 = vp.c2 } ; -- objCtrl = 
+        vpi = infzuVP v.isAux v.ctrl Simul Pos vp ;
+        -- comma = case <vp.isAux,vp.inf.ctrl> of { <True,_> => [] ; <_,NoC> => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = 
+          \\agr => "[" ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]";  
+        -- embeddedInf : Agr => Str = case vp.inf.isAux of {
+        --   True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
+        --   False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf (
+              insertObjNP np v.c2 vps )))) ;
+-}
+{-
+TestLang> p "the book that we beg her to promise him to read" | l
+the book that we beg her to promise him to read
+das Buch , das wir sie bitten , ihn zu versprechen [ [ ] zu lesen ]
+
+TestLang> p "the book that we beg her to beg him to read" | l
+the book that we beg her to beg him to read
+das Buch , das wir sie bitten , ihn zu bitten [ [ ] zu lesen ]
+
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+TestLangEng: the book that we promise her to read
+TestLangGer: das Buch , dem wir ihr versprechen , zu lesen   Bug: dem => das
+
+TestLang> p "the book that we beg her to sell to him" | l
+the book that we beg her to sell to him
+das Buch , das wir ihm sie bitten , zu verkaufen
+=> das Buch , das wir sie bitten , ihm zu verkaufen
+~~> das Buch , das ihm zu verkaufen wir sie bitten
+ ~~ das Buch , an das zu glauben wir sie bitten
+
+Wrong in gf-3.9 as well:
+Lang> p "the woman that we beg him to listen to" | l
+the woman that we beg him to listen to
+die Frau , die wir ihn zuzuhören bitten  (Bug: die => der)
+
+Lang> p "the book that we beg her to sell to him" | l
+the book that we beg her to sell to him
+das Buch , das wir ihn sie zu verkaufen bitten (Bug: ihn sie => sie ihm)
+=> das Buch, das wir sie bitten, ihm zu verkaufen
+-}
 }

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -47,16 +47,21 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
 
     Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
       let vps : VPSlash = 
-            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
-            ** { subjc = R.PrepNom ; c2 = v.c3 } 
+            lin VPSlash (R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
+                  ** { subjc = R.PrepNom ; c2 = v.c3 }) 
       in R.insertObjNP np vps.c2 vps ;
 
     Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
       let bekommenPass : R.Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
-          vps : VPSlash = 
+          vps = 
             R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV bekommenPass)
             ** { subjc = R.PrepNom ; c2 = v.c2 } 
       in R.insertObjNP np vps.c2 vps ;
       
-
+    Pass2V4 v np = 
+      let vps : VPSlashSlash = 
+            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
+            ** { subjc = R.PrepNom ; c2 = v.c3 ; c3 = v.c4 } 
+      in (R.insertObjNP np vps.c3 vps) ;
+      
 } ;

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -4,7 +4,7 @@
 concrete TestLangGer of TestLang = 
   GrammarGer - [PassV2,SlashV2V,ComplVV,SlashVV] -- to improve these
   , TestLexiconGer
-  , ConstructionGer
+--  , ConstructionGer
   ** open ResGer,Prelude,(P=ParadigmsGer) in {
 
 flags startcat = Phr ; unlexer = text ; lexer = text ;
@@ -19,11 +19,11 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
     Slash3V4 v np = (lin VPSlash (insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
     Slash4V4 v np = (lin VPSlash (insertObjNP np v.c4 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
 
-    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
+--    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
 
     -- linref
     --   V4 = \v -> useInfVP False (predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
-
+{-
     PassV2 v = -- insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
       let c = case <v.c2.c, v.c2.isPrep> of {
             <NPC Acc, False> => NPC Nom ; _ => v.c2.c} -- acc object -> nom; all others: same PCase
@@ -63,7 +63,7 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
     PastPartAP vp = {
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ 
         (vp.nn ! agrP3 Sg).p3 ++ (vp.nn ! agrP3 Sg).p4 ++ vp.adj ++ vp.a2 
-        ++ vp.inf ++ vp.infExt ++ vp.s.s ! VPastPart af ;
+        ++ vp.inf.s ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
       adj = [] ;
@@ -88,6 +88,7 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
       in (insertObjNP np vps.c3 vps) ;
 
     -- Todo: Pass?V2S, Pass?V2Q, PassVS, PassVQ Pass?V2V
+-}
 {- todo later:
     SlashVV v vp = 
       let 
@@ -98,60 +99,58 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
         insertInf vpi.p2 (
           insertObj vpi.p1 vps)) ;
 -}
-    ComplVV v vp = 
+    ComplVV v vp = -- will|wage (es (zu) tun [] | ihn [es tun] (zu) lassen | ihm (zu) versprechen [, es zu tun])
       let 
         vps = predVGen v.isAux v ;
-               -- ComplVV will/wage (es ihr []/zu verkaufen) = (vp.nn=<es,ihr>; vp.inf=verkaufen)
-               --                   (ihm []/zu versprechen, (es ihr zu verkaufen)) = 
-               --          v=wage   (vp.nn.p2=ihm; vp.inf=zu versprechen; vp.nn.p4=sich/es ihr zu verkaufen)
-        infVP : Bool -> ResGer.VP -> {objNPs:(Agr => Str) ; objInf:(Agr => Str) ;
-                                      pred:Str ; inf:Str ; ext:Str ; infExt:Str} = 
-          \isAux, vp -> let vps = useVP vp in
-          { objNPs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 
-              ++ vp.a2 ++ (vp.nn ! agr).p4 ;  -- objs + predicative A|CN|NP
-            objInf = \\agr => (vp.nn ! agr).p5 ;
-            pred = vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf ;
-            inf = vp.inf ; ext = vp.ext ; infExt = vp.infExt 
-          } ;
-        comma = case v.isAux of {True => [] ; _ => bindComma} ;
-        vpi = infVP v.isAux vp         
-        -- plan:
-        -- { objNPs: ihm ; pred: []/zu versprechen, objInf: sich/es ihr zu verkaufen }
-        -- (ich) vfin:werde ihm ([]/zu) versprechen vinf:(wollen/gewagt haben) , (es ihr zu verkaufen)
-        -- (ich) vfin:werde (ihn (es ihr verkaufen) lassen)/[] vinf:(wollen/gewagt haben) 
-        --                  []/,(ihn (es ihr verkaufen) zu lassen)
+        vpi = infzuVP v.isAux SubjC vp ;
+        -- { objs: ihm ; pred: []/zu versprechen, objInf: sich/es zu tun }
+        -- (ich) vfin:werde (ihm ([]/zu) versprechen) vinf:(wollen/gewagt haben) (, es zu tun)
+        -- (ich) vfin:werde (ihn (es tun) lassen)/[]  vinf:(wollen/gewagt haben) []/(, ihn (es tun) zu lassen)
+--        comma = case andB vp.isAux vp.inf.isAux of {True => [] ; _ => bindComma} ;
+        comma = case vp.inf.ctrl of { NoC => [] ; _ => bindComma} ; -- es (zu) tun
+        embeddedInf : Agr => Str = 
+          case <vps.isAux,vp.isAux> of {<True,True> => -- <will,lassen> ihn [es tun] lassen 
+                                          \\agr => "A[" ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]";           
+                                        <False,True> => -- <wage,lassen> ihn [es tun] (zu) lassen 
+                                          \\agr => "B[" ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]";           
+                                        <True,False> => -- <will,versprechen> ihr versprechen [, es zu tun]
+                                          \\agr => "C[" ++ comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]"; 
+                                        <False,False> => -- [] | , es zu tun | (,) ihm (zu) versprechen , es zu tun
+                                          \\agr => "D[" ++ comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 ++ "]"} 
       in
-      insertExtrapos vpi.ext (           -- vps.ext   <- object-sentence of vp 
-        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
-          insertInfExtraObj vpi.objNPs ( -- vps.nn.p5 <- vp's object nps
-          insertInfExtraInf (\\agr => (vp.nn!agr).p6 ++ (vp.nn!agr).p5 ++ vpi.inf) vps))) ;
-
-  oper
-  insertInfExtraInf : (Agr => Str) -> VPSlash -> VPSlash = \inf,vp -> vp ** { 
-    nn = \\a => let vpnn = vp.nn ! a in
-      <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6 ++ inf ! a>   
-      -- embedded inf + modalInf / nonmodalInf + embedded inf ?
-    } ;
+      insertExtrapos vpi.ext (         -- vps.ext   <- object-sentence of vp 
+        insertInf vpi.pred (           -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs ( -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
   lin
-    SlashV2V v vp =   -- warne (\agr => sich!agr das Buch zu merken) : der infzu muss in nn.p4 oder ext:Agr=>Str
+    SlashV2V v vp =   -- warnen, (\agr => sich!agr das Buch zu merken) 
       let 
-        b : Bool = case v.ctrl of { SubjC => True ; _ => False } ;
-        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; missingAdv = b } ; 
-        infVP : Bool -> ResGer.VP -> {objNPs:(Agr => Str) ;
-                                      pred:Str ; inf:Str ; ext:Str ; infExt:Str} = 
-          \isAux, vp -> let vps = useVP vp in
-          { objNPs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 
-              ++ (vp.nn ! agr).p4 ++ vp.a2 ;
-            pred = vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf ;
-            inf = vp.inf ; ext = vp.ext ; infExt = vp.infExt 
-          } ;
-        comma = case v.isAux of {True => [] ; _ => bindComma} ;
-        vpi = infVP v.isAux vp 
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; 
+                                        missingAdv = case v.ctrl of { SubjC => True ; _ => False } } ;
+        vpi = infzuVP v.isAux v.ctrl vp ;
+        comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} 
       in { missingAdv = True } **
       insertExtrapos vpi.ext (           -- vps.ext   <- object-sentence of vp 
         insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
-          insertInfExtraObj vpi.objNPs ( -- vps.nn.p5 <- vp's object nps
-            insertInfExtraInf (\\agr => (vp.nn!agr).p6 ++ (vp.nn!agr).p5 ++ vpi.inf) vps))) ;
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf (\\agr => comma ++ (vp.nn!agr).p6 ++ (vp.nn!agr).p5 ++ vpi.inf) vps))) ;
+
+  oper
+    infzuVP : Bool -> Control -> ResGer.VP -> { objs:(Agr => Str) ; pred:{s:Str;isAux:Bool;ctrl:Control} ; inf:Str ; ext:Str } = 
+      \isAux, ctrl, vp -> let vps = useVP vp in
+      { pred = { s = vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf ;
+                 isAux = vp.isAux ; ctrl = ctrl } ;
+        objs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 
+          ++ vp.a2 ++ (vp.nn ! agr).p4 ;  -- objects + predicative A|CN|NP
+        inf = vp.inf.s ; 
+        ext = vp.ext  
+      } ;
+
+    insertInfExtraInf : (Agr => Str) -> VPSlash -> VPSlash = \inf,vp -> vp ** { 
+      nn = \\a => let vpnn = vp.nn ! a in
+        <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6 ++ inf ! a>   
+        -- embedded inf + modalInf / nonmodalInf + embedded inf ?
+      } ;
 
 {-
     SlashV2V v vp =   -- warne (\agr => sich!agr das Buch zu merken) : der infzu muss in nn.p4 oder ext:Agr=>Str

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -6,7 +6,7 @@ concrete TestLangGer of TestLang =
   LexiconGer
   , TestLexiconGer
   , ConstructionGer
-  ** open (R=ResGer),Prelude in {
+  ** open (R=ResGer),Prelude,(P=ParadigmsGer) in {
 
 flags startcat = Phr ; unlexer = text ; lexer = text ;
   lincat
@@ -24,5 +24,39 @@ flags startcat = Phr ; unlexer = text ; lexer = text ;
 
     -- linref
     --   V4 = \v -> useInfVP False (R.predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+
+    PassVPSlash vp = 
+      let c = case <vp.c2.c,vp.c2.isPrep> of {
+            <R.NPC R.Acc,False> => R.NPC R.Nom ;
+            _ => vp.c2.c}
+      in R.insertObj (\\_ => (PastPartAP vp).s ! R.APred) (R.predV R.werdenPass) **
+      {subjc = vp.c2 ** {c= c}} ;
+                -- regulates passivised object: accusative objects -> nom; all others: same case
+		-- this also gives "mit dir wird gerechnet" ;
+		-- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
+       -- HL: does not work for vp = (Slash2V3 v np): uns wird den Beweis erklärt
+    PastPartAP vp = {
+      s = \\af => (vp.nn ! R.agrP3 R.Sg).p1 ++ (vp.nn ! R.agrP3 R.Sg).p2 ++ 
+        (vp.nn ! R.agrP3 R.Sg).p3 ++ (vp.nn ! R.agrP3 R.Sg).p4 ++ vp.adj ++ vp.a2 
+        ++ vp.inf ++ vp.ext ++ vp.infExt ++ vp.s.s ! R.VPastPart af ;
+      isPre = True ;
+      c = <[],[]> ;
+      adj = [] ;
+      ext = [] 
+      } ;
+
+    Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
+      let vps : VPSlash = 
+            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
+            ** { subjc = R.PrepNom ; c2 = v.c3 } 
+      in R.insertObjNP np vps.c2 vps ;
+
+    Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
+      let bekommenPass : R.Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
+          vps : VPSlash = 
+            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV bekommenPass)
+            ** { subjc = R.PrepNom ; c2 = v.c2 } 
+      in R.insertObjNP np vps.c2 vps ;
+      
 
 } ;

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -2,66 +2,176 @@
 -- --# -path=.:../abstract:../common:../api:../prelude
 
 concrete TestLangGer of TestLang = 
-  GrammarGer,
-  LexiconGer
+  GrammarGer - [PassV2,SlashV2V,ComplVV,SlashVV] -- to improve these
   , TestLexiconGer
   , ConstructionGer
-  ** open (R=ResGer),Prelude,(P=ParadigmsGer) in {
+  ** open ResGer,Prelude,(P=ParadigmsGer) in {
 
 flags startcat = Phr ; unlexer = text ; lexer = text ;
   lincat
-    VPSlashSlash = VPSlash ** {c3 : R.Preposition} ;
+    VPSlashSlash = CatGer.VPSlash ** {c3 : Preposition} ;
   lin 
-    ReflVPSlash v3 = (R.insertObjRefl (R.predVc v3) ** {c2 = v3.c3 ; missingAdv = True}); -- reflexive use of v:V3, untested
+    ReflVPSlash v3 = (insertObjRefl (predVc v3) ** {c2 = v3.c3 ; missingAdv = True}); -- reflexive use of v:V3, untested
 
-    -- SlashV3a v = (R.predVc v) ** {c3 = v.c3} ;
+    -- SlashV3a v = (predVc v) ** {c3 = v.c3} ;
 
-    Slash2V4 v np = (lin VPSlash (R.insertObjNP np v.c2 (R.predV v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
-    Slash3V4 v np = (lin VPSlash (R.insertObjNP np v.c3 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
-    Slash4V4 v np = (lin VPSlash (R.insertObjNP np v.c4 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
+    Slash2V4 v np = (lin VPSlash (insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
+    Slash3V4 v np = (lin VPSlash (insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
+    Slash4V4 v np = (lin VPSlash (insertObjNP np v.c4 (predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
 
-    ComplSlashSlash vpss np = R.insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
+    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
 
     -- linref
-    --   V4 = \v -> useInfVP False (R.predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+    --   V4 = \v -> useInfVP False (predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+
+    PassV2 v = -- insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} -- acc object -> nom; all others: same PCase
+      in insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) ** { subjc = v.c2 ** {c = c} } ;
+
+    PassV2Q v q = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ q.s ! QIndir) vp ;
+
+    PassV2S v s = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ conjThat ++ s.s ! Sub) vp ;
+
+    PassV2V v vp = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp2 = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ (useInfVP False vp)) vp2 ; -- misses subject agr for vp = ReflVP vps
 
     PassVPSlash vp = 
       let c = case <vp.c2.c,vp.c2.isPrep> of {
-            <R.NPC R.Acc,False> => R.NPC R.Nom ;
-            _ => vp.c2.c}
-      in R.insertObj (\\_ => (PastPartAP vp).s ! R.APred) (R.predV R.werdenPass) **
-      {subjc = vp.c2 ** {c= c}} ;
+            <NPC Acc, False> => NPC Nom ; _ => vp.c2.c}
+      in insertObjc (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) 
+      ** {ext = vp.ext ; subjc = vp.c2 ** {c = c}} ;
                 -- regulates passivised object: accusative objects -> nom; all others: same case
 		-- this also gives "mit dir wird gerechnet" ;
 		-- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
        -- HL: does not work for vp = (Slash2V3 v np): uns wird den Beweis erklärt
+       --                       vp = (SlashV2V v2v reflVP): wir werden gebeten, uns zu fragen , ob S
     PastPartAP vp = {
-      s = \\af => (vp.nn ! R.agrP3 R.Sg).p1 ++ (vp.nn ! R.agrP3 R.Sg).p2 ++ 
-        (vp.nn ! R.agrP3 R.Sg).p3 ++ (vp.nn ! R.agrP3 R.Sg).p4 ++ vp.adj ++ vp.a2 
-        ++ vp.inf ++ vp.ext ++ vp.infExt ++ vp.s.s ! R.VPastPart af ;
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ 
+        (vp.nn ! agrP3 Sg).p3 ++ (vp.nn ! agrP3 Sg).p4 ++ vp.adj ++ vp.a2 
+        ++ vp.inf ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
       adj = [] ;
-      ext = [] 
+      ext = vp.ext 
       } ;
 
     Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
-      let vps : VPSlash = 
-            lin VPSlash (R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
-                  ** { subjc = R.PrepNom ; c2 = v.c3 }) 
-      in R.insertObjNP np vps.c2 vps ;
+      let vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+            ** { subjc = PrepNom ; c2 = v.c3 }
+      in insertObjNP np vps.c2 vps ;
 
     Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
-      let bekommenPass : R.Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
-          vps = 
-            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV bekommenPass)
-            ** { subjc = R.PrepNom ; c2 = v.c2 } 
-      in R.insertObjNP np vps.c2 vps ;
+      let bekommen : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
+          vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
+            ** { subjc = PrepNom ; c2 = v.c2 } 
+      in insertObjNP np vps.c2 vps ;
       
     Pass2V4 v np = 
-      let vps : VPSlashSlash = 
-            R.insertObj (\\_ => (v.s ! R.VPastPart R.APred)) (R.predV R.werdenPass)
-            ** { subjc = R.PrepNom ; c2 = v.c3 ; c3 = v.c4 } 
-      in (R.insertObjNP np vps.c3 vps) ;
-      
-} ;
+      let vps = -- : VPSlashSlash = 
+            insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+            ** { subjc = PrepNom ; c2 = v.c3 ; c3 = v.c4 } 
+      in (insertObjNP np vps.c3 vps) ;
+
+    -- Todo: Pass?V2S, Pass?V2Q, PassVS, PassVQ Pass?V2V
+{- todo later:
+    SlashVV v vp = 
+      let 
+        vpi = infVP v.isAux vp ;
+        vps = predVGen v.isAux v ** {c2 = vp.c2 ; missingAdv = vp.missingAdv} ; -- mAdv added, HL 23.7.19
+      in vps **                                                        -- to preserve reflexiveness of vp
+      insertExtrapos vpi.p3 (
+        insertInf vpi.p2 (
+          insertObj vpi.p1 vps)) ;
+-}
+    ComplVV v vp = 
+      let 
+        vps = predVGen v.isAux v ;
+               -- ComplVV will/wage (es ihr []/zu verkaufen) = (vp.nn=<es,ihr>; vp.inf=verkaufen)
+               --                   (ihm []/zu versprechen, (es ihr zu verkaufen)) = 
+               --          v=wage   (vp.nn.p2=ihm; vp.inf=zu versprechen; vp.nn.p4=sich/es ihr zu verkaufen)
+        infVP : Bool -> ResGer.VP -> {objNPs:(Agr => Str) ; objInf:(Agr => Str) ;
+                                      pred:Str ; inf:Str ; ext:Str ; infExt:Str} = 
+          \isAux, vp -> let vps = useVP vp in
+          { objNPs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 
+              ++ vp.a2 ++ (vp.nn ! agr).p4 ;  -- objs + predicative A|CN|NP
+            objInf = \\agr => (vp.nn ! agr).p5 ;
+            pred = vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf ;
+            inf = vp.inf ; ext = vp.ext ; infExt = vp.infExt 
+          } ;
+        comma = case v.isAux of {True => [] ; _ => bindComma} ;
+        vpi = infVP v.isAux vp         
+        -- plan:
+        -- { objNPs: ihm ; pred: []/zu versprechen, objInf: sich/es ihr zu verkaufen }
+        -- (ich) vfin:werde ihm ([]/zu) versprechen vinf:(wollen/gewagt haben) , (es ihr zu verkaufen)
+        -- (ich) vfin:werde (ihn (es ihr verkaufen) lassen)/[] vinf:(wollen/gewagt haben) 
+        --                  []/,(ihn (es ihr verkaufen) zu lassen)
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- object-sentence of vp 
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objNPs ( -- vps.nn.p5 <- vp's object nps
+          insertInfExtraInf (\\agr => (vp.nn!agr).p6 ++ (vp.nn!agr).p5 ++ vpi.inf) vps))) ;
+
+  oper
+  insertInfExtraInf : (Agr => Str) -> VPSlash -> VPSlash = \inf,vp -> vp ** { 
+    nn = \\a => let vpnn = vp.nn ! a in
+      <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6 ++ inf ! a>   
+      -- embedded inf + modalInf / nonmodalInf + embedded inf ?
+    } ;
+  lin
+    SlashV2V v vp =   -- warne (\agr => sich!agr das Buch zu merken) : der infzu muss in nn.p4 oder ext:Agr=>Str
+      let 
+        b : Bool = case v.ctrl of { SubjC => True ; _ => False } ;
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; missingAdv = b } ; 
+        infVP : Bool -> ResGer.VP -> {objNPs:(Agr => Str) ;
+                                      pred:Str ; inf:Str ; ext:Str ; infExt:Str} = 
+          \isAux, vp -> let vps = useVP vp in
+          { objNPs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 
+              ++ (vp.nn ! agr).p4 ++ vp.a2 ;
+            pred = vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf ;
+            inf = vp.inf ; ext = vp.ext ; infExt = vp.infExt 
+          } ;
+        comma = case v.isAux of {True => [] ; _ => bindComma} ;
+        vpi = infVP v.isAux vp 
+      in { missingAdv = True } **
+      insertExtrapos vpi.ext (           -- vps.ext   <- object-sentence of vp 
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objNPs ( -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf (\\agr => (vp.nn!agr).p6 ++ (vp.nn!agr).p5 ++ vpi.inf) vps))) ;
+
+{-
+    SlashV2V v vp =   -- warne (\agr => sich!agr das Buch zu merken) : der infzu muss in nn.p4 oder ext:Agr=>Str
+      let 
+        b : Bool = case v.ctrl of { SubjC => True ; _ => False } ;
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; missingAdv = b } ; 
+        vpi = infVP v.isAux vp ;
+      in { missingAdv = True } **
+       insertExtrapos vpi.p4 ( -- inplace vp; better extract it (in mkClause?) !
+        insertInfExt vpi.p3 (
+          insertInf vpi.p2 (
+            insertObjc vpi.p1 vps))) ; -- glues all vp.nn-fields into nn.p4
+
+   infVP : Bool -> VP -> ((Agr => Str) * Str * Str * Str) = \isAux, vp -> let vps = useVP vp in
+    <
+     \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4 ++ vp.a2,
+     vp.a1 ! Pos ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf,
+     vp.inf,
+     vp.infExt ++ vp.ext
+    > ;
+-}
+
+}

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -3,7 +3,7 @@
 -- translations and corresponding c2,c3,c4-objects under Slash?V3, Slash?V4.
 
 concrete TestLexiconEng of TestLexiconGerAbs = 
-  CatEng ** open (R=ResEng), (P=Prelude), ParadigmsEng
+  LexiconEng ** open (R=ResEng), (P=Prelude), ParadigmsEng, (I=IrregEng)
 in {
 
 lincat 
@@ -20,6 +20,8 @@ oper
   mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
          \v,p2,p3,p4 -> lin V4 (v ** { c2=p2.s ; c3=p3.s ; c4=p4.s }) ;
   dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v noPrep c d ;
+  -- control verbs:
+  defaultV2V : V -> V2V = \v -> lin V2V (dirV2 v ** {c3=[] ; typ = R.VVInf}) ;
 
 lin
   aendern_rV = (regV "change") ;
@@ -27,6 +29,7 @@ lin
                       compl : Str = "an effort" 
     in {s = \\vf => v.s!vf ++ compl ; isRefl = P.False ; p = []} ;
 
+  gedenken_gen_V2  = dirV2 (regV "remember") ;
   bedienen_gen_rV2 = dirV2 (regV "use") ;
   stuetzen_auf_rV2 = mkV2 (irregV "rely" "relied" "relied") (mkPrep "on") ;
   ergeben_dat_rV2 = mkV2 (regV "surrender") (mkPrep "to") ;
@@ -49,4 +52,11 @@ lin
   mieten_von_fuer_V4 = dirV4 (regV "rent") (mkPrep "from") (mkPrep "for") ;
 
   neugierig_auf_A2 = mkA2 (regA "curious") (mkPrep "about") ;
+
+  wagen_VV = mkVV (regV "dare") ;                       -- typ=VVInf
+  versuchen_VV = mkVV (irregV "try" "tried" "tried") ;  -- typ=VVInf
+  warnen_V2V = defaultV2V (regV "warn") ;               -- typ=VVInf
+  versprechen_dat_V2V = defaultV2V (regV "promise") ;   -- typ=VVInf
+  lassen_V2V = ParadigmsEng.mkV2V (I.let_V) ;           -- typ=VVAux
+
 }

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -55,6 +55,7 @@ lin
 
   wagen_VV = mkVV (regV "dare") ;                       -- typ=VVInf
   versuchen_VV = mkVV (irregV "try" "tried" "tried") ;  -- typ=VVInf
+  helfen_V2V = defaultV2V (regV "help") ;
   warnen_V2V = defaultV2V (regV "warn") ;               -- typ=VVInf
   versprechen_dat_V2V = defaultV2V (regV "promise") ;   -- typ=VVInf
   lassen_V2V = ParadigmsEng.mkV2V (I.let_V) ;           -- typ=VVAux

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -36,6 +36,7 @@ lin
   erklaeren_dat_V3 = dirV3 (regV "explain") (mkPrep "to") ;
   erinnern_an_V3 = dirV3 (regV "remind") (mkPrep "of") ;
   danken_dat_fuer_V3 = dirV3 (regV "thank") (mkPrep "for") ;
+  debattieren_mit_ueber_V3 = mkV3 (regV "debate") (mkPrep "with") (mkPrep "about") ;
   lehren_V3 = mkV3 (irregV "teach" "taught" "taught") noPrep noPrep ;
 
   abschauen_bei_rV3 = dirV3 (regV "copy") (mkPrep "from") ; 

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -1,7 +1,7 @@
 --# -path=.:../abstract:../common:../prelude: 
 
 concrete TestLexiconGer of TestLexiconGerAbs = 
-  CatGer ** open (R=ResGer), (P=Prelude), ParadigmsGer 
+  LexiconGer ** open (R=ResGer), (P=Prelude), ParadigmsGer 
 in {
 
 lincat 
@@ -22,11 +22,14 @@ oper
   mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
          \v,p2,p3,p4 -> lin V4 (v ** { c2=p2 ; c3=p3 ; c4=p4 }) ;
   dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v accPrep c d ;
+  -- control verbs
+  dirV2V : V -> V2V = \v -> mkV2V v ; 
 
 lin
   aendern_rV = reflV (regV "ändern") accusative ;
   anstrengen_rV = reflV (prefixV "an" (regV "strengen")) accusative ;
 
+  gedenken_gen_V2 = mkV2 (irregV "gedenken" "gedenkt" "gedachte" "gedächte" "gedacht") genPrep ;
   bedienen_gen_rV2 = reflV2 (regV "bedienen") accusative genPrep ;
   stuetzen_auf_rV2 = reflV2 (regV "stützen") accusative (mkPrep "auf" accusative) ;
   ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergibt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
@@ -50,5 +53,11 @@ lin
   mieten_von_fuer_V4 = dirV4 (regV "mieten") von_Prep fuer_Prep ;
 
   neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
+
+  wagen_VV = mkVV (regV "wagen")  ;
+  versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
+  warnen_V2V = dirV2V (regV "warnen")  ;
+  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "versprecht" "versprach" "verspräche" "versprochen") datPrep) ;
+  lassen_V2V = auxV2V (irregV "lassen" "lasst" "ließ" "ließe" "gelassen") accPrep ;  -- lasse dich (*zu) arbeiten
 
 }

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -56,6 +56,8 @@ lin
 
   wagen_VV = mkVV (regV "wagen")  ;
   versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
+
+  helfen_V2V = mkV2V (irregV "helfen" "helft" "half" "hälfe" "geholfen") datPrep ; 
   warnen_V2V = dirV2V (regV "warnen")  ;
   versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "versprecht" "versprach" "verspräche" "versprochen") datPrep) ;
   lassen_V2V = auxV2V (irregV "lassen" "lasst" "ließ" "ließe" "gelassen") accPrep ;  -- lasse dich (*zu) arbeiten

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -16,6 +16,7 @@ oper
 
   bei_Prep   = mkPrep "bei" dative ; 
   fuer_Prep  = mkPrep "für" accusative ;
+  mit_Prep   = mkPrep "mit" dative ; 
 
   -- quaternary verbs:
   mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
@@ -31,10 +32,11 @@ lin
   ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergibt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
   merken_rV2 = reflV2 (regV "merken") dative accPrep ;
 
-  erklaeren_dat_V3 = accdatV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
+  erklaeren_dat_V3 = mkV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
   anklagen_gen_V3 = dirV3 (prefixV "an" (regV "klagen")) genPrep ;
   erinnern_an_V3 = dirV3 (irregV "erinnern" "erinnert" "erinnerte" "erinnerte" "erinnert") (mkPrep "an" accusative) ; 
   danken_dat_fuer_V3 = mkV3 (regV "danken") datPrep (mkPrep "für" accusative) ;
+  debattieren_mit_ueber_V3 = mkV3 (irregV "debattieren" "debattiert" "debattierte" "debattierte" "debattiert") mit_Prep (mkPrep "über" accusative) ;
   lehren_V3 = dirV3 (regV "lehren") accPrep ;
 
   abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -57,9 +57,9 @@ lin
   wagen_VV = mkVV (regV "wagen")  ;
   versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
 
-  helfen_V2V = mkV2V (irregV "helfen" "helft" "half" "hälfe" "geholfen") datPrep ; 
+  helfen_V2V = mkV2V (irregV "helfen" "hilft" "half" "hälfe" "geholfen") datPrep ; 
   warnen_V2V = dirV2V (regV "warnen")  ;
-  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "versprecht" "versprach" "verspräche" "versprochen") datPrep) ;
+--  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") datPrep) ;
   lassen_V2V = auxV2V (irregV "lassen" "lasst" "ließ" "ließe" "gelassen") accPrep ;  -- lasse dich (*zu) arbeiten
 
 }

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -33,6 +33,7 @@ fun
 
   wagen_VV : VV ;
   versuchen_VV : VV ;
+  helfen_V2V : V2V ;
   warnen_V2V : V2V ;          -- object control verb
   versprechen_dat_V2V : V2V ; -- subject control verb
   lassen_V2V : V2V ;          -- inf without zu

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -1,5 +1,5 @@
 --# -path=.:../abstract:../common:../prelude: -- partially extracted from DictVerbsGerAbs
-abstract TestLexiconGerAbs = Cat ** {
+abstract TestLexiconGerAbs = Lexicon ** {
 cat 
   V4 ;
 
@@ -7,6 +7,7 @@ fun
   aendern_rV : V ;
   anstrengen_rV : V ;
 
+  gedenken_gen_V2 : V2 ;
   bedienen_gen_rV2 : V2 ;
   stuetzen_auf_rV2 : V2 ;
   ergeben_dat_rV2 : V2 ;
@@ -30,4 +31,9 @@ fun
 
   neugierig_auf_A2 : A2 ;
 
+  wagen_VV : VV ;
+  versuchen_VV : VV ;
+  warnen_V2V : V2V ;          -- object control verb
+  versprechen_dat_V2V : V2V ; -- subject control verb
+  lassen_V2V : V2V ;          -- inf without zu
 }

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -1,7 +1,5 @@
 --# -path=.:../abstract:../common:../prelude: -- partially extracted from DictVerbsGerAbs
 abstract TestLexiconGerAbs = Lexicon ** {
-cat 
-  V4 ;
 
 fun
   aendern_rV : V ;
@@ -26,15 +24,20 @@ fun
   entschuldigen_bei_fuer_rV3 : V3 ;
   raechen_am_fuer_rV3 : V3 ;
 
-  kaufen_bei_fuer_V4 : V4 ;
-  mieten_von_fuer_V4 : V4 ;
-
   neugierig_auf_A2 : A2 ;
 
   wagen_VV : VV ;
   versuchen_VV : VV ;
-  helfen_V2V : V2V ;
-  warnen_V2V : V2V ;          -- object control verb
-  versprechen_dat_V2V : V2V ; -- subject control verb
-  lassen_V2V : V2V ;          -- inf without zu
+
+  helfen_V2V : V2V ;          -- -aux(zu-inf), object control
+  warnen_V2V : V2V ;          -- -aux,         object control
+  versprechen_dat_V2V : V2V ; -- -aux,         subject control
+  lassen_V2V : V2V ;          -- +aux(inf),    object control
+
+cat 
+  V4 ;
+fun
+  kaufen_bei_fuer_V4 : V4 ;
+  mieten_von_fuer_V4 : V4 ;
+
 }

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -17,6 +17,7 @@ fun
   lehren_V3 : V3 ;
   erinnern_an_V3 : V3 ;
   danken_dat_fuer_V3 : V3 ;
+  debattieren_mit_ueber_V3 : V3 ;
 
   abschauen_bei_rV3 : V3 ;
   leihen_von_rV3 : V3 ;

--- a/tests/german/examples.dub.out
+++ b/tests/german/examples.dub.out
@@ -91,6 +91,9 @@ TestLangEng: we want to see not somebody
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2a see_V2) somebody_NP))))) NoVoc
 TestLangGer: wir wollen nicht jemanden sehen
 TestLangEng: we don't want to see somebody
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (SlashVV want_VV (SlashV2a see_V2)) somebody_NP)))) NoVoc
+TestLangGer: wir wollen jemanden nicht sehen
+TestLangEng: we don't want to see somebody
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
 TestLangGer: wir lehrten ihn sie
 TestLangEng: we taught her him

--- a/tests/german/examples.eng.out
+++ b/tests/german/examples.eng.out
@@ -1,195 +1,237 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
+TestLangEng: the child gives the woman the apple
+TestLangGer: das Kind gibt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman the apple
+TestLangGer: das Kind gibt der Frau den Apfel
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt der Frau das
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman it
+TestLangGer: das Kind gibt es der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron he_Pron))))) NoVoc
+TestLangEng: the child gives the woman him
+TestLangGer: das Kind gibt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman him
+TestLangGer: das Kind gibt ihn der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron she_Pron))))) NoVoc
+TestLangEng: the child gives the woman her
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman her
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron they_Pron))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt sie der Frau
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt der Frau die
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
+TestLangEng: the child gives the woman them
+TestLangGer: das Kind gibt sie der Frau
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives her the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
 TestLangEng: the child gives her the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron he_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives him the apple
-TestLangGer: das Kind gibt ihn dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron he_Pron))))) NoVoc
 TestLangEng: the child gives him the apple
-TestLangGer: das Kind gibt ihn dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt dem Apfel das
+TestLangGer: das Kind gibt dem den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt es dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt dem Apfel das
+TestLangGer: das Kind gibt dem den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron it_Pron))))) NoVoc
 TestLangEng: the child gives it the apple
-TestLangGer: das Kind gibt es dem Apfel
+TestLangGer: das Kind gibt ihm den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt dem Apfel die
+TestLangGer: das Kind gibt denen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 give_V3 (UsePron they_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihnen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetNP (DetQuant DefArt NumPl)))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt dem Apfel die
+TestLangGer: das Kind gibt denen den Apfel
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron they_Pron))))) NoVoc
 TestLangEng: the child gives them the apple
-TestLangGer: das Kind gibt sie dem Apfel
+TestLangGer: das Kind gibt ihnen den Apfel
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that the child gives her
-TestLangGer: der Apfel , dem das Kind sie gibt
+TestLangGer: der Apfel , den das Kind ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that the child gives her
-TestLangGer: der Apfel , den das Kind ihr gibt
+TestLangGer: der Apfel , dem das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , dem das sie gibt
+TestLangGer: der Apfel , den das ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , den das ihr gibt
+TestLangGer: der Apfel , dem das sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , dem es sie gibt
+TestLangGer: der Apfel , den es ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives her
-TestLangGer: der Apfel , den es ihr gibt
+TestLangGer: der Apfel , dem es sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , dem das ihn gibt
+TestLangGer: der Apfel , den das ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , den das ihm gibt
+TestLangGer: der Apfel , dem das ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , dem es ihn gibt
+TestLangGer: der Apfel , den es ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives him
-TestLangGer: der Apfel , den es ihm gibt
+TestLangGer: der Apfel , dem es ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem das das gibt
+TestLangGer: der Apfel , den das dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem das es gibt
+TestLangGer: der Apfel , den das ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den das dem gibt
+TestLangGer: der Apfel , dem das das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den das ihm gibt
+TestLangGer: der Apfel , dem das es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem es das gibt
+TestLangGer: der Apfel , den es dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , dem es es gibt
+TestLangGer: der Apfel , den es ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den es dem gibt
+TestLangGer: der Apfel , dem es das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives it
-TestLangGer: der Apfel , den es ihm gibt
+TestLangGer: der Apfel , dem es es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem das die gibt
+TestLangGer: der Apfel , den das denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem das sie gibt
+TestLangGer: der Apfel , den das ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den das denen gibt
+TestLangGer: der Apfel , dem das die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den das ihnen gibt
+TestLangGer: der Apfel , dem das sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem es die gibt
+TestLangGer: der Apfel , den es denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , dem es sie gibt
+TestLangGer: der Apfel , den es ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den es denen gibt
+TestLangGer: der Apfel , dem es die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the apple that it gives them
-TestLangGer: der Apfel , den es ihnen gibt
+TestLangGer: der Apfel , dem es sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangEng: the woman that the child gives the apple
-TestLangGer: die Frau , der das Kind den Apfel gibt
+TestLangGer: die Frau , die das Kind dem Apfel gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangEng: the woman that the child gives the apple
-TestLangGer: die Frau , die das Kind dem Apfel gibt
+TestLangGer: die Frau , der das Kind den Apfel gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives him
-TestLangGer: die Frau , der das Kind ihn gibt
+TestLangGer: die Frau , die das Kind ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives him
-TestLangGer: die Frau , die das Kind ihm gibt
+TestLangGer: die Frau , der das Kind ihn gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives her
-TestLangGer: die Frau , der das Kind sie gibt
+TestLangGer: die Frau , die das Kind ihr gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives her
-TestLangGer: die Frau , die das Kind ihr gibt
+TestLangGer: die Frau , der das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , der das Kind das gibt
+TestLangGer: die Frau , die das Kind dem gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , der das Kind es gibt
+TestLangGer: die Frau , die das Kind ihm gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , die das Kind dem gibt
+TestLangGer: die Frau , der das Kind das gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron it_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives it
-TestLangGer: die Frau , die das Kind ihm gibt
+TestLangGer: die Frau , der das Kind es gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , der das Kind die gibt
+TestLangGer: die Frau , die das Kind denen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , der das Kind sie gibt
+TestLangGer: die Frau , die das Kind ihnen gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumPl))))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , die das Kind denen gibt
+TestLangGer: die Frau , der das Kind die gibt
 TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron they_Pron)))))))) NoVoc
 TestLangEng: the woman that the child gives them
-TestLangGer: die Frau , die das Kind ihnen gibt
+TestLangGer: die Frau , der das Kind sie gibt
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: who gives the woman the apple
-TestLangGer: wer gibt dem Apfel die Frau
+TestLangGer: wer gibt der Frau den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman the apple
-TestLangGer: wer gibt dem Apfel die Frau
+TestLangGer: wer gibt der Frau den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt dem die Frau
+TestLangGer: wer gibt der Frau das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (UsePron it_Pron))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt ihm die Frau
+TestLangGer: wer gibt es der Frau
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt dem die Frau
+TestLangGer: wer gibt der Frau das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: who gives the woman it
-TestLangGer: wer gibt ihm die Frau
+TestLangGer: wer gibt es der Frau
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))) NoVoc
 TestLangEng: who gives her the apple
-TestLangGer: wer gibt sie dem Apfel
+TestLangGer: wer gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her the apple
-TestLangGer: wer gibt sie dem Apfel
+TestLangGer: wer gibt ihr den Apfel
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (DetNP (DetQuant DefArt NumSg)))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie dem
+TestLangGer: wer gibt ihr das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash2V3 give_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie ihm
+TestLangGer: wer gibt es ihr
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (DetNP (DetQuant DefArt NumSg))) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie dem
+TestLangGer: wer gibt ihr das
 TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestVP whoSg_IP (ComplSlash (Slash3V3 give_V3 (UsePron it_Pron)) (UsePron she_Pron))))) NoVoc
 TestLangEng: who gives her it
-TestLangGer: wer gibt sie ihm
+TestLangGer: wer gibt es ihr
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))) NoVoc
 TestLangEng: the child sends the apple to the woman
 TestLangGer: das Kind schickt der Frau den Apfel

--- a/tests/german/examples.eng.txt
+++ b/tests/german/examples.eng.txt
@@ -1,0 +1,88 @@
+-- ditransitive give: give sb(indir=c2) sth(dir=c3)
+the child gives the woman the apple
+the child gives the woman it
+the child gives the woman him
+the child gives the woman her
+the child gives the woman them
+
+the child gives the apple to her
+the child gives the apple to him
+the child gives the apple to it
+the child gives the apple to them
+
+the child gives her the apple
+the child gives him the apple
+the child gives it the apple 
+the child gives them the apple
+
+the apple that the child gives to the women
+the apple that the child gives her
+the apple that it gives to the women
+the apple that it gives her
+the apple that it gives him
+the apple that it gives it
+the apple that it gives them
+
+the woman that the child gives the apple
+the woman that the child gives him
+the woman that the child gives her
+the woman that the child gives it
+the woman that the child gives them
+
+the woman that the child gives the apple to
+the woman that the child gives him to
+the woman that the child gives her to
+the woman that the child gives it to 
+the woman that the child gives them to 
+
+who gives the woman the apple
+who gives the woman it
+who gives it to the woman
+who gives her the apple
+who gives her it
+
+-- v3 = mkV3 v noPrep toPrep: send sth(dir=c2) to sb(indir=c3)
+the child sends the apple to the woman
+the child sends it to the woman
+the child sends him to the woman
+the child sends her to the woman
+the child sends them to the woman
+
+the child sends the apple to her
+the child sends the apple to him
+the child sends the apple to it
+the child sends the apple to them
+
+the child sends to her the apple
+the child sends to him the apple
+the child sends to it the apple 
+the child sends to them the apple
+
+the apple that the child sends to the women
+the apple that the child sends to her
+the apple that it sends to the women
+the apple that it sends to her
+the apple that it sends to him
+the apple that it sends to it
+the apple that it sends to them
+
+the woman that the child sends the apple to
+the woman that the child sends him to
+the woman that the child sends her to
+the woman that the child sends it to
+the woman that the child sends them to
+
+the woman who the child sends the apple to
+the woman who the child sends him to
+the woman who the child sends her to
+the woman who the child sends it to
+the woman who the child sends them to
+
+who sends to the woman the apple
+who sends to the woman it
+who sends to her the apple
+who sends to her it
+who sends the apple to the woman
+who sends it to the woman
+who sends the apple to her
+who sends it to her 

--- a/tests/german/examples.eng2ger.out
+++ b/tests/german/examples.eng2ger.out
@@ -1,131 +1,159 @@
+the child gives the woman the apple
+das Kind gibt der Frau den Apfel
+the child gives the woman the apple
+das Kind gibt der Frau den Apfel
+the child gives the woman it
+das Kind gibt der Frau das
+the child gives the woman it
+das Kind gibt es der Frau
+the child gives the woman it
+das Kind gibt der Frau das
+the child gives the woman it
+das Kind gibt es der Frau
+the child gives the woman him
+das Kind gibt ihn der Frau
+the child gives the woman him
+das Kind gibt ihn der Frau
+the child gives the woman her
+das Kind gibt sie der Frau
+the child gives the woman her
+das Kind gibt sie der Frau
+the child gives the woman them
+das Kind gibt der Frau die
+the child gives the woman them
+das Kind gibt sie der Frau
+the child gives the woman them
+das Kind gibt der Frau die
+the child gives the woman them
+das Kind gibt sie der Frau
 the child gives her the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihr den Apfel
 the child gives her the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihr den Apfel
 the child gives him the apple
-das Kind gibt ihn dem Apfel
+das Kind gibt ihm den Apfel
 the child gives him the apple
-das Kind gibt ihn dem Apfel
+das Kind gibt ihm den Apfel
 the child gives it the apple
-das Kind gibt dem Apfel das
+das Kind gibt dem den Apfel
 the child gives it the apple
-das Kind gibt es dem Apfel
+das Kind gibt ihm den Apfel
 the child gives it the apple
-das Kind gibt dem Apfel das
+das Kind gibt dem den Apfel
 the child gives it the apple
-das Kind gibt es dem Apfel
+das Kind gibt ihm den Apfel
 the child gives them the apple
-das Kind gibt dem Apfel die
+das Kind gibt denen den Apfel
 the child gives them the apple
-das Kind gibt sie dem Apfel
+das Kind gibt ihnen den Apfel
 the child gives them the apple
-das Kind gibt dem Apfel die
+das Kind gibt denen den Apfel
 the child gives them the apple
-das Kind gibt sie dem Apfel
-the apple that the child gives her
-der Apfel , dem das Kind sie gibt
+das Kind gibt ihnen den Apfel
 the apple that the child gives her
 der Apfel , den das Kind ihr gibt
-the apple that it gives her
-der Apfel , dem das sie gibt
+the apple that the child gives her
+der Apfel , dem das Kind sie gibt
 the apple that it gives her
 der Apfel , den das ihr gibt
 the apple that it gives her
-der Apfel , dem es sie gibt
+der Apfel , dem das sie gibt
 the apple that it gives her
 der Apfel , den es ihr gibt
-the apple that it gives him
-der Apfel , dem das ihn gibt
+the apple that it gives her
+der Apfel , dem es sie gibt
 the apple that it gives him
 der Apfel , den das ihm gibt
 the apple that it gives him
-der Apfel , dem es ihn gibt
+der Apfel , dem das ihn gibt
 the apple that it gives him
 der Apfel , den es ihm gibt
-the apple that it gives it
-der Apfel , dem das das gibt
-the apple that it gives it
-der Apfel , dem das es gibt
+the apple that it gives him
+der Apfel , dem es ihn gibt
 the apple that it gives it
 der Apfel , den das dem gibt
 the apple that it gives it
 der Apfel , den das ihm gibt
 the apple that it gives it
-der Apfel , dem es das gibt
+der Apfel , dem das das gibt
 the apple that it gives it
-der Apfel , dem es es gibt
+der Apfel , dem das es gibt
 the apple that it gives it
 der Apfel , den es dem gibt
 the apple that it gives it
 der Apfel , den es ihm gibt
-the apple that it gives them
-der Apfel , dem das die gibt
-the apple that it gives them
-der Apfel , dem das sie gibt
+the apple that it gives it
+der Apfel , dem es das gibt
+the apple that it gives it
+der Apfel , dem es es gibt
 the apple that it gives them
 der Apfel , den das denen gibt
 the apple that it gives them
 der Apfel , den das ihnen gibt
 the apple that it gives them
-der Apfel , dem es die gibt
+der Apfel , dem das die gibt
 the apple that it gives them
-der Apfel , dem es sie gibt
+der Apfel , dem das sie gibt
 the apple that it gives them
 der Apfel , den es denen gibt
 the apple that it gives them
 der Apfel , den es ihnen gibt
-the woman that the child gives the apple
-die Frau , der das Kind den Apfel gibt
+the apple that it gives them
+der Apfel , dem es die gibt
+the apple that it gives them
+der Apfel , dem es sie gibt
 the woman that the child gives the apple
 die Frau , die das Kind dem Apfel gibt
-the woman that the child gives him
-die Frau , der das Kind ihn gibt
+the woman that the child gives the apple
+die Frau , der das Kind den Apfel gibt
 the woman that the child gives him
 die Frau , die das Kind ihm gibt
-the woman that the child gives her
-die Frau , der das Kind sie gibt
+the woman that the child gives him
+die Frau , der das Kind ihn gibt
 the woman that the child gives her
 die Frau , die das Kind ihr gibt
-the woman that the child gives it
-die Frau , der das Kind das gibt
-the woman that the child gives it
-die Frau , der das Kind es gibt
+the woman that the child gives her
+die Frau , der das Kind sie gibt
 the woman that the child gives it
 die Frau , die das Kind dem gibt
 the woman that the child gives it
 die Frau , die das Kind ihm gibt
-the woman that the child gives them
-die Frau , der das Kind die gibt
-the woman that the child gives them
-die Frau , der das Kind sie gibt
+the woman that the child gives it
+die Frau , der das Kind das gibt
+the woman that the child gives it
+die Frau , der das Kind es gibt
 the woman that the child gives them
 die Frau , die das Kind denen gibt
 the woman that the child gives them
 die Frau , die das Kind ihnen gibt
+the woman that the child gives them
+die Frau , der das Kind die gibt
+the woman that the child gives them
+die Frau , der das Kind sie gibt
 who gives the woman the apple
-wer gibt dem Apfel die Frau
+wer gibt der Frau den Apfel
 who gives the woman the apple
-wer gibt dem Apfel die Frau
+wer gibt der Frau den Apfel
 who gives the woman it
-wer gibt dem die Frau
+wer gibt der Frau das
 who gives the woman it
-wer gibt ihm die Frau
+wer gibt es der Frau
 who gives the woman it
-wer gibt dem die Frau
+wer gibt der Frau das
 who gives the woman it
-wer gibt ihm die Frau
+wer gibt es der Frau
 who gives her the apple
-wer gibt sie dem Apfel
+wer gibt ihr den Apfel
 who gives her the apple
-wer gibt sie dem Apfel
+wer gibt ihr den Apfel
 who gives her it
-wer gibt sie dem
+wer gibt ihr das
 who gives her it
-wer gibt sie ihm
+wer gibt es ihr
 who gives her it
-wer gibt sie dem
+wer gibt ihr das
 who gives her it
-wer gibt sie ihm
+wer gibt es ihr
 the child sends the apple to the woman
 das Kind schickt der Frau den Apfel
 the child sends the apple to the woman

--- a/tests/german/examples.neg.out
+++ b/tests/german/examples.neg.out
@@ -37,16 +37,16 @@ TestLangEng: I send it to not her
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (PredetNP not_Predet (UsePron she_Pron))) (UsePron it_Pron))))) NoVoc
 TestLangGer: ich schicke es nicht ihr
 TestLangEng: I send it to not her
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't it give child he
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't the child give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't it give child he
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt das Kind ihn nicht
 TestLangEng: whom doesn't the child give him
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 anklagen_gen_V3 (DetNP (DetQuant IndefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN beer_N) (UsePron he_Pron))))))) NoVoc

--- a/tests/german/examples.pos.out
+++ b/tests/german/examples.pos.out
@@ -379,142 +379,142 @@ TestLangEng: I don't send the book to her
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))) (UsePron she_Pron))))) NoVoc
 TestLangGer: ich schicke ihr das Buch nicht
 TestLangEng: I don't send the book to her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple that it gives child the woman
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple that the child gives the woman
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple , that it gives child the woman
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N)))))))) NoVoc
 TestLangGer: der Apfel , den das Kind der Frau gibt
 TestLangEng: the apple , that the child gives the woman
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron)))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple that it gives child she
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple that the child gives her
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron she_Pron))))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple , that it gives child she
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron she_Pron))))))) NoVoc
 TestLangGer: der Apfel , den das Kind ihr gibt
 TestLangEng: the apple , that the child gives her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN apple_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron)))))))) NoVoc
 TestLangGer: der Apfel , den es ihr gibt
 TestLangEng: the apple that it gives her
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron she_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN apple_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron she_Pron))))))) NoVoc
 TestLangGer: der Apfel , den es ihr gibt
 TestLangEng: the apple , that it gives her
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman that it doesn't give child the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman that the child doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman , that it doesn't give child the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der das Kind den Apfel nicht gibt
 TestLangEng: the woman , that the child doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der es den Apfel nicht gibt
 TestLangEng: the woman that it doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der es den Apfel nicht gibt
 TestLangEng: the woman , that it doesn't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman that it doesn't give child he
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman that the child doesn't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman , that it doesn't give child he
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der das Kind ihn nicht gibt
 TestLangEng: the woman , that the child doesn't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman that they don't give children the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman that the children don't give the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman , that they don't give children the apple
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: die Frau , der die Kinder den Apfel nicht geben
 TestLangEng: the woman , that the children don't give the apple
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron)))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman that they don't give children he
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman that the children don't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash2V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetNP (DetQuant DefArt NumPl)) (Slash3V3 give_V3 (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN child_N) (UsePron he_Pron))))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman , that they don't give children he
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (DetCN (DetQuant DefArt NumPl) (UseN child_N)) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der die Kinder ihn nicht geben
 TestLangEng: the woman , that the children don't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der sie ihn nicht geben
 TestLangEng: the woman that they don't give him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron they_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der sie ihn nicht geben
 TestLangEng: the woman , that they don't give him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der es ihn gibt
 TestLangEng: the woman that it gives him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der es ihn gibt
 TestLangEng: the woman , that it gives him
-TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN woman_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))))) NoVoc
 TestLangGer: die Frau , der er ihn gibt
 TestLangEng: the woman that he gives him
-TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash2V3 give_V3 (UsePron he_Pron))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttNP (RelNP (DetCN (DetQuant DefArt NumSg) (UseN woman_N)) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron he_Pron) (Slash3V3 give_V3 (UsePron he_Pron))))))) NoVoc
 TestLangGer: die Frau , der er ihn gibt
 TestLangEng: the woman , that he gives him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't it give child the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't the child give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash2V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetNP (DetQuant DefArt NumSg)) (Slash3V3 give_V3 (MassNP (ApposCN (UseN child_N) (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't it give child the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (DetCN (DetQuant DefArt NumSg) (UseN child_N)) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt das Kind den Apfel nicht
 TestLangEng: whom doesn't the child give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt es den Apfel nicht
 TestLangEng: whom doesn't it give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN apple_N))))))) NoVoc
 TestLangGer: wem gibt es den Apfel nicht
 TestLangEng: whom doesn't it give the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt es ihn nicht
 TestLangEng: whom doesn't it give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (UsePron he_Pron)))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (UsePron he_Pron)))))) NoVoc
 TestLangGer: wem gibt es ihn nicht
 TestLangEng: whom doesn't it give him
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: wem gibt es nicht den Apfel
 TestLangEng: whom does it give not the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PPos (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN apple_N)))))))) NoVoc
 TestLangGer: wem gibt es nicht den Apfel
 TestLangEng: whom does it give not the apple
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoPl_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
 TestLangGer: wen gibt es der Frau nicht
 TestLangEng: whom doesn't it give the woman
-TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
+TestLang: PhrUtt NoPConj (UttQS (UseQCl (TTAnt TPres ASimul) PNeg (QuestSlash whoSg_IP (SlashVP (UsePron it_Pron) (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))))))) NoVoc
 TestLangGer: wen gibt es der Frau nicht
 TestLangEng: whom doesn't it give the woman
 TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash2V3 anklagen_gen_V3 (DetNP (DetQuant DefArt NumPl))) (DetCN (DetQuant IndefArt NumPl) (ApposCN (UseN man_N) (DetCN (DetQuant DefArt NumSg) (UseN beer_N)))))))) NoVoc

--- a/tests/german/examples.txt
+++ b/tests/german/examples.txt
@@ -331,3 +331,29 @@ ich bin nicht auf ihn neugierig            -- reject
 
 -- done
 
+-- Passive of VPSlash and V3
+
+sie gibt uns den Wagen                     -- accept
+
+der Wagen wird uns gegeben                 -- accept, via PassVPSlash or Pass2V3
+uns wird der Wagen gegeben                 -- accept, word order variant (not recognized)
+wir bekommen den Wagen gegeben             -- accept, via Pass3V3
+
+sie schickte uns den Wagen                 -- accept (Eng with prep)
+
+der Wagen wurde uns geschickt              -- accept, via PassVPSlash
+uns wurde der Wagen geschickt              -- accept, word order variant (not recognized)
+wir bekamen den Wagen geschickt            -- accept, via Pass3V3
+
+der Wagen würde uns geschickt werden       -- accept
+der Wagen würde uns nicht geschickt werden -- accept
+wir würden den Wagen geschickt bekommen    -- accept
+wir würden den Wagen nicht geschickt bekommen -- accept
+wir würden nicht den Wagen geschickt bekommen -- accept ?
+
+der Wagen sei uns geschickt worden         -- accept
+wir hätten den Wagen geschickt bekommen    -- accept
+
+wir wollen den Wagen geschickt bekommen    -- accept
+wir würden den Wagen geschickt bekommen wollen haben   -- accept
+

--- a/tests/german/infinitives.gfs
+++ b/tests/german/infinitives.gfs
@@ -1,0 +1,10 @@
+-- Use gf --run < V2V.gfs  or  gf> eh V2V.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
+? echo "remove infinitives.lin.tmp"
+? rm infinitives.lin.tmp
+? echo "linearizing infinitives.trees to infinitives.lin.tmp ... "
+rf -file="infinitives.trees" -lines -tree | l -lang="Ger,Eng" -treebank | wf -file="infinitives.lin.tmp" 
+--rf -file="infinitives.trees" -lines -tree | l -lang=Ger -table | wf -append -file="infinitives.lin.tmp" 
+? echo "diff infinitives.lin.out infinitives.lin.tmp" 
+? diff infinitives.lin.out1 infinitives.lin.tmp

--- a/tests/german/infinitives.gfs
+++ b/tests/german/infinitives.gfs
@@ -1,4 +1,4 @@
--- Use gf --run < V2V.gfs  or  gf> eh V2V.gfs 
+-- usage: gf --run < infinitives.gfs  or  gf> eh infinitives.gfs 
 --? echo "loading TestLangGer.gf and TestLangEng.gf ..."
 --i TestLangGer.gf TestLangEng.gf
 ? ls -l infinitives.lin.out infinitives.lin.tmp
@@ -10,5 +10,6 @@ rf -file="infinitives.trees" -lines -tree | l -lang=Ger -table | wf -file="infin
 ? ls -l infinitives.lin.out infinitives.lin.tmp
 ? echo "diff infinitives.lin.out infinitives.lin.tmp" 
 ? diff infinitives.lin.out infinitives.lin.tmp
-? echo "diff infinitives.lin.out.txt infinitives.lin.tmp.txt" 
-? diff infinitives.lin.out.txt infinitives.lin.tmp.txt
+? ls -l infinitives.lin.out.txt infinitives.lin.tmp.txt
+--? echo "diff infinitives.lin.out.txt infinitives.lin.tmp.txt" 
+--? diff infinitives.lin.out.txt infinitives.lin.tmp.txt

--- a/tests/german/infinitives.gfs
+++ b/tests/german/infinitives.gfs
@@ -1,10 +1,14 @@
 -- Use gf --run < V2V.gfs  or  gf> eh V2V.gfs 
 --? echo "loading TestLangGer.gf and TestLangEng.gf ..."
 --i TestLangGer.gf TestLangEng.gf
+? ls -l infinitives.lin.out infinitives.lin.tmp
 ? echo "remove infinitives.lin.tmp"
 ? rm infinitives.lin.tmp
 ? echo "linearizing infinitives.trees to infinitives.lin.tmp ... "
 rf -file="infinitives.trees" -lines -tree | l -lang="Ger,Eng" -treebank | wf -file="infinitives.lin.tmp" 
---rf -file="infinitives.trees" -lines -tree | l -lang=Ger -table | wf -append -file="infinitives.lin.tmp" 
+rf -file="infinitives.trees" -lines -tree | l -lang=Ger -table | wf -file="infinitives.lin.tmp.txt" 
+? ls -l infinitives.lin.out infinitives.lin.tmp
 ? echo "diff infinitives.lin.out infinitives.lin.tmp" 
-? diff infinitives.lin.out1 infinitives.lin.tmp
+? diff infinitives.lin.out infinitives.lin.tmp
+? echo "diff infinitives.lin.out.txt infinitives.lin.tmp.txt" 
+? diff infinitives.lin.out.txt infinitives.lin.tmp.txt

--- a/tests/german/infinitives.lin.out
+++ b/tests/german/infinitives.lin.out
@@ -223,6 +223,12 @@ TestLangEng: the book that we hadn't to read
 TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2)))))))
 TestLangGer: das Buch , das wir nicht wagten , zu lesen
 TestLangEng: the book that we didn't dare to read
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2)))))))
+TestLangGer: 
+TestLangEng: the book that we promise her to read
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP lassen_V2V (UsePron she_Pron) (SlashV2a read_V2)))))))
+TestLangGer: 
+TestLangEng: the book that we let her read
 TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
 TestLangGer: der Junge , den ich das Buch lesen lasse
 TestLangEng: the boy that I let read the book
@@ -236,5 +242,5 @@ TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAn
 TestLangGer: der Junge , dem ich verspreche , das Buch lesen zu wollen
 TestLangEng: the boy that I promise to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N))))))))))
-TestLangGer: ich weiß , dass sie sagte , , dass wir die Kinder Johann helfen lassen wollten , das Haus blau zu malen
+TestLangGer: ich weiß , dass sie sagte , dass wir die Kinder Johann helfen lassen wollten , das Haus blau zu malen
 TestLangEng: I know that she said that we wanted to let the children help John to paint the house blue

--- a/tests/german/infinitives.lin.out
+++ b/tests/german/infinitives.lin.out
@@ -1,0 +1,795 @@
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron))
+TestLangGer: ich verspreche euch , das Buch zu lesen
+TestLangEng: I promise you to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron))
+TestLangGer: ich lasse euch das Buch lesen
+TestLangEng: I let you read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , uns zu versprechen , das Buch zu lesen
+TestLangEng: I beg you to promise us to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich lasse dich uns versprechen , das Buch zu lesen
+TestLangEng: I let you promise us to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , uns das Buch lesen zu lassen
+TestLangEng: I beg you to let us read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich lasse dich uns das Buch lesen lassen
+TestLangEng: I let you let us read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich will das Buch lesen
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich wage , das Buch zu lesen
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich muss ihr versprechen , zu schlafen
+TestLangEng: I must promise her to sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich wage , ihr zu versprechen , zu schlafen
+TestLangEng: I dare to promise her to sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich muss sie schlafen lassen
+TestLangEng: I must let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich wage , sie schlafen zu lassen
+TestLangEng: I dare to let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))) (UsePron she_Pron)))
+TestLangGer: ich muss ihr versprechen , sie schlafen zu lassen
+TestLangEng: I must promise her to let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron)))
+TestLangGer: ich muss sie das Buch lesen lassen
+TestLangEng: I must let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron)))
+TestLangGer: ich will ihm versprechen , sie das Buch lesen zu lassen
+TestLangEng: I want to promise him to let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron))))
+TestLangGer: ich muss ihm versprechen wollen , sie das Buch lesen zu lassen
+TestLangEng: I must want to promise him to let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I must read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch lesen
+TestLangEng: I must read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich will das Buch lesen
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich wage , das Buch zu lesen
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss das Buch lesen wollen
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss wagen , das Buch zu lesen
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich will wagen , das Buch zu lesen
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich wage , das Buch lesen zu wollen
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: 
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+TestLangGer: ich muss wagen wollen , das Buch zu lesen
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: 
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: 
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+TestLangGer: ich muss wagen , das Buch lesen zu wollen
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich lasse ihn das Buch lesen
+TestLangEng: I let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich bitte ihn , das Buch zu lesen
+TestLangEng: I beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich verspreche ihm , das Buch zu lesen
+TestLangEng: I promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich bitte die , ihn das Buch lesen zu lassen
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron))
+TestLangGer: ich bitte sie , ihn das Buch lesen zu lassen
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich verspreche denen , ihn zu bitten , das Buch zu lesen
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron))
+TestLangGer: ich verspreche ihnen , ihn zu bitten , das Buch zu lesen
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron he_Pron))
+TestLangGer: ich bitte ihn , ihm zu versprechen , das Buch zu lesen
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron they_Pron) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: 
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
+TestLangGer: 
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron they_Pron) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: 
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
+TestLangGer: 
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: 
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: 
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , dich zu lieben
+TestLangEng: I beg you to love yourself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V warnen_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youPl_Pron))
+TestLangGer: ich warne euch , euch zu hassen
+TestLangEng: I warn you to hate yourselves
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich zu lieben
+TestLangEng: I promise her to love herself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ReflVP (SlashV2a love_V2)))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich lieben zu wollen
+TestLangEng: I promise her to want to love herself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2Vneg versprechen_dat_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
+TestLangGer: ich will sie bitten , dir zu versprechen , sich nicht zu hassen
+TestLangEng: I want to beg her to promise you not to hate yourself -- wrong: herself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich bei mir für es zu entschuldigen
+TestLangEng: I promise her to apologize for it itself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron))
+TestLangGer: ich verspreche uns , es mir zu geben
+TestLangEng: I promise us to give it itself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
+TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu lieben
+TestLangEng: I want to promise her to beg you to not love yourself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , dich bei dir für es zu entschuldigen
+TestLangEng: I beg you to apologize for it itself -- wrong: yourself
+TestLang: PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N))))))))))
+TestLangGer: ich weiß , dass sie sagte , , dass wir die Kinder Johann helfen lassen wollten , das Haus blau zu malen
+TestLangEng: I know that she said that we wanted to let the children help John to paint the house blue
+s MIndic Pres Simul Pos Main : ich verspreche euch , das Buch zu lesen
+s MIndic Pres Simul Pos Inv : verspreche ich euch , das Buch zu lesen
+s MIndic Pres Simul Pos Sub : ich euch verspreche , das Buch zu lesen
+s MIndic Pres Simul Neg Main : ich verspreche euch nicht , das Buch zu lesen
+s MIndic Pres Simul Neg Inv : verspreche ich euch nicht , das Buch zu lesen
+s MIndic Pres Simul Neg Sub : ich euch nicht verspreche , das Buch zu lesen
+s MIndic Pres Anter Pos Main : ich habe euch versprochen , das Buch zu lesen
+s MIndic Pres Anter Pos Inv : habe ich euch versprochen , das Buch zu lesen
+s MIndic Pres Anter Pos Sub : ich euch versprochen habe , das Buch zu lesen
+s MIndic Pres Anter Neg Main : ich habe euch nicht versprochen , das Buch zu lesen
+s MIndic Pres Anter Neg Inv : habe ich euch nicht versprochen , das Buch zu lesen
+s MIndic Pres Anter Neg Sub : ich euch nicht versprochen habe , das Buch zu lesen
+s MIndic Past Simul Pos Main : ich versprach euch , das Buch zu lesen
+s MIndic Past Simul Pos Inv : versprach ich euch , das Buch zu lesen
+s MIndic Past Simul Pos Sub : ich euch versprach , das Buch zu lesen
+s MIndic Past Simul Neg Main : ich versprach euch nicht , das Buch zu lesen
+s MIndic Past Simul Neg Inv : versprach ich euch nicht , das Buch zu lesen
+s MIndic Past Simul Neg Sub : ich euch nicht versprach , das Buch zu lesen
+s MIndic Past Anter Pos Main : ich hatte euch versprochen , das Buch zu lesen
+s MIndic Past Anter Pos Inv : hatte ich euch versprochen , das Buch zu lesen
+s MIndic Past Anter Pos Sub : ich euch versprochen hatte , das Buch zu lesen
+s MIndic Past Anter Neg Main : ich hatte euch nicht versprochen , das Buch zu lesen
+s MIndic Past Anter Neg Inv : hatte ich euch nicht versprochen , das Buch zu lesen
+s MIndic Past Anter Neg Sub : ich euch nicht versprochen hatte , das Buch zu lesen
+s MIndic Fut Simul Pos Main : ich werde euch versprechen , das Buch zu lesen
+s MIndic Fut Simul Pos Inv : werde ich euch versprechen , das Buch zu lesen
+s MIndic Fut Simul Pos Sub : ich euch versprechen werde , das Buch zu lesen
+s MIndic Fut Simul Neg Main : ich werde euch nicht versprechen , das Buch zu lesen
+s MIndic Fut Simul Neg Inv : werde ich euch nicht versprechen , das Buch zu lesen
+s MIndic Fut Simul Neg Sub : ich euch nicht versprechen werde , das Buch zu lesen
+s MIndic Fut Anter Pos Main : ich werde euch versprochen haben , das Buch zu lesen
+s MIndic Fut Anter Pos Inv : werde ich euch versprochen haben , das Buch zu lesen
+s MIndic Fut Anter Pos Sub : ich euch versprochen haben werde , das Buch zu lesen
+s MIndic Fut Anter Neg Main : ich werde euch nicht versprochen haben , das Buch zu lesen
+s MIndic Fut Anter Neg Inv : werde ich euch nicht versprochen haben , das Buch zu lesen
+s MIndic Fut Anter Neg Sub : ich euch nicht versprochen haben werde , das Buch zu lesen
+s MIndic Cond Simul Pos Main : ich würde euch versprechen , das Buch zu lesen
+s MIndic Cond Simul Pos Inv : würde ich euch versprechen , das Buch zu lesen
+s MIndic Cond Simul Pos Sub : ich euch versprechen würde , das Buch zu lesen
+s MIndic Cond Simul Neg Main : ich würde euch nicht versprechen , das Buch zu lesen
+s MIndic Cond Simul Neg Inv : würde ich euch nicht versprechen , das Buch zu lesen
+s MIndic Cond Simul Neg Sub : ich euch nicht versprechen würde , das Buch zu lesen
+s MIndic Cond Anter Pos Main : ich würde euch versprochen haben , das Buch zu lesen
+s MIndic Cond Anter Pos Inv : würde ich euch versprochen haben , das Buch zu lesen
+s MIndic Cond Anter Pos Sub : ich euch versprochen haben würde , das Buch zu lesen
+s MIndic Cond Anter Neg Main : ich würde euch nicht versprochen haben , das Buch zu lesen
+s MIndic Cond Anter Neg Inv : würde ich euch nicht versprochen haben , das Buch zu lesen
+s MIndic Cond Anter Neg Sub : ich euch nicht versprochen haben würde , das Buch zu lesen
+s MConjunct Pres Simul Pos Main : ich verspreche euch , das Buch zu lesen
+s MConjunct Pres Simul Pos Inv : verspreche ich euch , das Buch zu lesen
+s MConjunct Pres Simul Pos Sub : ich euch verspreche , das Buch zu lesen
+s MConjunct Pres Simul Neg Main : ich verspreche euch nicht , das Buch zu lesen
+s MConjunct Pres Simul Neg Inv : verspreche ich euch nicht , das Buch zu lesen
+s MConjunct Pres Simul Neg Sub : ich euch nicht verspreche , das Buch zu lesen
+s MConjunct Pres Anter Pos Main : ich habe euch versprochen , das Buch zu lesen
+s MConjunct Pres Anter Pos Inv : habe ich euch versprochen , das Buch zu lesen
+s MConjunct Pres Anter Pos Sub : ich euch versprochen habe , das Buch zu lesen
+s MConjunct Pres Anter Neg Main : ich habe euch nicht versprochen , das Buch zu lesen
+s MConjunct Pres Anter Neg Inv : habe ich euch nicht versprochen , das Buch zu lesen
+s MConjunct Pres Anter Neg Sub : ich euch nicht versprochen habe , das Buch zu lesen
+s MConjunct Past Simul Pos Main : ich verspräche euch , das Buch zu lesen
+s MConjunct Past Simul Pos Inv : verspräche ich euch , das Buch zu lesen
+s MConjunct Past Simul Pos Sub : ich euch verspräche , das Buch zu lesen
+s MConjunct Past Simul Neg Main : ich verspräche euch nicht , das Buch zu lesen
+s MConjunct Past Simul Neg Inv : verspräche ich euch nicht , das Buch zu lesen
+s MConjunct Past Simul Neg Sub : ich euch nicht verspräche , das Buch zu lesen
+s MConjunct Past Anter Pos Main : ich hätte euch versprochen , das Buch zu lesen
+s MConjunct Past Anter Pos Inv : hätte ich euch versprochen , das Buch zu lesen
+s MConjunct Past Anter Pos Sub : ich euch versprochen hätte , das Buch zu lesen
+s MConjunct Past Anter Neg Main : ich hätte euch nicht versprochen , das Buch zu lesen
+s MConjunct Past Anter Neg Inv : hätte ich euch nicht versprochen , das Buch zu lesen
+s MConjunct Past Anter Neg Sub : ich euch nicht versprochen hätte , das Buch zu lesen
+s MConjunct Fut Simul Pos Main : ich werde euch versprechen , das Buch zu lesen
+s MConjunct Fut Simul Pos Inv : werde ich euch versprechen , das Buch zu lesen
+s MConjunct Fut Simul Pos Sub : ich euch versprechen werde , das Buch zu lesen
+s MConjunct Fut Simul Neg Main : ich werde euch nicht versprechen , das Buch zu lesen
+s MConjunct Fut Simul Neg Inv : werde ich euch nicht versprechen , das Buch zu lesen
+s MConjunct Fut Simul Neg Sub : ich euch nicht versprechen werde , das Buch zu lesen
+s MConjunct Fut Anter Pos Main : ich werde euch versprochen haben , das Buch zu lesen
+s MConjunct Fut Anter Pos Inv : werde ich euch versprochen haben , das Buch zu lesen
+s MConjunct Fut Anter Pos Sub : ich euch versprochen haben werde , das Buch zu lesen
+s MConjunct Fut Anter Neg Main : ich werde euch nicht versprochen haben , das Buch zu lesen
+s MConjunct Fut Anter Neg Inv : werde ich euch nicht versprochen haben , das Buch zu lesen
+s MConjunct Fut Anter Neg Sub : ich euch nicht versprochen haben werde , das Buch zu lesen
+s MConjunct Cond Simul Pos Main : ich würde euch versprechen , das Buch zu lesen
+s MConjunct Cond Simul Pos Inv : würde ich euch versprechen , das Buch zu lesen
+s MConjunct Cond Simul Pos Sub : ich euch versprechen würde , das Buch zu lesen
+s MConjunct Cond Simul Neg Main : ich würde euch nicht versprechen , das Buch zu lesen
+s MConjunct Cond Simul Neg Inv : würde ich euch nicht versprechen , das Buch zu lesen
+s MConjunct Cond Simul Neg Sub : ich euch nicht versprechen würde , das Buch zu lesen
+s MConjunct Cond Anter Pos Main : ich würde euch versprochen haben , das Buch zu lesen
+s MConjunct Cond Anter Pos Inv : würde ich euch versprochen haben , das Buch zu lesen
+s MConjunct Cond Anter Pos Sub : ich euch versprochen haben würde , das Buch zu lesen
+s MConjunct Cond Anter Neg Main : ich würde euch nicht versprochen haben , das Buch zu lesen
+s MConjunct Cond Anter Neg Inv : würde ich euch nicht versprochen haben , das Buch zu lesen
+s MConjunct Cond Anter Neg Sub : ich euch nicht versprochen haben würde , das Buch zu lesen
+s MIndic Pres Simul Pos Main : ich lasse euch das Buch lesen
+s MIndic Pres Simul Pos Inv : lasse ich euch das Buch lesen
+s MIndic Pres Simul Pos Sub : ich euch das Buch lesen lasse
+s MIndic Pres Simul Neg Main : ich lasse euch nicht das Buch lesen
+s MIndic Pres Simul Neg Inv : lasse ich euch nicht das Buch lesen
+s MIndic Pres Simul Neg Sub : ich euch nicht das Buch lesen lasse
+s MIndic Pres Anter Pos Main : ich habe euch das Buch lesen lassen
+s MIndic Pres Anter Pos Inv : habe ich euch das Buch lesen lassen
+s MIndic Pres Anter Pos Sub : ich euch das Buch habe lesen lassen
+s MIndic Pres Anter Neg Main : ich habe euch nicht das Buch lesen lassen
+s MIndic Pres Anter Neg Inv : habe ich euch nicht das Buch lesen lassen
+s MIndic Pres Anter Neg Sub : ich euch nicht das Buch habe lesen lassen
+s MIndic Past Simul Pos Main : ich ließ euch das Buch lesen
+s MIndic Past Simul Pos Inv : ließ ich euch das Buch lesen
+s MIndic Past Simul Pos Sub : ich euch das Buch lesen ließ
+s MIndic Past Simul Neg Main : ich ließ euch nicht das Buch lesen
+s MIndic Past Simul Neg Inv : ließ ich euch nicht das Buch lesen
+s MIndic Past Simul Neg Sub : ich euch nicht das Buch lesen ließ
+s MIndic Past Anter Pos Main : ich hatte euch das Buch lesen lassen
+s MIndic Past Anter Pos Inv : hatte ich euch das Buch lesen lassen
+s MIndic Past Anter Pos Sub : ich euch das Buch hatte lesen lassen
+s MIndic Past Anter Neg Main : ich hatte euch nicht das Buch lesen lassen
+s MIndic Past Anter Neg Inv : hatte ich euch nicht das Buch lesen lassen
+s MIndic Past Anter Neg Sub : ich euch nicht das Buch hatte lesen lassen
+s MIndic Fut Simul Pos Main : ich werde euch das Buch lesen lassen
+s MIndic Fut Simul Pos Inv : werde ich euch das Buch lesen lassen
+s MIndic Fut Simul Pos Sub : ich euch das Buch lesen lassen werde
+s MIndic Fut Simul Neg Main : ich werde euch nicht das Buch lesen lassen
+s MIndic Fut Simul Neg Inv : werde ich euch nicht das Buch lesen lassen
+s MIndic Fut Simul Neg Sub : ich euch nicht das Buch lesen lassen werde
+s MIndic Fut Anter Pos Main : ich werde euch das Buch haben lesen lassen
+s MIndic Fut Anter Pos Inv : werde ich euch das Buch haben lesen lassen
+s MIndic Fut Anter Pos Sub : ich euch das Buch werde haben lesen lassen
+s MIndic Fut Anter Neg Main : ich werde euch nicht das Buch haben lesen lassen
+s MIndic Fut Anter Neg Inv : werde ich euch nicht das Buch haben lesen lassen
+s MIndic Fut Anter Neg Sub : ich euch nicht das Buch werde haben lesen lassen
+s MIndic Cond Simul Pos Main : ich würde euch das Buch lesen lassen
+s MIndic Cond Simul Pos Inv : würde ich euch das Buch lesen lassen
+s MIndic Cond Simul Pos Sub : ich euch das Buch lesen lassen würde
+s MIndic Cond Simul Neg Main : ich würde euch nicht das Buch lesen lassen
+s MIndic Cond Simul Neg Inv : würde ich euch nicht das Buch lesen lassen
+s MIndic Cond Simul Neg Sub : ich euch nicht das Buch lesen lassen würde
+s MIndic Cond Anter Pos Main : ich würde euch das Buch haben lesen lassen
+s MIndic Cond Anter Pos Inv : würde ich euch das Buch haben lesen lassen
+s MIndic Cond Anter Pos Sub : ich euch das Buch würde haben lesen lassen
+s MIndic Cond Anter Neg Main : ich würde euch nicht das Buch haben lesen lassen
+s MIndic Cond Anter Neg Inv : würde ich euch nicht das Buch haben lesen lassen
+s MIndic Cond Anter Neg Sub : ich euch nicht das Buch würde haben lesen lassen
+s MConjunct Pres Simul Pos Main : ich lasse euch das Buch lesen
+s MConjunct Pres Simul Pos Inv : lasse ich euch das Buch lesen
+s MConjunct Pres Simul Pos Sub : ich euch das Buch lesen lasse
+s MConjunct Pres Simul Neg Main : ich lasse euch nicht das Buch lesen
+s MConjunct Pres Simul Neg Inv : lasse ich euch nicht das Buch lesen
+s MConjunct Pres Simul Neg Sub : ich euch nicht das Buch lesen lasse
+s MConjunct Pres Anter Pos Main : ich habe euch das Buch lesen lassen
+s MConjunct Pres Anter Pos Inv : habe ich euch das Buch lesen lassen
+s MConjunct Pres Anter Pos Sub : ich euch das Buch habe lesen lassen
+s MConjunct Pres Anter Neg Main : ich habe euch nicht das Buch lesen lassen
+s MConjunct Pres Anter Neg Inv : habe ich euch nicht das Buch lesen lassen
+s MConjunct Pres Anter Neg Sub : ich euch nicht das Buch habe lesen lassen
+s MConjunct Past Simul Pos Main : ich ließe euch das Buch lesen
+s MConjunct Past Simul Pos Inv : ließe ich euch das Buch lesen
+s MConjunct Past Simul Pos Sub : ich euch das Buch lesen ließe
+s MConjunct Past Simul Neg Main : ich ließe euch nicht das Buch lesen
+s MConjunct Past Simul Neg Inv : ließe ich euch nicht das Buch lesen
+s MConjunct Past Simul Neg Sub : ich euch nicht das Buch lesen ließe
+s MConjunct Past Anter Pos Main : ich hätte euch das Buch lesen lassen
+s MConjunct Past Anter Pos Inv : hätte ich euch das Buch lesen lassen
+s MConjunct Past Anter Pos Sub : ich euch das Buch hätte lesen lassen
+s MConjunct Past Anter Neg Main : ich hätte euch nicht das Buch lesen lassen
+s MConjunct Past Anter Neg Inv : hätte ich euch nicht das Buch lesen lassen
+s MConjunct Past Anter Neg Sub : ich euch nicht das Buch hätte lesen lassen
+s MConjunct Fut Simul Pos Main : ich werde euch das Buch lesen lassen
+s MConjunct Fut Simul Pos Inv : werde ich euch das Buch lesen lassen
+s MConjunct Fut Simul Pos Sub : ich euch das Buch lesen lassen werde
+s MConjunct Fut Simul Neg Main : ich werde euch nicht das Buch lesen lassen
+s MConjunct Fut Simul Neg Inv : werde ich euch nicht das Buch lesen lassen
+s MConjunct Fut Simul Neg Sub : ich euch nicht das Buch lesen lassen werde
+s MConjunct Fut Anter Pos Main : ich werde euch das Buch haben lesen lassen
+s MConjunct Fut Anter Pos Inv : werde ich euch das Buch haben lesen lassen
+s MConjunct Fut Anter Pos Sub : ich euch das Buch werde haben lesen lassen
+s MConjunct Fut Anter Neg Main : ich werde euch nicht das Buch haben lesen lassen
+s MConjunct Fut Anter Neg Inv : werde ich euch nicht das Buch haben lesen lassen
+s MConjunct Fut Anter Neg Sub : ich euch nicht das Buch werde haben lesen lassen
+s MConjunct Cond Simul Pos Main : ich würde euch das Buch lesen lassen
+s MConjunct Cond Simul Pos Inv : würde ich euch das Buch lesen lassen
+s MConjunct Cond Simul Pos Sub : ich euch das Buch lesen lassen würde
+s MConjunct Cond Simul Neg Main : ich würde euch nicht das Buch lesen lassen
+s MConjunct Cond Simul Neg Inv : würde ich euch nicht das Buch lesen lassen
+s MConjunct Cond Simul Neg Sub : ich euch nicht das Buch lesen lassen würde
+s MConjunct Cond Anter Pos Main : ich würde euch das Buch haben lesen lassen
+s MConjunct Cond Anter Pos Inv : würde ich euch das Buch haben lesen lassen
+s MConjunct Cond Anter Pos Sub : ich euch das Buch würde haben lesen lassen
+s MConjunct Cond Anter Neg Main : ich würde euch nicht das Buch haben lesen lassen
+s MConjunct Cond Anter Neg Inv : würde ich euch nicht das Buch haben lesen lassen
+s MConjunct Cond Anter Neg Sub : ich euch nicht das Buch würde haben lesen lassen
+s MIndic Pres Simul Pos Main : ich bitte dich , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Pos Inv : bitte ich dich , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Pos Sub : ich dich bitte , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Neg Main : ich bitte dich nicht , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Neg Inv : bitte ich dich nicht , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Neg Sub : ich dich nicht bitte , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Pos Main : ich habe dich gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Pos Inv : habe ich dich gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Pos Sub : ich dich gebeten habe , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Neg Main : ich habe dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Neg Inv : habe ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Anter Neg Sub : ich dich nicht gebeten habe , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Pos Main : ich bat dich , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Pos Inv : bat ich dich , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Pos Sub : ich dich bat , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Neg Main : ich bat dich nicht , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Neg Inv : bat ich dich nicht , uns zu versprechen , das Buch zu lesen
+s MIndic Past Simul Neg Sub : ich dich nicht bat , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Pos Main : ich hatte dich gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Pos Inv : hatte ich dich gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Pos Sub : ich dich gebeten hatte , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Neg Main : ich hatte dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Neg Inv : hatte ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MIndic Past Anter Neg Sub : ich dich nicht gebeten hatte , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Pos Main : ich werde dich bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Pos Inv : werde ich dich bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Pos Sub : ich dich bitten werde , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Neg Main : ich werde dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Neg Inv : werde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Simul Neg Sub : ich dich nicht bitten werde , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Pos Main : ich werde dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Pos Inv : werde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Pos Sub : ich dich gebeten haben werde , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Pos Main : ich würde dich bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Pos Inv : würde ich dich bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Pos Sub : ich dich bitten würde , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Neg Main : ich würde dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Neg Inv : würde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Simul Neg Sub : ich dich nicht bitten würde , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Pos Main : ich würde dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Pos Inv : würde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Pos Sub : ich dich gebeten haben würde , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MIndic Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Pos Main : ich bitte dich , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Pos Inv : bitte ich dich , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Pos Sub : ich dich bitte , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Neg Main : ich bitte dich nicht , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Neg Inv : bitte ich dich nicht , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Simul Neg Sub : ich dich nicht bitte , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Pos Main : ich habe dich gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Pos Inv : habe ich dich gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Pos Sub : ich dich gebeten habe , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Neg Main : ich habe dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Neg Inv : habe ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Pres Anter Neg Sub : ich dich nicht gebeten habe , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Pos Main : ich bäte dich , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Pos Inv : bäte ich dich , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Pos Sub : ich dich bäte , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Neg Main : ich bäte dich nicht , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Neg Inv : bäte ich dich nicht , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Simul Neg Sub : ich dich nicht bäte , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Pos Main : ich hätte dich gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Pos Inv : hätte ich dich gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Pos Sub : ich dich gebeten hätte , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Neg Main : ich hätte dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Neg Inv : hätte ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
+s MConjunct Past Anter Neg Sub : ich dich nicht gebeten hätte , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Pos Main : ich werde dich bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Pos Inv : werde ich dich bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Pos Sub : ich dich bitten werde , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Neg Main : ich werde dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Neg Inv : werde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Simul Neg Sub : ich dich nicht bitten werde , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Pos Main : ich werde dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Pos Inv : werde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Pos Sub : ich dich gebeten haben werde , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Pos Main : ich würde dich bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Pos Inv : würde ich dich bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Pos Sub : ich dich bitten würde , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Neg Main : ich würde dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Neg Inv : würde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Simul Neg Sub : ich dich nicht bitten würde , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Pos Main : ich würde dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Pos Inv : würde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Pos Sub : ich dich gebeten haben würde , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
+s MConjunct Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns zu versprechen , das Buch zu lesen
+s MIndic Pres Simul Pos Main : ich lasse dich uns versprechen , das Buch zu lesen
+s MIndic Pres Simul Pos Inv : lasse ich dich uns versprechen , das Buch zu lesen
+s MIndic Pres Simul Pos Sub : ich dich uns versprechen lasse , das Buch zu lesen
+s MIndic Pres Simul Neg Main : ich lasse dich nicht uns versprechen , das Buch zu lesen
+s MIndic Pres Simul Neg Inv : lasse ich dich nicht uns versprechen , das Buch zu lesen
+s MIndic Pres Simul Neg Sub : ich dich nicht uns versprechen lasse , das Buch zu lesen
+s MIndic Pres Anter Pos Main : ich habe dich uns versprechen lassen , das Buch zu lesen
+s MIndic Pres Anter Pos Inv : habe ich dich uns versprechen lassen , das Buch zu lesen
+s MIndic Pres Anter Pos Sub : ich dich uns habe versprechen lassen , das Buch zu lesen
+s MIndic Pres Anter Neg Main : ich habe dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Pres Anter Neg Inv : habe ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Pres Anter Neg Sub : ich dich nicht uns habe versprechen lassen , das Buch zu lesen
+s MIndic Past Simul Pos Main : ich ließ dich uns versprechen , das Buch zu lesen
+s MIndic Past Simul Pos Inv : ließ ich dich uns versprechen , das Buch zu lesen
+s MIndic Past Simul Pos Sub : ich dich uns versprechen ließ , das Buch zu lesen
+s MIndic Past Simul Neg Main : ich ließ dich nicht uns versprechen , das Buch zu lesen
+s MIndic Past Simul Neg Inv : ließ ich dich nicht uns versprechen , das Buch zu lesen
+s MIndic Past Simul Neg Sub : ich dich nicht uns versprechen ließ , das Buch zu lesen
+s MIndic Past Anter Pos Main : ich hatte dich uns versprechen lassen , das Buch zu lesen
+s MIndic Past Anter Pos Inv : hatte ich dich uns versprechen lassen , das Buch zu lesen
+s MIndic Past Anter Pos Sub : ich dich uns hatte versprechen lassen , das Buch zu lesen
+s MIndic Past Anter Neg Main : ich hatte dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Past Anter Neg Inv : hatte ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Past Anter Neg Sub : ich dich nicht uns hatte versprechen lassen , das Buch zu lesen
+s MIndic Fut Simul Pos Main : ich werde dich uns versprechen lassen , das Buch zu lesen
+s MIndic Fut Simul Pos Inv : werde ich dich uns versprechen lassen , das Buch zu lesen
+s MIndic Fut Simul Pos Sub : ich dich uns versprechen lassen werde , das Buch zu lesen
+s MIndic Fut Simul Neg Main : ich werde dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Fut Simul Neg Inv : werde ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Fut Simul Neg Sub : ich dich nicht uns versprechen lassen werde , das Buch zu lesen
+s MIndic Fut Anter Pos Main : ich werde dich uns haben versprechen lassen , das Buch zu lesen
+s MIndic Fut Anter Pos Inv : werde ich dich uns haben versprechen lassen , das Buch zu lesen
+s MIndic Fut Anter Pos Sub : ich dich uns werde haben versprechen lassen , das Buch zu lesen
+s MIndic Fut Anter Neg Main : ich werde dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MIndic Fut Anter Neg Inv : werde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MIndic Fut Anter Neg Sub : ich dich nicht uns werde haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Simul Pos Main : ich würde dich uns versprechen lassen , das Buch zu lesen
+s MIndic Cond Simul Pos Inv : würde ich dich uns versprechen lassen , das Buch zu lesen
+s MIndic Cond Simul Pos Sub : ich dich uns versprechen lassen würde , das Buch zu lesen
+s MIndic Cond Simul Neg Main : ich würde dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Cond Simul Neg Inv : würde ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MIndic Cond Simul Neg Sub : ich dich nicht uns versprechen lassen würde , das Buch zu lesen
+s MIndic Cond Anter Pos Main : ich würde dich uns haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Anter Pos Inv : würde ich dich uns haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Anter Pos Sub : ich dich uns würde haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Anter Neg Main : ich würde dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Anter Neg Inv : würde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MIndic Cond Anter Neg Sub : ich dich nicht uns würde haben versprechen lassen , das Buch zu lesen
+s MConjunct Pres Simul Pos Main : ich lasse dich uns versprechen , das Buch zu lesen
+s MConjunct Pres Simul Pos Inv : lasse ich dich uns versprechen , das Buch zu lesen
+s MConjunct Pres Simul Pos Sub : ich dich uns versprechen lasse , das Buch zu lesen
+s MConjunct Pres Simul Neg Main : ich lasse dich nicht uns versprechen , das Buch zu lesen
+s MConjunct Pres Simul Neg Inv : lasse ich dich nicht uns versprechen , das Buch zu lesen
+s MConjunct Pres Simul Neg Sub : ich dich nicht uns versprechen lasse , das Buch zu lesen
+s MConjunct Pres Anter Pos Main : ich habe dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Pres Anter Pos Inv : habe ich dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Pres Anter Pos Sub : ich dich uns habe versprechen lassen , das Buch zu lesen
+s MConjunct Pres Anter Neg Main : ich habe dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Pres Anter Neg Inv : habe ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Pres Anter Neg Sub : ich dich nicht uns habe versprechen lassen , das Buch zu lesen
+s MConjunct Past Simul Pos Main : ich ließe dich uns versprechen , das Buch zu lesen
+s MConjunct Past Simul Pos Inv : ließe ich dich uns versprechen , das Buch zu lesen
+s MConjunct Past Simul Pos Sub : ich dich uns versprechen ließe , das Buch zu lesen
+s MConjunct Past Simul Neg Main : ich ließe dich nicht uns versprechen , das Buch zu lesen
+s MConjunct Past Simul Neg Inv : ließe ich dich nicht uns versprechen , das Buch zu lesen
+s MConjunct Past Simul Neg Sub : ich dich nicht uns versprechen ließe , das Buch zu lesen
+s MConjunct Past Anter Pos Main : ich hätte dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Past Anter Pos Inv : hätte ich dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Past Anter Pos Sub : ich dich uns hätte versprechen lassen , das Buch zu lesen
+s MConjunct Past Anter Neg Main : ich hätte dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Past Anter Neg Inv : hätte ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Past Anter Neg Sub : ich dich nicht uns hätte versprechen lassen , das Buch zu lesen
+s MConjunct Fut Simul Pos Main : ich werde dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Fut Simul Pos Inv : werde ich dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Fut Simul Pos Sub : ich dich uns versprechen lassen werde , das Buch zu lesen
+s MConjunct Fut Simul Neg Main : ich werde dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Fut Simul Neg Inv : werde ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Fut Simul Neg Sub : ich dich nicht uns versprechen lassen werde , das Buch zu lesen
+s MConjunct Fut Anter Pos Main : ich werde dich uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Fut Anter Pos Inv : werde ich dich uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Fut Anter Pos Sub : ich dich uns werde haben versprechen lassen , das Buch zu lesen
+s MConjunct Fut Anter Neg Main : ich werde dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Fut Anter Neg Inv : werde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Fut Anter Neg Sub : ich dich nicht uns werde haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Simul Pos Main : ich würde dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Cond Simul Pos Inv : würde ich dich uns versprechen lassen , das Buch zu lesen
+s MConjunct Cond Simul Pos Sub : ich dich uns versprechen lassen würde , das Buch zu lesen
+s MConjunct Cond Simul Neg Main : ich würde dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Cond Simul Neg Inv : würde ich dich nicht uns versprechen lassen , das Buch zu lesen
+s MConjunct Cond Simul Neg Sub : ich dich nicht uns versprechen lassen würde , das Buch zu lesen
+s MConjunct Cond Anter Pos Main : ich würde dich uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Anter Pos Inv : würde ich dich uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Anter Pos Sub : ich dich uns würde haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Anter Neg Main : ich würde dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Anter Neg Inv : würde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
+s MConjunct Cond Anter Neg Sub : ich dich nicht uns würde haben versprechen lassen , das Buch zu lesen
+s MIndic Pres Simul Pos Main : ich bitte dich , uns das Buch lesen zu lassen
+s MIndic Pres Simul Pos Inv : bitte ich dich , uns das Buch lesen zu lassen
+s MIndic Pres Simul Pos Sub : ich dich bitte , uns das Buch lesen zu lassen
+s MIndic Pres Simul Neg Main : ich bitte dich nicht , uns das Buch lesen zu lassen
+s MIndic Pres Simul Neg Inv : bitte ich dich nicht , uns das Buch lesen zu lassen
+s MIndic Pres Simul Neg Sub : ich dich nicht bitte , uns das Buch lesen zu lassen
+s MIndic Pres Anter Pos Main : ich habe dich gebeten , uns das Buch lesen zu lassen
+s MIndic Pres Anter Pos Inv : habe ich dich gebeten , uns das Buch lesen zu lassen
+s MIndic Pres Anter Pos Sub : ich dich gebeten habe , uns das Buch lesen zu lassen
+s MIndic Pres Anter Neg Main : ich habe dich nicht gebeten , uns das Buch lesen zu lassen
+s MIndic Pres Anter Neg Inv : habe ich dich nicht gebeten , uns das Buch lesen zu lassen
+s MIndic Pres Anter Neg Sub : ich dich nicht gebeten habe , uns das Buch lesen zu lassen
+s MIndic Past Simul Pos Main : ich bat dich , uns das Buch lesen zu lassen
+s MIndic Past Simul Pos Inv : bat ich dich , uns das Buch lesen zu lassen
+s MIndic Past Simul Pos Sub : ich dich bat , uns das Buch lesen zu lassen
+s MIndic Past Simul Neg Main : ich bat dich nicht , uns das Buch lesen zu lassen
+s MIndic Past Simul Neg Inv : bat ich dich nicht , uns das Buch lesen zu lassen
+s MIndic Past Simul Neg Sub : ich dich nicht bat , uns das Buch lesen zu lassen
+s MIndic Past Anter Pos Main : ich hatte dich gebeten , uns das Buch lesen zu lassen
+s MIndic Past Anter Pos Inv : hatte ich dich gebeten , uns das Buch lesen zu lassen
+s MIndic Past Anter Pos Sub : ich dich gebeten hatte , uns das Buch lesen zu lassen
+s MIndic Past Anter Neg Main : ich hatte dich nicht gebeten , uns das Buch lesen zu lassen
+s MIndic Past Anter Neg Inv : hatte ich dich nicht gebeten , uns das Buch lesen zu lassen
+s MIndic Past Anter Neg Sub : ich dich nicht gebeten hatte , uns das Buch lesen zu lassen
+s MIndic Fut Simul Pos Main : ich werde dich bitten , uns das Buch lesen zu lassen
+s MIndic Fut Simul Pos Inv : werde ich dich bitten , uns das Buch lesen zu lassen
+s MIndic Fut Simul Pos Sub : ich dich bitten werde , uns das Buch lesen zu lassen
+s MIndic Fut Simul Neg Main : ich werde dich nicht bitten , uns das Buch lesen zu lassen
+s MIndic Fut Simul Neg Inv : werde ich dich nicht bitten , uns das Buch lesen zu lassen
+s MIndic Fut Simul Neg Sub : ich dich nicht bitten werde , uns das Buch lesen zu lassen
+s MIndic Fut Anter Pos Main : ich werde dich gebeten haben , uns das Buch lesen zu lassen
+s MIndic Fut Anter Pos Inv : werde ich dich gebeten haben , uns das Buch lesen zu lassen
+s MIndic Fut Anter Pos Sub : ich dich gebeten haben werde , uns das Buch lesen zu lassen
+s MIndic Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MIndic Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MIndic Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns das Buch lesen zu lassen
+s MIndic Cond Simul Pos Main : ich würde dich bitten , uns das Buch lesen zu lassen
+s MIndic Cond Simul Pos Inv : würde ich dich bitten , uns das Buch lesen zu lassen
+s MIndic Cond Simul Pos Sub : ich dich bitten würde , uns das Buch lesen zu lassen
+s MIndic Cond Simul Neg Main : ich würde dich nicht bitten , uns das Buch lesen zu lassen
+s MIndic Cond Simul Neg Inv : würde ich dich nicht bitten , uns das Buch lesen zu lassen
+s MIndic Cond Simul Neg Sub : ich dich nicht bitten würde , uns das Buch lesen zu lassen
+s MIndic Cond Anter Pos Main : ich würde dich gebeten haben , uns das Buch lesen zu lassen
+s MIndic Cond Anter Pos Inv : würde ich dich gebeten haben , uns das Buch lesen zu lassen
+s MIndic Cond Anter Pos Sub : ich dich gebeten haben würde , uns das Buch lesen zu lassen
+s MIndic Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MIndic Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MIndic Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Pos Main : ich bitte dich , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Pos Inv : bitte ich dich , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Pos Sub : ich dich bitte , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Neg Main : ich bitte dich nicht , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Neg Inv : bitte ich dich nicht , uns das Buch lesen zu lassen
+s MConjunct Pres Simul Neg Sub : ich dich nicht bitte , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Pos Main : ich habe dich gebeten , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Pos Inv : habe ich dich gebeten , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Pos Sub : ich dich gebeten habe , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Neg Main : ich habe dich nicht gebeten , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Neg Inv : habe ich dich nicht gebeten , uns das Buch lesen zu lassen
+s MConjunct Pres Anter Neg Sub : ich dich nicht gebeten habe , uns das Buch lesen zu lassen
+s MConjunct Past Simul Pos Main : ich bäte dich , uns das Buch lesen zu lassen
+s MConjunct Past Simul Pos Inv : bäte ich dich , uns das Buch lesen zu lassen
+s MConjunct Past Simul Pos Sub : ich dich bäte , uns das Buch lesen zu lassen
+s MConjunct Past Simul Neg Main : ich bäte dich nicht , uns das Buch lesen zu lassen
+s MConjunct Past Simul Neg Inv : bäte ich dich nicht , uns das Buch lesen zu lassen
+s MConjunct Past Simul Neg Sub : ich dich nicht bäte , uns das Buch lesen zu lassen
+s MConjunct Past Anter Pos Main : ich hätte dich gebeten , uns das Buch lesen zu lassen
+s MConjunct Past Anter Pos Inv : hätte ich dich gebeten , uns das Buch lesen zu lassen
+s MConjunct Past Anter Pos Sub : ich dich gebeten hätte , uns das Buch lesen zu lassen
+s MConjunct Past Anter Neg Main : ich hätte dich nicht gebeten , uns das Buch lesen zu lassen
+s MConjunct Past Anter Neg Inv : hätte ich dich nicht gebeten , uns das Buch lesen zu lassen
+s MConjunct Past Anter Neg Sub : ich dich nicht gebeten hätte , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Pos Main : ich werde dich bitten , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Pos Inv : werde ich dich bitten , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Pos Sub : ich dich bitten werde , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Neg Main : ich werde dich nicht bitten , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Neg Inv : werde ich dich nicht bitten , uns das Buch lesen zu lassen
+s MConjunct Fut Simul Neg Sub : ich dich nicht bitten werde , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Pos Main : ich werde dich gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Pos Inv : werde ich dich gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Pos Sub : ich dich gebeten haben werde , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Pos Main : ich würde dich bitten , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Pos Inv : würde ich dich bitten , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Pos Sub : ich dich bitten würde , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Neg Main : ich würde dich nicht bitten , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Neg Inv : würde ich dich nicht bitten , uns das Buch lesen zu lassen
+s MConjunct Cond Simul Neg Sub : ich dich nicht bitten würde , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Pos Main : ich würde dich gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Pos Inv : würde ich dich gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Pos Sub : ich dich gebeten haben würde , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
+s MConjunct Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns das Buch lesen zu lassen
+s MIndic Pres Simul Pos Main : ich lasse dich uns das Buch lesen lassen
+s MIndic Pres Simul Pos Inv : lasse ich dich uns das Buch lesen lassen
+s MIndic Pres Simul Pos Sub : ich dich uns das Buch lesen lassen lasse
+s MIndic Pres Simul Neg Main : ich lasse dich nicht uns das Buch lesen lassen
+s MIndic Pres Simul Neg Inv : lasse ich dich nicht uns das Buch lesen lassen
+s MIndic Pres Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lasse
+s MIndic Pres Anter Pos Main : ich habe dich uns das Buch lesen lassen lassen
+s MIndic Pres Anter Pos Inv : habe ich dich uns das Buch lesen lassen lassen
+s MIndic Pres Anter Pos Sub : ich dich uns das Buch lesen habe lassen lassen
+s MIndic Pres Anter Neg Main : ich habe dich nicht uns das Buch lesen lassen lassen
+s MIndic Pres Anter Neg Inv : habe ich dich nicht uns das Buch lesen lassen lassen
+s MIndic Pres Anter Neg Sub : ich dich nicht uns das Buch lesen habe lassen lassen
+s MIndic Past Simul Pos Main : ich ließ dich uns das Buch lesen lassen
+s MIndic Past Simul Pos Inv : ließ ich dich uns das Buch lesen lassen
+s MIndic Past Simul Pos Sub : ich dich uns das Buch lesen lassen ließ
+s MIndic Past Simul Neg Main : ich ließ dich nicht uns das Buch lesen lassen
+s MIndic Past Simul Neg Inv : ließ ich dich nicht uns das Buch lesen lassen
+s MIndic Past Simul Neg Sub : ich dich nicht uns das Buch lesen lassen ließ
+s MIndic Past Anter Pos Main : ich hatte dich uns das Buch lesen lassen lassen
+s MIndic Past Anter Pos Inv : hatte ich dich uns das Buch lesen lassen lassen
+s MIndic Past Anter Pos Sub : ich dich uns das Buch lesen hatte lassen lassen
+s MIndic Past Anter Neg Main : ich hatte dich nicht uns das Buch lesen lassen lassen
+s MIndic Past Anter Neg Inv : hatte ich dich nicht uns das Buch lesen lassen lassen
+s MIndic Past Anter Neg Sub : ich dich nicht uns das Buch lesen hatte lassen lassen
+s MIndic Fut Simul Pos Main : ich werde dich uns das Buch lesen lassen lassen
+s MIndic Fut Simul Pos Inv : werde ich dich uns das Buch lesen lassen lassen
+s MIndic Fut Simul Pos Sub : ich dich uns das Buch lesen lassen lassen werde
+s MIndic Fut Simul Neg Main : ich werde dich nicht uns das Buch lesen lassen lassen
+s MIndic Fut Simul Neg Inv : werde ich dich nicht uns das Buch lesen lassen lassen
+s MIndic Fut Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen werde
+s MIndic Fut Anter Pos Main : ich werde dich uns haben das Buch lesen lassen lassen
+s MIndic Fut Anter Pos Inv : werde ich dich uns haben das Buch lesen lassen lassen
+s MIndic Fut Anter Pos Sub : ich dich uns werde haben das Buch lesen lassen lassen
+s MIndic Fut Anter Neg Main : ich werde dich nicht uns haben das Buch lesen lassen lassen
+s MIndic Fut Anter Neg Inv : werde ich dich nicht uns haben das Buch lesen lassen lassen
+s MIndic Fut Anter Neg Sub : ich dich nicht uns werde haben das Buch lesen lassen lassen
+s MIndic Cond Simul Pos Main : ich würde dich uns das Buch lesen lassen lassen
+s MIndic Cond Simul Pos Inv : würde ich dich uns das Buch lesen lassen lassen
+s MIndic Cond Simul Pos Sub : ich dich uns das Buch lesen lassen lassen würde
+s MIndic Cond Simul Neg Main : ich würde dich nicht uns das Buch lesen lassen lassen
+s MIndic Cond Simul Neg Inv : würde ich dich nicht uns das Buch lesen lassen lassen
+s MIndic Cond Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen würde
+s MIndic Cond Anter Pos Main : ich würde dich uns haben das Buch lesen lassen lassen
+s MIndic Cond Anter Pos Inv : würde ich dich uns haben das Buch lesen lassen lassen
+s MIndic Cond Anter Pos Sub : ich dich uns würde haben das Buch lesen lassen lassen
+s MIndic Cond Anter Neg Main : ich würde dich nicht uns haben das Buch lesen lassen lassen
+s MIndic Cond Anter Neg Inv : würde ich dich nicht uns haben das Buch lesen lassen lassen
+s MIndic Cond Anter Neg Sub : ich dich nicht uns würde haben das Buch lesen lassen lassen
+s MConjunct Pres Simul Pos Main : ich lasse dich uns das Buch lesen lassen
+s MConjunct Pres Simul Pos Inv : lasse ich dich uns das Buch lesen lassen
+s MConjunct Pres Simul Pos Sub : ich dich uns das Buch lesen lassen lasse
+s MConjunct Pres Simul Neg Main : ich lasse dich nicht uns das Buch lesen lassen
+s MConjunct Pres Simul Neg Inv : lasse ich dich nicht uns das Buch lesen lassen
+s MConjunct Pres Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lasse
+s MConjunct Pres Anter Pos Main : ich habe dich uns das Buch lesen lassen lassen
+s MConjunct Pres Anter Pos Inv : habe ich dich uns das Buch lesen lassen lassen
+s MConjunct Pres Anter Pos Sub : ich dich uns das Buch lesen habe lassen lassen
+s MConjunct Pres Anter Neg Main : ich habe dich nicht uns das Buch lesen lassen lassen
+s MConjunct Pres Anter Neg Inv : habe ich dich nicht uns das Buch lesen lassen lassen
+s MConjunct Pres Anter Neg Sub : ich dich nicht uns das Buch lesen habe lassen lassen
+s MConjunct Past Simul Pos Main : ich ließe dich uns das Buch lesen lassen
+s MConjunct Past Simul Pos Inv : ließe ich dich uns das Buch lesen lassen
+s MConjunct Past Simul Pos Sub : ich dich uns das Buch lesen lassen ließe
+s MConjunct Past Simul Neg Main : ich ließe dich nicht uns das Buch lesen lassen
+s MConjunct Past Simul Neg Inv : ließe ich dich nicht uns das Buch lesen lassen
+s MConjunct Past Simul Neg Sub : ich dich nicht uns das Buch lesen lassen ließe
+s MConjunct Past Anter Pos Main : ich hätte dich uns das Buch lesen lassen lassen
+s MConjunct Past Anter Pos Inv : hätte ich dich uns das Buch lesen lassen lassen
+s MConjunct Past Anter Pos Sub : ich dich uns das Buch lesen hätte lassen lassen
+s MConjunct Past Anter Neg Main : ich hätte dich nicht uns das Buch lesen lassen lassen
+s MConjunct Past Anter Neg Inv : hätte ich dich nicht uns das Buch lesen lassen lassen
+s MConjunct Past Anter Neg Sub : ich dich nicht uns das Buch lesen hätte lassen lassen
+s MConjunct Fut Simul Pos Main : ich werde dich uns das Buch lesen lassen lassen
+s MConjunct Fut Simul Pos Inv : werde ich dich uns das Buch lesen lassen lassen
+s MConjunct Fut Simul Pos Sub : ich dich uns das Buch lesen lassen lassen werde
+s MConjunct Fut Simul Neg Main : ich werde dich nicht uns das Buch lesen lassen lassen
+s MConjunct Fut Simul Neg Inv : werde ich dich nicht uns das Buch lesen lassen lassen
+s MConjunct Fut Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen werde
+s MConjunct Fut Anter Pos Main : ich werde dich uns haben das Buch lesen lassen lassen
+s MConjunct Fut Anter Pos Inv : werde ich dich uns haben das Buch lesen lassen lassen
+s MConjunct Fut Anter Pos Sub : ich dich uns werde haben das Buch lesen lassen lassen   ?? werde at end?
+s MConjunct Fut Anter Neg Main : ich werde dich nicht uns haben das Buch lesen lassen lassen
+s MConjunct Fut Anter Neg Inv : werde ich dich nicht uns haben das Buch lesen lassen lassen
+s MConjunct Fut Anter Neg Sub : ich dich nicht uns werde haben das Buch lesen lassen lassen  ?? werde at end?
+s MConjunct Cond Simul Pos Main : ich würde dich uns das Buch lesen lassen lassen
+s MConjunct Cond Simul Pos Inv : würde ich dich uns das Buch lesen lassen lassen
+s MConjunct Cond Simul Pos Sub : ich dich uns das Buch lesen lassen lassen würde
+s MConjunct Cond Simul Neg Main : ich würde dich nicht uns das Buch lesen lassen lassen
+s MConjunct Cond Simul Neg Inv : würde ich dich nicht uns das Buch lesen lassen lassen
+s MConjunct Cond Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen würde
+s MConjunct Cond Anter Pos Main : ich würde dich uns haben das Buch lesen lassen lassen
+s MConjunct Cond Anter Pos Inv : würde ich dich uns haben das Buch lesen lassen lassen
+s MConjunct Cond Anter Pos Sub : ich dich uns würde haben das Buch lesen lassen lassen  ?? würde at end?
+s MConjunct Cond Anter Neg Main : ich würde dich nicht uns haben das Buch lesen lassen lassen
+s MConjunct Cond Anter Neg Inv : würde ich dich nicht uns haben das Buch lesen lassen lassen
+s MConjunct Cond Anter Neg Sub : ich dich nicht uns würde haben das Buch lesen lassen lassen  ?? würde at end?

--- a/tests/german/infinitives.lin.out
+++ b/tests/german/infinitives.lin.out
@@ -47,13 +47,13 @@ TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash 
 TestLangGer: ich muss ihm versprechen wollen , sie das Buch lesen zu lassen
 TestLangEng: I must want to promise him to let her read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich muss das Buch lesen
 TestLangEng: I must read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich will das Buch lesen
 TestLangEng: I want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich wage das Buch , zu lesen -- wrong
 TestLangEng: I dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 TestLangGer: ich muss das Buch lesen
@@ -65,28 +65,28 @@ TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V
 TestLangGer: ich wage , das Buch zu lesen
 TestLangEng: I dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich muss das Buch wollen lesen -- wrong
 TestLangEng: I must want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen zu lesen -- wrong
 TestLangEng: I must dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich will das Buch wagen zu lesen -- wrong
 TestLangEng: I want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich wage das Buch , zu wollen lesen -- wrong
 TestLangEng: I dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich muss das Buch lesen wollen
 TestLangEng: I must want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen , zu lesen -- wrong
 TestLangEng: I must dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich will das Buch wagen , zu lesen -- wrong
 TestLangEng: I want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich wage , das Buch lesen zu wollen
 TestLangEng: I dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
 TestLangGer: ich muss das Buch lesen wollen
@@ -101,25 +101,25 @@ TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash
 TestLangGer: ich wage , das Buch lesen zu wollen
 TestLangEng: I dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen wollen zu lesen -- wrong
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen wollen , zu lesen -- wrong
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
 TestLangGer: ich muss wagen wollen , das Buch zu lesen
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen zu wollen -- wrong
 TestLangEng: I must dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: 
+TestLangGer: ich muss das Buch wollen wagen -- wrong (read?)
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: 
+TestLangGer: ich muss das Buch wagen , zu wollen lesen -- wrong
 TestLangEng: I must dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
-TestLangGer: 
+TestLangGer: ich muss wagen , das Buch lesen zu wollen
 TestLangEng: I must dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
 TestLangGer: ich muss wagen , das Buch lesen zu wollen
@@ -208,588 +208,33 @@ TestLangEng: I promise her to apologize for it itself -- wrong: myself
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron))
 TestLangGer: ich verspreche uns , es mir zu geben
 TestLangEng: I promise us to give it itself -- wrong: myself
-TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
-TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu lieben
-TestLangEng: I want to promise her to beg you to not love yourself
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
+TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu hassen
+TestLangEng: I want to promise her to beg you to not hate yourself
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
 TestLangGer: ich bitte dich , dich bei dir für es zu entschuldigen
 TestLangEng: I beg you to apologize for it itself -- wrong: yourself
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2)))))))
+TestLangGer: das Buch , das wir nicht lesen wollten
+TestLangEng: the book that we didn't want to read
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2)))))))
+TestLangGer: das Buch , das wir nicht lesen mussten
+TestLangEng: the book that we hadn't to read
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2)))))))
+TestLangGer: das Buch , das wir nicht wagten , zu lesen
+TestLangEng: the book that we didn't dare to read
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
+TestLangGer: der Junge , den ich das Buch lesen lasse
+TestLangEng: the boy that I let read the book
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch zu lesen
+TestLangEng: the boy that I promise to read the book
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch lesen zu wollen
+TestLangEng: the boy that I promise to want to read the book
+TestLang: UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch lesen zu wollen
+TestLangEng: the boy that I promise to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N))))))))))
 TestLangGer: ich weiß , dass sie sagte , , dass wir die Kinder Johann helfen lassen wollten , das Haus blau zu malen
 TestLangEng: I know that she said that we wanted to let the children help John to paint the house blue
-s MIndic Pres Simul Pos Main : ich verspreche euch , das Buch zu lesen
-s MIndic Pres Simul Pos Inv : verspreche ich euch , das Buch zu lesen
-s MIndic Pres Simul Pos Sub : ich euch verspreche , das Buch zu lesen
-s MIndic Pres Simul Neg Main : ich verspreche euch nicht , das Buch zu lesen
-s MIndic Pres Simul Neg Inv : verspreche ich euch nicht , das Buch zu lesen
-s MIndic Pres Simul Neg Sub : ich euch nicht verspreche , das Buch zu lesen
-s MIndic Pres Anter Pos Main : ich habe euch versprochen , das Buch zu lesen
-s MIndic Pres Anter Pos Inv : habe ich euch versprochen , das Buch zu lesen
-s MIndic Pres Anter Pos Sub : ich euch versprochen habe , das Buch zu lesen
-s MIndic Pres Anter Neg Main : ich habe euch nicht versprochen , das Buch zu lesen
-s MIndic Pres Anter Neg Inv : habe ich euch nicht versprochen , das Buch zu lesen
-s MIndic Pres Anter Neg Sub : ich euch nicht versprochen habe , das Buch zu lesen
-s MIndic Past Simul Pos Main : ich versprach euch , das Buch zu lesen
-s MIndic Past Simul Pos Inv : versprach ich euch , das Buch zu lesen
-s MIndic Past Simul Pos Sub : ich euch versprach , das Buch zu lesen
-s MIndic Past Simul Neg Main : ich versprach euch nicht , das Buch zu lesen
-s MIndic Past Simul Neg Inv : versprach ich euch nicht , das Buch zu lesen
-s MIndic Past Simul Neg Sub : ich euch nicht versprach , das Buch zu lesen
-s MIndic Past Anter Pos Main : ich hatte euch versprochen , das Buch zu lesen
-s MIndic Past Anter Pos Inv : hatte ich euch versprochen , das Buch zu lesen
-s MIndic Past Anter Pos Sub : ich euch versprochen hatte , das Buch zu lesen
-s MIndic Past Anter Neg Main : ich hatte euch nicht versprochen , das Buch zu lesen
-s MIndic Past Anter Neg Inv : hatte ich euch nicht versprochen , das Buch zu lesen
-s MIndic Past Anter Neg Sub : ich euch nicht versprochen hatte , das Buch zu lesen
-s MIndic Fut Simul Pos Main : ich werde euch versprechen , das Buch zu lesen
-s MIndic Fut Simul Pos Inv : werde ich euch versprechen , das Buch zu lesen
-s MIndic Fut Simul Pos Sub : ich euch versprechen werde , das Buch zu lesen
-s MIndic Fut Simul Neg Main : ich werde euch nicht versprechen , das Buch zu lesen
-s MIndic Fut Simul Neg Inv : werde ich euch nicht versprechen , das Buch zu lesen
-s MIndic Fut Simul Neg Sub : ich euch nicht versprechen werde , das Buch zu lesen
-s MIndic Fut Anter Pos Main : ich werde euch versprochen haben , das Buch zu lesen
-s MIndic Fut Anter Pos Inv : werde ich euch versprochen haben , das Buch zu lesen
-s MIndic Fut Anter Pos Sub : ich euch versprochen haben werde , das Buch zu lesen
-s MIndic Fut Anter Neg Main : ich werde euch nicht versprochen haben , das Buch zu lesen
-s MIndic Fut Anter Neg Inv : werde ich euch nicht versprochen haben , das Buch zu lesen
-s MIndic Fut Anter Neg Sub : ich euch nicht versprochen haben werde , das Buch zu lesen
-s MIndic Cond Simul Pos Main : ich würde euch versprechen , das Buch zu lesen
-s MIndic Cond Simul Pos Inv : würde ich euch versprechen , das Buch zu lesen
-s MIndic Cond Simul Pos Sub : ich euch versprechen würde , das Buch zu lesen
-s MIndic Cond Simul Neg Main : ich würde euch nicht versprechen , das Buch zu lesen
-s MIndic Cond Simul Neg Inv : würde ich euch nicht versprechen , das Buch zu lesen
-s MIndic Cond Simul Neg Sub : ich euch nicht versprechen würde , das Buch zu lesen
-s MIndic Cond Anter Pos Main : ich würde euch versprochen haben , das Buch zu lesen
-s MIndic Cond Anter Pos Inv : würde ich euch versprochen haben , das Buch zu lesen
-s MIndic Cond Anter Pos Sub : ich euch versprochen haben würde , das Buch zu lesen
-s MIndic Cond Anter Neg Main : ich würde euch nicht versprochen haben , das Buch zu lesen
-s MIndic Cond Anter Neg Inv : würde ich euch nicht versprochen haben , das Buch zu lesen
-s MIndic Cond Anter Neg Sub : ich euch nicht versprochen haben würde , das Buch zu lesen
-s MConjunct Pres Simul Pos Main : ich verspreche euch , das Buch zu lesen
-s MConjunct Pres Simul Pos Inv : verspreche ich euch , das Buch zu lesen
-s MConjunct Pres Simul Pos Sub : ich euch verspreche , das Buch zu lesen
-s MConjunct Pres Simul Neg Main : ich verspreche euch nicht , das Buch zu lesen
-s MConjunct Pres Simul Neg Inv : verspreche ich euch nicht , das Buch zu lesen
-s MConjunct Pres Simul Neg Sub : ich euch nicht verspreche , das Buch zu lesen
-s MConjunct Pres Anter Pos Main : ich habe euch versprochen , das Buch zu lesen
-s MConjunct Pres Anter Pos Inv : habe ich euch versprochen , das Buch zu lesen
-s MConjunct Pres Anter Pos Sub : ich euch versprochen habe , das Buch zu lesen
-s MConjunct Pres Anter Neg Main : ich habe euch nicht versprochen , das Buch zu lesen
-s MConjunct Pres Anter Neg Inv : habe ich euch nicht versprochen , das Buch zu lesen
-s MConjunct Pres Anter Neg Sub : ich euch nicht versprochen habe , das Buch zu lesen
-s MConjunct Past Simul Pos Main : ich verspräche euch , das Buch zu lesen
-s MConjunct Past Simul Pos Inv : verspräche ich euch , das Buch zu lesen
-s MConjunct Past Simul Pos Sub : ich euch verspräche , das Buch zu lesen
-s MConjunct Past Simul Neg Main : ich verspräche euch nicht , das Buch zu lesen
-s MConjunct Past Simul Neg Inv : verspräche ich euch nicht , das Buch zu lesen
-s MConjunct Past Simul Neg Sub : ich euch nicht verspräche , das Buch zu lesen
-s MConjunct Past Anter Pos Main : ich hätte euch versprochen , das Buch zu lesen
-s MConjunct Past Anter Pos Inv : hätte ich euch versprochen , das Buch zu lesen
-s MConjunct Past Anter Pos Sub : ich euch versprochen hätte , das Buch zu lesen
-s MConjunct Past Anter Neg Main : ich hätte euch nicht versprochen , das Buch zu lesen
-s MConjunct Past Anter Neg Inv : hätte ich euch nicht versprochen , das Buch zu lesen
-s MConjunct Past Anter Neg Sub : ich euch nicht versprochen hätte , das Buch zu lesen
-s MConjunct Fut Simul Pos Main : ich werde euch versprechen , das Buch zu lesen
-s MConjunct Fut Simul Pos Inv : werde ich euch versprechen , das Buch zu lesen
-s MConjunct Fut Simul Pos Sub : ich euch versprechen werde , das Buch zu lesen
-s MConjunct Fut Simul Neg Main : ich werde euch nicht versprechen , das Buch zu lesen
-s MConjunct Fut Simul Neg Inv : werde ich euch nicht versprechen , das Buch zu lesen
-s MConjunct Fut Simul Neg Sub : ich euch nicht versprechen werde , das Buch zu lesen
-s MConjunct Fut Anter Pos Main : ich werde euch versprochen haben , das Buch zu lesen
-s MConjunct Fut Anter Pos Inv : werde ich euch versprochen haben , das Buch zu lesen
-s MConjunct Fut Anter Pos Sub : ich euch versprochen haben werde , das Buch zu lesen
-s MConjunct Fut Anter Neg Main : ich werde euch nicht versprochen haben , das Buch zu lesen
-s MConjunct Fut Anter Neg Inv : werde ich euch nicht versprochen haben , das Buch zu lesen
-s MConjunct Fut Anter Neg Sub : ich euch nicht versprochen haben werde , das Buch zu lesen
-s MConjunct Cond Simul Pos Main : ich würde euch versprechen , das Buch zu lesen
-s MConjunct Cond Simul Pos Inv : würde ich euch versprechen , das Buch zu lesen
-s MConjunct Cond Simul Pos Sub : ich euch versprechen würde , das Buch zu lesen
-s MConjunct Cond Simul Neg Main : ich würde euch nicht versprechen , das Buch zu lesen
-s MConjunct Cond Simul Neg Inv : würde ich euch nicht versprechen , das Buch zu lesen
-s MConjunct Cond Simul Neg Sub : ich euch nicht versprechen würde , das Buch zu lesen
-s MConjunct Cond Anter Pos Main : ich würde euch versprochen haben , das Buch zu lesen
-s MConjunct Cond Anter Pos Inv : würde ich euch versprochen haben , das Buch zu lesen
-s MConjunct Cond Anter Pos Sub : ich euch versprochen haben würde , das Buch zu lesen
-s MConjunct Cond Anter Neg Main : ich würde euch nicht versprochen haben , das Buch zu lesen
-s MConjunct Cond Anter Neg Inv : würde ich euch nicht versprochen haben , das Buch zu lesen
-s MConjunct Cond Anter Neg Sub : ich euch nicht versprochen haben würde , das Buch zu lesen
-s MIndic Pres Simul Pos Main : ich lasse euch das Buch lesen
-s MIndic Pres Simul Pos Inv : lasse ich euch das Buch lesen
-s MIndic Pres Simul Pos Sub : ich euch das Buch lesen lasse
-s MIndic Pres Simul Neg Main : ich lasse euch nicht das Buch lesen
-s MIndic Pres Simul Neg Inv : lasse ich euch nicht das Buch lesen
-s MIndic Pres Simul Neg Sub : ich euch nicht das Buch lesen lasse
-s MIndic Pres Anter Pos Main : ich habe euch das Buch lesen lassen
-s MIndic Pres Anter Pos Inv : habe ich euch das Buch lesen lassen
-s MIndic Pres Anter Pos Sub : ich euch das Buch habe lesen lassen
-s MIndic Pres Anter Neg Main : ich habe euch nicht das Buch lesen lassen
-s MIndic Pres Anter Neg Inv : habe ich euch nicht das Buch lesen lassen
-s MIndic Pres Anter Neg Sub : ich euch nicht das Buch habe lesen lassen
-s MIndic Past Simul Pos Main : ich ließ euch das Buch lesen
-s MIndic Past Simul Pos Inv : ließ ich euch das Buch lesen
-s MIndic Past Simul Pos Sub : ich euch das Buch lesen ließ
-s MIndic Past Simul Neg Main : ich ließ euch nicht das Buch lesen
-s MIndic Past Simul Neg Inv : ließ ich euch nicht das Buch lesen
-s MIndic Past Simul Neg Sub : ich euch nicht das Buch lesen ließ
-s MIndic Past Anter Pos Main : ich hatte euch das Buch lesen lassen
-s MIndic Past Anter Pos Inv : hatte ich euch das Buch lesen lassen
-s MIndic Past Anter Pos Sub : ich euch das Buch hatte lesen lassen
-s MIndic Past Anter Neg Main : ich hatte euch nicht das Buch lesen lassen
-s MIndic Past Anter Neg Inv : hatte ich euch nicht das Buch lesen lassen
-s MIndic Past Anter Neg Sub : ich euch nicht das Buch hatte lesen lassen
-s MIndic Fut Simul Pos Main : ich werde euch das Buch lesen lassen
-s MIndic Fut Simul Pos Inv : werde ich euch das Buch lesen lassen
-s MIndic Fut Simul Pos Sub : ich euch das Buch lesen lassen werde
-s MIndic Fut Simul Neg Main : ich werde euch nicht das Buch lesen lassen
-s MIndic Fut Simul Neg Inv : werde ich euch nicht das Buch lesen lassen
-s MIndic Fut Simul Neg Sub : ich euch nicht das Buch lesen lassen werde
-s MIndic Fut Anter Pos Main : ich werde euch das Buch haben lesen lassen
-s MIndic Fut Anter Pos Inv : werde ich euch das Buch haben lesen lassen
-s MIndic Fut Anter Pos Sub : ich euch das Buch werde haben lesen lassen
-s MIndic Fut Anter Neg Main : ich werde euch nicht das Buch haben lesen lassen
-s MIndic Fut Anter Neg Inv : werde ich euch nicht das Buch haben lesen lassen
-s MIndic Fut Anter Neg Sub : ich euch nicht das Buch werde haben lesen lassen
-s MIndic Cond Simul Pos Main : ich würde euch das Buch lesen lassen
-s MIndic Cond Simul Pos Inv : würde ich euch das Buch lesen lassen
-s MIndic Cond Simul Pos Sub : ich euch das Buch lesen lassen würde
-s MIndic Cond Simul Neg Main : ich würde euch nicht das Buch lesen lassen
-s MIndic Cond Simul Neg Inv : würde ich euch nicht das Buch lesen lassen
-s MIndic Cond Simul Neg Sub : ich euch nicht das Buch lesen lassen würde
-s MIndic Cond Anter Pos Main : ich würde euch das Buch haben lesen lassen
-s MIndic Cond Anter Pos Inv : würde ich euch das Buch haben lesen lassen
-s MIndic Cond Anter Pos Sub : ich euch das Buch würde haben lesen lassen
-s MIndic Cond Anter Neg Main : ich würde euch nicht das Buch haben lesen lassen
-s MIndic Cond Anter Neg Inv : würde ich euch nicht das Buch haben lesen lassen
-s MIndic Cond Anter Neg Sub : ich euch nicht das Buch würde haben lesen lassen
-s MConjunct Pres Simul Pos Main : ich lasse euch das Buch lesen
-s MConjunct Pres Simul Pos Inv : lasse ich euch das Buch lesen
-s MConjunct Pres Simul Pos Sub : ich euch das Buch lesen lasse
-s MConjunct Pres Simul Neg Main : ich lasse euch nicht das Buch lesen
-s MConjunct Pres Simul Neg Inv : lasse ich euch nicht das Buch lesen
-s MConjunct Pres Simul Neg Sub : ich euch nicht das Buch lesen lasse
-s MConjunct Pres Anter Pos Main : ich habe euch das Buch lesen lassen
-s MConjunct Pres Anter Pos Inv : habe ich euch das Buch lesen lassen
-s MConjunct Pres Anter Pos Sub : ich euch das Buch habe lesen lassen
-s MConjunct Pres Anter Neg Main : ich habe euch nicht das Buch lesen lassen
-s MConjunct Pres Anter Neg Inv : habe ich euch nicht das Buch lesen lassen
-s MConjunct Pres Anter Neg Sub : ich euch nicht das Buch habe lesen lassen
-s MConjunct Past Simul Pos Main : ich ließe euch das Buch lesen
-s MConjunct Past Simul Pos Inv : ließe ich euch das Buch lesen
-s MConjunct Past Simul Pos Sub : ich euch das Buch lesen ließe
-s MConjunct Past Simul Neg Main : ich ließe euch nicht das Buch lesen
-s MConjunct Past Simul Neg Inv : ließe ich euch nicht das Buch lesen
-s MConjunct Past Simul Neg Sub : ich euch nicht das Buch lesen ließe
-s MConjunct Past Anter Pos Main : ich hätte euch das Buch lesen lassen
-s MConjunct Past Anter Pos Inv : hätte ich euch das Buch lesen lassen
-s MConjunct Past Anter Pos Sub : ich euch das Buch hätte lesen lassen
-s MConjunct Past Anter Neg Main : ich hätte euch nicht das Buch lesen lassen
-s MConjunct Past Anter Neg Inv : hätte ich euch nicht das Buch lesen lassen
-s MConjunct Past Anter Neg Sub : ich euch nicht das Buch hätte lesen lassen
-s MConjunct Fut Simul Pos Main : ich werde euch das Buch lesen lassen
-s MConjunct Fut Simul Pos Inv : werde ich euch das Buch lesen lassen
-s MConjunct Fut Simul Pos Sub : ich euch das Buch lesen lassen werde
-s MConjunct Fut Simul Neg Main : ich werde euch nicht das Buch lesen lassen
-s MConjunct Fut Simul Neg Inv : werde ich euch nicht das Buch lesen lassen
-s MConjunct Fut Simul Neg Sub : ich euch nicht das Buch lesen lassen werde
-s MConjunct Fut Anter Pos Main : ich werde euch das Buch haben lesen lassen
-s MConjunct Fut Anter Pos Inv : werde ich euch das Buch haben lesen lassen
-s MConjunct Fut Anter Pos Sub : ich euch das Buch werde haben lesen lassen
-s MConjunct Fut Anter Neg Main : ich werde euch nicht das Buch haben lesen lassen
-s MConjunct Fut Anter Neg Inv : werde ich euch nicht das Buch haben lesen lassen
-s MConjunct Fut Anter Neg Sub : ich euch nicht das Buch werde haben lesen lassen
-s MConjunct Cond Simul Pos Main : ich würde euch das Buch lesen lassen
-s MConjunct Cond Simul Pos Inv : würde ich euch das Buch lesen lassen
-s MConjunct Cond Simul Pos Sub : ich euch das Buch lesen lassen würde
-s MConjunct Cond Simul Neg Main : ich würde euch nicht das Buch lesen lassen
-s MConjunct Cond Simul Neg Inv : würde ich euch nicht das Buch lesen lassen
-s MConjunct Cond Simul Neg Sub : ich euch nicht das Buch lesen lassen würde
-s MConjunct Cond Anter Pos Main : ich würde euch das Buch haben lesen lassen
-s MConjunct Cond Anter Pos Inv : würde ich euch das Buch haben lesen lassen
-s MConjunct Cond Anter Pos Sub : ich euch das Buch würde haben lesen lassen
-s MConjunct Cond Anter Neg Main : ich würde euch nicht das Buch haben lesen lassen
-s MConjunct Cond Anter Neg Inv : würde ich euch nicht das Buch haben lesen lassen
-s MConjunct Cond Anter Neg Sub : ich euch nicht das Buch würde haben lesen lassen
-s MIndic Pres Simul Pos Main : ich bitte dich , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Pos Inv : bitte ich dich , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Pos Sub : ich dich bitte , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Neg Main : ich bitte dich nicht , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Neg Inv : bitte ich dich nicht , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Neg Sub : ich dich nicht bitte , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Pos Main : ich habe dich gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Pos Inv : habe ich dich gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Pos Sub : ich dich gebeten habe , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Neg Main : ich habe dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Neg Inv : habe ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Anter Neg Sub : ich dich nicht gebeten habe , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Pos Main : ich bat dich , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Pos Inv : bat ich dich , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Pos Sub : ich dich bat , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Neg Main : ich bat dich nicht , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Neg Inv : bat ich dich nicht , uns zu versprechen , das Buch zu lesen
-s MIndic Past Simul Neg Sub : ich dich nicht bat , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Pos Main : ich hatte dich gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Pos Inv : hatte ich dich gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Pos Sub : ich dich gebeten hatte , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Neg Main : ich hatte dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Neg Inv : hatte ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MIndic Past Anter Neg Sub : ich dich nicht gebeten hatte , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Pos Main : ich werde dich bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Pos Inv : werde ich dich bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Pos Sub : ich dich bitten werde , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Neg Main : ich werde dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Neg Inv : werde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Simul Neg Sub : ich dich nicht bitten werde , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Pos Main : ich werde dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Pos Inv : werde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Pos Sub : ich dich gebeten haben werde , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Pos Main : ich würde dich bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Pos Inv : würde ich dich bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Pos Sub : ich dich bitten würde , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Neg Main : ich würde dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Neg Inv : würde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Simul Neg Sub : ich dich nicht bitten würde , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Pos Main : ich würde dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Pos Inv : würde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Pos Sub : ich dich gebeten haben würde , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MIndic Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Pos Main : ich bitte dich , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Pos Inv : bitte ich dich , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Pos Sub : ich dich bitte , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Neg Main : ich bitte dich nicht , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Neg Inv : bitte ich dich nicht , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Simul Neg Sub : ich dich nicht bitte , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Pos Main : ich habe dich gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Pos Inv : habe ich dich gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Pos Sub : ich dich gebeten habe , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Neg Main : ich habe dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Neg Inv : habe ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Pres Anter Neg Sub : ich dich nicht gebeten habe , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Pos Main : ich bäte dich , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Pos Inv : bäte ich dich , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Pos Sub : ich dich bäte , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Neg Main : ich bäte dich nicht , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Neg Inv : bäte ich dich nicht , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Simul Neg Sub : ich dich nicht bäte , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Pos Main : ich hätte dich gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Pos Inv : hätte ich dich gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Pos Sub : ich dich gebeten hätte , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Neg Main : ich hätte dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Neg Inv : hätte ich dich nicht gebeten , uns zu versprechen , das Buch zu lesen
-s MConjunct Past Anter Neg Sub : ich dich nicht gebeten hätte , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Pos Main : ich werde dich bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Pos Inv : werde ich dich bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Pos Sub : ich dich bitten werde , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Neg Main : ich werde dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Neg Inv : werde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Simul Neg Sub : ich dich nicht bitten werde , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Pos Main : ich werde dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Pos Inv : werde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Pos Sub : ich dich gebeten haben werde , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Pos Main : ich würde dich bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Pos Inv : würde ich dich bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Pos Sub : ich dich bitten würde , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Neg Main : ich würde dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Neg Inv : würde ich dich nicht bitten , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Simul Neg Sub : ich dich nicht bitten würde , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Pos Main : ich würde dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Pos Inv : würde ich dich gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Pos Sub : ich dich gebeten haben würde , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns zu versprechen , das Buch zu lesen
-s MConjunct Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns zu versprechen , das Buch zu lesen
-s MIndic Pres Simul Pos Main : ich lasse dich uns versprechen , das Buch zu lesen
-s MIndic Pres Simul Pos Inv : lasse ich dich uns versprechen , das Buch zu lesen
-s MIndic Pres Simul Pos Sub : ich dich uns versprechen lasse , das Buch zu lesen
-s MIndic Pres Simul Neg Main : ich lasse dich nicht uns versprechen , das Buch zu lesen
-s MIndic Pres Simul Neg Inv : lasse ich dich nicht uns versprechen , das Buch zu lesen
-s MIndic Pres Simul Neg Sub : ich dich nicht uns versprechen lasse , das Buch zu lesen
-s MIndic Pres Anter Pos Main : ich habe dich uns versprechen lassen , das Buch zu lesen
-s MIndic Pres Anter Pos Inv : habe ich dich uns versprechen lassen , das Buch zu lesen
-s MIndic Pres Anter Pos Sub : ich dich uns habe versprechen lassen , das Buch zu lesen
-s MIndic Pres Anter Neg Main : ich habe dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Pres Anter Neg Inv : habe ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Pres Anter Neg Sub : ich dich nicht uns habe versprechen lassen , das Buch zu lesen
-s MIndic Past Simul Pos Main : ich ließ dich uns versprechen , das Buch zu lesen
-s MIndic Past Simul Pos Inv : ließ ich dich uns versprechen , das Buch zu lesen
-s MIndic Past Simul Pos Sub : ich dich uns versprechen ließ , das Buch zu lesen
-s MIndic Past Simul Neg Main : ich ließ dich nicht uns versprechen , das Buch zu lesen
-s MIndic Past Simul Neg Inv : ließ ich dich nicht uns versprechen , das Buch zu lesen
-s MIndic Past Simul Neg Sub : ich dich nicht uns versprechen ließ , das Buch zu lesen
-s MIndic Past Anter Pos Main : ich hatte dich uns versprechen lassen , das Buch zu lesen
-s MIndic Past Anter Pos Inv : hatte ich dich uns versprechen lassen , das Buch zu lesen
-s MIndic Past Anter Pos Sub : ich dich uns hatte versprechen lassen , das Buch zu lesen
-s MIndic Past Anter Neg Main : ich hatte dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Past Anter Neg Inv : hatte ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Past Anter Neg Sub : ich dich nicht uns hatte versprechen lassen , das Buch zu lesen
-s MIndic Fut Simul Pos Main : ich werde dich uns versprechen lassen , das Buch zu lesen
-s MIndic Fut Simul Pos Inv : werde ich dich uns versprechen lassen , das Buch zu lesen
-s MIndic Fut Simul Pos Sub : ich dich uns versprechen lassen werde , das Buch zu lesen
-s MIndic Fut Simul Neg Main : ich werde dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Fut Simul Neg Inv : werde ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Fut Simul Neg Sub : ich dich nicht uns versprechen lassen werde , das Buch zu lesen
-s MIndic Fut Anter Pos Main : ich werde dich uns haben versprechen lassen , das Buch zu lesen
-s MIndic Fut Anter Pos Inv : werde ich dich uns haben versprechen lassen , das Buch zu lesen
-s MIndic Fut Anter Pos Sub : ich dich uns werde haben versprechen lassen , das Buch zu lesen
-s MIndic Fut Anter Neg Main : ich werde dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MIndic Fut Anter Neg Inv : werde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MIndic Fut Anter Neg Sub : ich dich nicht uns werde haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Simul Pos Main : ich würde dich uns versprechen lassen , das Buch zu lesen
-s MIndic Cond Simul Pos Inv : würde ich dich uns versprechen lassen , das Buch zu lesen
-s MIndic Cond Simul Pos Sub : ich dich uns versprechen lassen würde , das Buch zu lesen
-s MIndic Cond Simul Neg Main : ich würde dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Cond Simul Neg Inv : würde ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MIndic Cond Simul Neg Sub : ich dich nicht uns versprechen lassen würde , das Buch zu lesen
-s MIndic Cond Anter Pos Main : ich würde dich uns haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Anter Pos Inv : würde ich dich uns haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Anter Pos Sub : ich dich uns würde haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Anter Neg Main : ich würde dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Anter Neg Inv : würde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MIndic Cond Anter Neg Sub : ich dich nicht uns würde haben versprechen lassen , das Buch zu lesen
-s MConjunct Pres Simul Pos Main : ich lasse dich uns versprechen , das Buch zu lesen
-s MConjunct Pres Simul Pos Inv : lasse ich dich uns versprechen , das Buch zu lesen
-s MConjunct Pres Simul Pos Sub : ich dich uns versprechen lasse , das Buch zu lesen
-s MConjunct Pres Simul Neg Main : ich lasse dich nicht uns versprechen , das Buch zu lesen
-s MConjunct Pres Simul Neg Inv : lasse ich dich nicht uns versprechen , das Buch zu lesen
-s MConjunct Pres Simul Neg Sub : ich dich nicht uns versprechen lasse , das Buch zu lesen
-s MConjunct Pres Anter Pos Main : ich habe dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Pres Anter Pos Inv : habe ich dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Pres Anter Pos Sub : ich dich uns habe versprechen lassen , das Buch zu lesen
-s MConjunct Pres Anter Neg Main : ich habe dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Pres Anter Neg Inv : habe ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Pres Anter Neg Sub : ich dich nicht uns habe versprechen lassen , das Buch zu lesen
-s MConjunct Past Simul Pos Main : ich ließe dich uns versprechen , das Buch zu lesen
-s MConjunct Past Simul Pos Inv : ließe ich dich uns versprechen , das Buch zu lesen
-s MConjunct Past Simul Pos Sub : ich dich uns versprechen ließe , das Buch zu lesen
-s MConjunct Past Simul Neg Main : ich ließe dich nicht uns versprechen , das Buch zu lesen
-s MConjunct Past Simul Neg Inv : ließe ich dich nicht uns versprechen , das Buch zu lesen
-s MConjunct Past Simul Neg Sub : ich dich nicht uns versprechen ließe , das Buch zu lesen
-s MConjunct Past Anter Pos Main : ich hätte dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Past Anter Pos Inv : hätte ich dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Past Anter Pos Sub : ich dich uns hätte versprechen lassen , das Buch zu lesen
-s MConjunct Past Anter Neg Main : ich hätte dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Past Anter Neg Inv : hätte ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Past Anter Neg Sub : ich dich nicht uns hätte versprechen lassen , das Buch zu lesen
-s MConjunct Fut Simul Pos Main : ich werde dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Fut Simul Pos Inv : werde ich dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Fut Simul Pos Sub : ich dich uns versprechen lassen werde , das Buch zu lesen
-s MConjunct Fut Simul Neg Main : ich werde dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Fut Simul Neg Inv : werde ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Fut Simul Neg Sub : ich dich nicht uns versprechen lassen werde , das Buch zu lesen
-s MConjunct Fut Anter Pos Main : ich werde dich uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Fut Anter Pos Inv : werde ich dich uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Fut Anter Pos Sub : ich dich uns werde haben versprechen lassen , das Buch zu lesen
-s MConjunct Fut Anter Neg Main : ich werde dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Fut Anter Neg Inv : werde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Fut Anter Neg Sub : ich dich nicht uns werde haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Simul Pos Main : ich würde dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Cond Simul Pos Inv : würde ich dich uns versprechen lassen , das Buch zu lesen
-s MConjunct Cond Simul Pos Sub : ich dich uns versprechen lassen würde , das Buch zu lesen
-s MConjunct Cond Simul Neg Main : ich würde dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Cond Simul Neg Inv : würde ich dich nicht uns versprechen lassen , das Buch zu lesen
-s MConjunct Cond Simul Neg Sub : ich dich nicht uns versprechen lassen würde , das Buch zu lesen
-s MConjunct Cond Anter Pos Main : ich würde dich uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Anter Pos Inv : würde ich dich uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Anter Pos Sub : ich dich uns würde haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Anter Neg Main : ich würde dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Anter Neg Inv : würde ich dich nicht uns haben versprechen lassen , das Buch zu lesen
-s MConjunct Cond Anter Neg Sub : ich dich nicht uns würde haben versprechen lassen , das Buch zu lesen
-s MIndic Pres Simul Pos Main : ich bitte dich , uns das Buch lesen zu lassen
-s MIndic Pres Simul Pos Inv : bitte ich dich , uns das Buch lesen zu lassen
-s MIndic Pres Simul Pos Sub : ich dich bitte , uns das Buch lesen zu lassen
-s MIndic Pres Simul Neg Main : ich bitte dich nicht , uns das Buch lesen zu lassen
-s MIndic Pres Simul Neg Inv : bitte ich dich nicht , uns das Buch lesen zu lassen
-s MIndic Pres Simul Neg Sub : ich dich nicht bitte , uns das Buch lesen zu lassen
-s MIndic Pres Anter Pos Main : ich habe dich gebeten , uns das Buch lesen zu lassen
-s MIndic Pres Anter Pos Inv : habe ich dich gebeten , uns das Buch lesen zu lassen
-s MIndic Pres Anter Pos Sub : ich dich gebeten habe , uns das Buch lesen zu lassen
-s MIndic Pres Anter Neg Main : ich habe dich nicht gebeten , uns das Buch lesen zu lassen
-s MIndic Pres Anter Neg Inv : habe ich dich nicht gebeten , uns das Buch lesen zu lassen
-s MIndic Pres Anter Neg Sub : ich dich nicht gebeten habe , uns das Buch lesen zu lassen
-s MIndic Past Simul Pos Main : ich bat dich , uns das Buch lesen zu lassen
-s MIndic Past Simul Pos Inv : bat ich dich , uns das Buch lesen zu lassen
-s MIndic Past Simul Pos Sub : ich dich bat , uns das Buch lesen zu lassen
-s MIndic Past Simul Neg Main : ich bat dich nicht , uns das Buch lesen zu lassen
-s MIndic Past Simul Neg Inv : bat ich dich nicht , uns das Buch lesen zu lassen
-s MIndic Past Simul Neg Sub : ich dich nicht bat , uns das Buch lesen zu lassen
-s MIndic Past Anter Pos Main : ich hatte dich gebeten , uns das Buch lesen zu lassen
-s MIndic Past Anter Pos Inv : hatte ich dich gebeten , uns das Buch lesen zu lassen
-s MIndic Past Anter Pos Sub : ich dich gebeten hatte , uns das Buch lesen zu lassen
-s MIndic Past Anter Neg Main : ich hatte dich nicht gebeten , uns das Buch lesen zu lassen
-s MIndic Past Anter Neg Inv : hatte ich dich nicht gebeten , uns das Buch lesen zu lassen
-s MIndic Past Anter Neg Sub : ich dich nicht gebeten hatte , uns das Buch lesen zu lassen
-s MIndic Fut Simul Pos Main : ich werde dich bitten , uns das Buch lesen zu lassen
-s MIndic Fut Simul Pos Inv : werde ich dich bitten , uns das Buch lesen zu lassen
-s MIndic Fut Simul Pos Sub : ich dich bitten werde , uns das Buch lesen zu lassen
-s MIndic Fut Simul Neg Main : ich werde dich nicht bitten , uns das Buch lesen zu lassen
-s MIndic Fut Simul Neg Inv : werde ich dich nicht bitten , uns das Buch lesen zu lassen
-s MIndic Fut Simul Neg Sub : ich dich nicht bitten werde , uns das Buch lesen zu lassen
-s MIndic Fut Anter Pos Main : ich werde dich gebeten haben , uns das Buch lesen zu lassen
-s MIndic Fut Anter Pos Inv : werde ich dich gebeten haben , uns das Buch lesen zu lassen
-s MIndic Fut Anter Pos Sub : ich dich gebeten haben werde , uns das Buch lesen zu lassen
-s MIndic Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MIndic Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MIndic Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns das Buch lesen zu lassen
-s MIndic Cond Simul Pos Main : ich würde dich bitten , uns das Buch lesen zu lassen
-s MIndic Cond Simul Pos Inv : würde ich dich bitten , uns das Buch lesen zu lassen
-s MIndic Cond Simul Pos Sub : ich dich bitten würde , uns das Buch lesen zu lassen
-s MIndic Cond Simul Neg Main : ich würde dich nicht bitten , uns das Buch lesen zu lassen
-s MIndic Cond Simul Neg Inv : würde ich dich nicht bitten , uns das Buch lesen zu lassen
-s MIndic Cond Simul Neg Sub : ich dich nicht bitten würde , uns das Buch lesen zu lassen
-s MIndic Cond Anter Pos Main : ich würde dich gebeten haben , uns das Buch lesen zu lassen
-s MIndic Cond Anter Pos Inv : würde ich dich gebeten haben , uns das Buch lesen zu lassen
-s MIndic Cond Anter Pos Sub : ich dich gebeten haben würde , uns das Buch lesen zu lassen
-s MIndic Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MIndic Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MIndic Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Pos Main : ich bitte dich , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Pos Inv : bitte ich dich , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Pos Sub : ich dich bitte , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Neg Main : ich bitte dich nicht , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Neg Inv : bitte ich dich nicht , uns das Buch lesen zu lassen
-s MConjunct Pres Simul Neg Sub : ich dich nicht bitte , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Pos Main : ich habe dich gebeten , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Pos Inv : habe ich dich gebeten , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Pos Sub : ich dich gebeten habe , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Neg Main : ich habe dich nicht gebeten , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Neg Inv : habe ich dich nicht gebeten , uns das Buch lesen zu lassen
-s MConjunct Pres Anter Neg Sub : ich dich nicht gebeten habe , uns das Buch lesen zu lassen
-s MConjunct Past Simul Pos Main : ich bäte dich , uns das Buch lesen zu lassen
-s MConjunct Past Simul Pos Inv : bäte ich dich , uns das Buch lesen zu lassen
-s MConjunct Past Simul Pos Sub : ich dich bäte , uns das Buch lesen zu lassen
-s MConjunct Past Simul Neg Main : ich bäte dich nicht , uns das Buch lesen zu lassen
-s MConjunct Past Simul Neg Inv : bäte ich dich nicht , uns das Buch lesen zu lassen
-s MConjunct Past Simul Neg Sub : ich dich nicht bäte , uns das Buch lesen zu lassen
-s MConjunct Past Anter Pos Main : ich hätte dich gebeten , uns das Buch lesen zu lassen
-s MConjunct Past Anter Pos Inv : hätte ich dich gebeten , uns das Buch lesen zu lassen
-s MConjunct Past Anter Pos Sub : ich dich gebeten hätte , uns das Buch lesen zu lassen
-s MConjunct Past Anter Neg Main : ich hätte dich nicht gebeten , uns das Buch lesen zu lassen
-s MConjunct Past Anter Neg Inv : hätte ich dich nicht gebeten , uns das Buch lesen zu lassen
-s MConjunct Past Anter Neg Sub : ich dich nicht gebeten hätte , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Pos Main : ich werde dich bitten , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Pos Inv : werde ich dich bitten , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Pos Sub : ich dich bitten werde , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Neg Main : ich werde dich nicht bitten , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Neg Inv : werde ich dich nicht bitten , uns das Buch lesen zu lassen
-s MConjunct Fut Simul Neg Sub : ich dich nicht bitten werde , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Pos Main : ich werde dich gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Pos Inv : werde ich dich gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Pos Sub : ich dich gebeten haben werde , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Neg Main : ich werde dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Neg Inv : werde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Fut Anter Neg Sub : ich dich nicht gebeten haben werde , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Pos Main : ich würde dich bitten , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Pos Inv : würde ich dich bitten , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Pos Sub : ich dich bitten würde , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Neg Main : ich würde dich nicht bitten , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Neg Inv : würde ich dich nicht bitten , uns das Buch lesen zu lassen
-s MConjunct Cond Simul Neg Sub : ich dich nicht bitten würde , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Pos Main : ich würde dich gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Pos Inv : würde ich dich gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Pos Sub : ich dich gebeten haben würde , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Neg Main : ich würde dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Neg Inv : würde ich dich nicht gebeten haben , uns das Buch lesen zu lassen
-s MConjunct Cond Anter Neg Sub : ich dich nicht gebeten haben würde , uns das Buch lesen zu lassen
-s MIndic Pres Simul Pos Main : ich lasse dich uns das Buch lesen lassen
-s MIndic Pres Simul Pos Inv : lasse ich dich uns das Buch lesen lassen
-s MIndic Pres Simul Pos Sub : ich dich uns das Buch lesen lassen lasse
-s MIndic Pres Simul Neg Main : ich lasse dich nicht uns das Buch lesen lassen
-s MIndic Pres Simul Neg Inv : lasse ich dich nicht uns das Buch lesen lassen
-s MIndic Pres Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lasse
-s MIndic Pres Anter Pos Main : ich habe dich uns das Buch lesen lassen lassen
-s MIndic Pres Anter Pos Inv : habe ich dich uns das Buch lesen lassen lassen
-s MIndic Pres Anter Pos Sub : ich dich uns das Buch lesen habe lassen lassen
-s MIndic Pres Anter Neg Main : ich habe dich nicht uns das Buch lesen lassen lassen
-s MIndic Pres Anter Neg Inv : habe ich dich nicht uns das Buch lesen lassen lassen
-s MIndic Pres Anter Neg Sub : ich dich nicht uns das Buch lesen habe lassen lassen
-s MIndic Past Simul Pos Main : ich ließ dich uns das Buch lesen lassen
-s MIndic Past Simul Pos Inv : ließ ich dich uns das Buch lesen lassen
-s MIndic Past Simul Pos Sub : ich dich uns das Buch lesen lassen ließ
-s MIndic Past Simul Neg Main : ich ließ dich nicht uns das Buch lesen lassen
-s MIndic Past Simul Neg Inv : ließ ich dich nicht uns das Buch lesen lassen
-s MIndic Past Simul Neg Sub : ich dich nicht uns das Buch lesen lassen ließ
-s MIndic Past Anter Pos Main : ich hatte dich uns das Buch lesen lassen lassen
-s MIndic Past Anter Pos Inv : hatte ich dich uns das Buch lesen lassen lassen
-s MIndic Past Anter Pos Sub : ich dich uns das Buch lesen hatte lassen lassen
-s MIndic Past Anter Neg Main : ich hatte dich nicht uns das Buch lesen lassen lassen
-s MIndic Past Anter Neg Inv : hatte ich dich nicht uns das Buch lesen lassen lassen
-s MIndic Past Anter Neg Sub : ich dich nicht uns das Buch lesen hatte lassen lassen
-s MIndic Fut Simul Pos Main : ich werde dich uns das Buch lesen lassen lassen
-s MIndic Fut Simul Pos Inv : werde ich dich uns das Buch lesen lassen lassen
-s MIndic Fut Simul Pos Sub : ich dich uns das Buch lesen lassen lassen werde
-s MIndic Fut Simul Neg Main : ich werde dich nicht uns das Buch lesen lassen lassen
-s MIndic Fut Simul Neg Inv : werde ich dich nicht uns das Buch lesen lassen lassen
-s MIndic Fut Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen werde
-s MIndic Fut Anter Pos Main : ich werde dich uns haben das Buch lesen lassen lassen
-s MIndic Fut Anter Pos Inv : werde ich dich uns haben das Buch lesen lassen lassen
-s MIndic Fut Anter Pos Sub : ich dich uns werde haben das Buch lesen lassen lassen
-s MIndic Fut Anter Neg Main : ich werde dich nicht uns haben das Buch lesen lassen lassen
-s MIndic Fut Anter Neg Inv : werde ich dich nicht uns haben das Buch lesen lassen lassen
-s MIndic Fut Anter Neg Sub : ich dich nicht uns werde haben das Buch lesen lassen lassen
-s MIndic Cond Simul Pos Main : ich würde dich uns das Buch lesen lassen lassen
-s MIndic Cond Simul Pos Inv : würde ich dich uns das Buch lesen lassen lassen
-s MIndic Cond Simul Pos Sub : ich dich uns das Buch lesen lassen lassen würde
-s MIndic Cond Simul Neg Main : ich würde dich nicht uns das Buch lesen lassen lassen
-s MIndic Cond Simul Neg Inv : würde ich dich nicht uns das Buch lesen lassen lassen
-s MIndic Cond Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen würde
-s MIndic Cond Anter Pos Main : ich würde dich uns haben das Buch lesen lassen lassen
-s MIndic Cond Anter Pos Inv : würde ich dich uns haben das Buch lesen lassen lassen
-s MIndic Cond Anter Pos Sub : ich dich uns würde haben das Buch lesen lassen lassen
-s MIndic Cond Anter Neg Main : ich würde dich nicht uns haben das Buch lesen lassen lassen
-s MIndic Cond Anter Neg Inv : würde ich dich nicht uns haben das Buch lesen lassen lassen
-s MIndic Cond Anter Neg Sub : ich dich nicht uns würde haben das Buch lesen lassen lassen
-s MConjunct Pres Simul Pos Main : ich lasse dich uns das Buch lesen lassen
-s MConjunct Pres Simul Pos Inv : lasse ich dich uns das Buch lesen lassen
-s MConjunct Pres Simul Pos Sub : ich dich uns das Buch lesen lassen lasse
-s MConjunct Pres Simul Neg Main : ich lasse dich nicht uns das Buch lesen lassen
-s MConjunct Pres Simul Neg Inv : lasse ich dich nicht uns das Buch lesen lassen
-s MConjunct Pres Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lasse
-s MConjunct Pres Anter Pos Main : ich habe dich uns das Buch lesen lassen lassen
-s MConjunct Pres Anter Pos Inv : habe ich dich uns das Buch lesen lassen lassen
-s MConjunct Pres Anter Pos Sub : ich dich uns das Buch lesen habe lassen lassen
-s MConjunct Pres Anter Neg Main : ich habe dich nicht uns das Buch lesen lassen lassen
-s MConjunct Pres Anter Neg Inv : habe ich dich nicht uns das Buch lesen lassen lassen
-s MConjunct Pres Anter Neg Sub : ich dich nicht uns das Buch lesen habe lassen lassen
-s MConjunct Past Simul Pos Main : ich ließe dich uns das Buch lesen lassen
-s MConjunct Past Simul Pos Inv : ließe ich dich uns das Buch lesen lassen
-s MConjunct Past Simul Pos Sub : ich dich uns das Buch lesen lassen ließe
-s MConjunct Past Simul Neg Main : ich ließe dich nicht uns das Buch lesen lassen
-s MConjunct Past Simul Neg Inv : ließe ich dich nicht uns das Buch lesen lassen
-s MConjunct Past Simul Neg Sub : ich dich nicht uns das Buch lesen lassen ließe
-s MConjunct Past Anter Pos Main : ich hätte dich uns das Buch lesen lassen lassen
-s MConjunct Past Anter Pos Inv : hätte ich dich uns das Buch lesen lassen lassen
-s MConjunct Past Anter Pos Sub : ich dich uns das Buch lesen hätte lassen lassen
-s MConjunct Past Anter Neg Main : ich hätte dich nicht uns das Buch lesen lassen lassen
-s MConjunct Past Anter Neg Inv : hätte ich dich nicht uns das Buch lesen lassen lassen
-s MConjunct Past Anter Neg Sub : ich dich nicht uns das Buch lesen hätte lassen lassen
-s MConjunct Fut Simul Pos Main : ich werde dich uns das Buch lesen lassen lassen
-s MConjunct Fut Simul Pos Inv : werde ich dich uns das Buch lesen lassen lassen
-s MConjunct Fut Simul Pos Sub : ich dich uns das Buch lesen lassen lassen werde
-s MConjunct Fut Simul Neg Main : ich werde dich nicht uns das Buch lesen lassen lassen
-s MConjunct Fut Simul Neg Inv : werde ich dich nicht uns das Buch lesen lassen lassen
-s MConjunct Fut Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen werde
-s MConjunct Fut Anter Pos Main : ich werde dich uns haben das Buch lesen lassen lassen
-s MConjunct Fut Anter Pos Inv : werde ich dich uns haben das Buch lesen lassen lassen
-s MConjunct Fut Anter Pos Sub : ich dich uns werde haben das Buch lesen lassen lassen   ?? werde at end?
-s MConjunct Fut Anter Neg Main : ich werde dich nicht uns haben das Buch lesen lassen lassen
-s MConjunct Fut Anter Neg Inv : werde ich dich nicht uns haben das Buch lesen lassen lassen
-s MConjunct Fut Anter Neg Sub : ich dich nicht uns werde haben das Buch lesen lassen lassen  ?? werde at end?
-s MConjunct Cond Simul Pos Main : ich würde dich uns das Buch lesen lassen lassen
-s MConjunct Cond Simul Pos Inv : würde ich dich uns das Buch lesen lassen lassen
-s MConjunct Cond Simul Pos Sub : ich dich uns das Buch lesen lassen lassen würde
-s MConjunct Cond Simul Neg Main : ich würde dich nicht uns das Buch lesen lassen lassen
-s MConjunct Cond Simul Neg Inv : würde ich dich nicht uns das Buch lesen lassen lassen
-s MConjunct Cond Simul Neg Sub : ich dich nicht uns das Buch lesen lassen lassen würde
-s MConjunct Cond Anter Pos Main : ich würde dich uns haben das Buch lesen lassen lassen
-s MConjunct Cond Anter Pos Inv : würde ich dich uns haben das Buch lesen lassen lassen
-s MConjunct Cond Anter Pos Sub : ich dich uns würde haben das Buch lesen lassen lassen  ?? würde at end?
-s MConjunct Cond Anter Neg Main : ich würde dich nicht uns haben das Buch lesen lassen lassen
-s MConjunct Cond Anter Neg Inv : würde ich dich nicht uns haben das Buch lesen lassen lassen
-s MConjunct Cond Anter Neg Sub : ich dich nicht uns würde haben das Buch lesen lassen lassen  ?? würde at end?

--- a/tests/german/infinitives.trees
+++ b/tests/german/infinitives.trees
@@ -56,13 +56,108 @@
 
 (PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron))))
 
--- +auxVV o +auxVV o -auxV2V o +auxV2V o V2: wrong: ich muss ihm versprechen , sie das Buch lesen zu lassen wollen
--- instead of: ich muss ihm versprechen wollen , sie das Buch lesen zu lassen 
+-- +auxVV o +auxVV o -auxV2V o +auxV2V o V2: 
 
 (PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron)))))
 
-(PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))))))
+-- ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 
--- TestLangGer: ich weiß , dass sie sagte , , dass wir die Kinder Johann helfen , das Haus blau zu malen lassen wollten
--- statt: ich weiß , dass sie sagte , dass wir die Kinder Johann [] helfen lassen wollten , das Haus blau zu malen 
+-- ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplSlash o SlashVV o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+-- ComplVV o ComplSlash o SlashVV 
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+- ComplVV o ComplVV o ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))
+
+-- ComplSlash o SlashVV o SlashVV o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+-- ComplVV o ComplSlash o SlashVV o SlashVV 
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplVV o ComplVV o ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))
+
+-- ComplSlash o SlashV2V o ComplSlash
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+-- ComplSlash o SlashV2V o ComplSlash o SlashV2V o ComplSlash
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron he_Pron)))
+
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron they_Pron) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron they_Pron) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+
+-- V2V o ReflVP with object control (default)
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V warnen_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youPl_Pron)))
+
+-- V2V o ReflVP with subject control
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron she_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ReflVP (SlashV2a love_V2)))) (UsePron she_Pron)))
+
+-- +auxVV o (V2V object control) o (V2V subject control) o ReflVP 
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2Vneg versprechen_dat_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
+
+-- V2V o ReflVPSlash with subject control
+
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron)))
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
+
+-- V2V o ReflVPSlash with object control
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
+
+-- Shieber's example
+
+(PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))))))
 

--- a/tests/german/infinitives.trees
+++ b/tests/german/infinitives.trees
@@ -157,13 +157,27 @@ PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (R
 -- V2V o ReflVPSlash with object control
 PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
 
--- VP.inf with extracted NP
+-- SlashV2V o SlashV2V o ReflVP with object control o subject control
 
-UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2)))))))
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
 
-(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2))))))))
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
 
-(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))))
+-- VP.inf with extracted NP (testing SlashVV, SlashV2VNP)
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (Slash3V3 erklaeren_dat_V3 (UsePron she_Pron)))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP lassen_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+
+--
 
 (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))))
 
@@ -173,7 +187,9 @@ UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast A
 
 (UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))))
 
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V helfen_V2V (ReflVP (SlashV2a wash_V2)))))))))
+
 -- Shieber's example
 
-(PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))))))
+(PredVP (UsePN john_PN) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePron he_Pron))) (DetCN (DetQuant DefArt NumPl) (UseN child_N))))))))
 

--- a/tests/german/infinitives.trees
+++ b/tests/german/infinitives.trees
@@ -88,7 +88,7 @@
 (PredVP (UsePron i_Pron) (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
 (PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
 
--- ComplVV o ComplSlash o SlashVV
+-- ComplVV o ComplSlash o SlashVV o SlashVV
 (PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
 
 - ComplVV o ComplVV o ComplSlash o SlashVV
@@ -152,10 +152,26 @@
 PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
 (PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron)))
 
-(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
 
 -- V2V o ReflVPSlash with object control
 PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
+
+-- VP.inf with extracted NP
+
+UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2)))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2))))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))))
+
+(UttNP (DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))))
 
 -- Shieber's example
 

--- a/tests/german/infinitives.trees
+++ b/tests/german/infinitives.trees
@@ -1,0 +1,68 @@
+-- V2V o V2 and V2V o V2V o V2 works:
+
+-- -auxV2V o V2 
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron)))
+
+-- +auxV2V o V2
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron)))
+
+-- -auxV2V o -auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- +auxV2V o -auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- -auxV2V o +auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- +auxV2V o +auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- ---------- VV combined with V2 and V2V ----------
+
+-- VV o V2 ok
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- VV o -auxV2V ok:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+-- VV o +auxV2V ok:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+-- +auxVV o -auxV2V o +auxV2V:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))) (UsePron she_Pron))))
+
+-- +auxVV o +auxV2V o V2:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))))
+
+-- +auxVV o -auxV2V o +auxV2V o V2:
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron))))
+
+-- +auxVV o +auxVV o -auxV2V o +auxV2V o V2: wrong: ich muss ihm versprechen , sie das Buch lesen zu lassen wollen
+-- instead of: ich muss ihm versprechen wollen , sie das Buch lesen zu lassen 
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron)))))
+
+(PredVP (UsePron i_Pron) (ComplVS know_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePN john_PN))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))))))
+
+-- TestLangGer: ich weiß , dass sie sagte , , dass wir die Kinder Johann helfen , das Haus blau zu malen lassen wollten
+-- statt: ich weiß , dass sie sagte , dass wir die Kinder Johann [] helfen lassen wollten , das Haus blau zu malen 
+

--- a/tests/german/object-order.README
+++ b/tests/german/object-order.README
@@ -1,4 +1,4 @@
-Implementing pronoun switch e.a. in LangGer        HL 13.6.2019 -- 20.3.2019
+Implementing pronoun switch e.a. in LangGer        HL 13.6.2019 -- 20.6.2019
 -------------------------------------------
 Ternary verbs v:V3 with two objects of category NP order them
 depending on their being (personal) pronouns or not. Basically
@@ -273,7 +273,7 @@ From Eng to Ger:
 
 examples.eng.txt could also be parsed using LangEng instead of TestLangEng|Ger.
 
-Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.tmp
 Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
 
 Using give_V3 is confusing, as both objects are connected with noPrep. The examples are

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -12,9 +12,9 @@ rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=ex
 ? diff examples.eng2ger.out examples.eng2ger.new
 
 ? echo "extracting positive, negative and dubious examples from examples.txt ..."
-? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.pos.txt
-? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.neg.txt
-? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// > examples.dub.txt
+? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.pos.txt
+? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.neg.txt
+? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.dub.txt
 
 ? echo "parsing negative examples ...; storing trees in examples.neg.new ..."
 rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.new"

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -2,29 +2,29 @@
 --? echo "loading TestLangGer.gf and TestLangEng.gf ..."
 --i TestLangGer.gf TestLangEng.gf
 -- Remark: examples in examples.eng.txt need only LangEng,LangGer
-? echo "parsing from examples.eng and writing trees to examples.eng.new:"
-rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
-? echo "diff examples.eng.out examples.eng.new"
-? diff examples.eng.out examples.eng.new
-? echo "parsing from examples.eng and writing source and translation to examples.eng2ger.new:"
-rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
-? echo "diff examples.eng2ger.out examples.eng2ger.new"
-? diff examples.eng2ger.out examples.eng2ger.new
+? echo "parsing from examples.eng and writing trees to examples.eng.tmp:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.tmp
+? echo "diff examples.eng.out examples.eng.tmp"
+? diff examples.eng.out examples.eng.tmp
+? echo "parsing from examples.eng and writing source and translation to examples.eng2ger.tmp:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.tmp
+? echo "diff examples.eng2ger.out examples.eng2ger.tmp"
+? diff examples.eng2ger.out examples.eng2ger.tmp
 
 ? echo "extracting positive, negative and dubious examples from examples.txt ..."
 ? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.pos.txt
 ? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.neg.txt
 ? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.dub.txt
 
-? echo "parsing negative examples ...; storing trees in examples.neg.new ..."
-rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.new"
-? echo "diff examples.neg.out examples.neg.new:"
-? diff examples.neg.out examples.neg.new
-? echo "parsing dubious examples ...; storing trees in examples.dub.new ..."
-rf -lines -file="examples.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.dub.new"
-? echo "diff examples.dub.out examples.dub.new:"
-? diff examples.dub.out examples.dub.new
-? echo "parsing positive examples ...; storing trees in examples.pos.new ..."
-rf -lines -file="examples.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.pos.new"
-? echo "diff examples.pos.out examples.pos.new:"
-? diff examples.pos.out examples.pos.new
+? echo "parsing negative examples ...; storing trees in examples.neg.tmp ..."
+rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.tmp"
+? echo "diff examples.neg.out examples.neg.tmp:"
+? diff examples.neg.out examples.neg.tmp
+? echo "parsing dubious examples ...; storing trees in examples.dub.tmp ..."
+rf -lines -file="examples.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.dub.tmp"
+? echo "diff examples.dub.out examples.dub.tmp:"
+? diff examples.dub.out examples.dub.tmp
+? echo "parsing positive examples ...; storing trees in examples.pos.tmp ..."
+rf -lines -file="examples.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.pos.tmp"
+? echo "diff examples.pos.out examples.pos.tmp:"
+? diff examples.pos.out examples.pos.tmp

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -1,6 +1,6 @@
---# Use gf --run < obj-order.gfs  or  gf> eh object-order.gfs 
-? echo "loading TestLangGer.gf and TestLangEng.gf ..."
-i TestLangGer.gf TestLangEng.gf
+-- Use gf --run < obj-order.gfs  or  gf> eh object-order.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
 -- Remark: examples in examples.eng.txt need only LangEng,LangGer
 ? echo "parsing from examples.eng and writing trees to examples.eng.new:"
 rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new

--- a/tests/german/passive.dub.out
+++ b/tests/german/passive.dub.out
@@ -1,0 +1,12 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond AAnter) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt haben bekommen wollen
+TestLangEng: we would have wanted to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (PredetNP not_Predet (UsePron youPl_Pron))))))) NoVoc
+TestLangGer: für die Bücher wird nicht euch gedankt
+TestLangEng: the books are thanked not you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+TestLangGer: für die Bücher wird nicht euch gedankt
+TestLangEng: the books aren't thanked you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist nicht mit mir debattiert worden
+TestLangEng: the book hasn't been debated with me about

--- a/tests/german/passive.gfs
+++ b/tests/german/passive.gfs
@@ -1,0 +1,23 @@
+-- Use gf --run < passive.gfs  or  gf> eh passive.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
+
+? echo "extracting positive, negative and dubious examples from passive.txt ..."
+? grep accept passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.pos.txt
+? wc -l passive.pos.txt
+? grep reject passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.neg.txt
+? wc -l passive.neg.txt
+? grep dubious passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.dub.txt
+? wc -l passive.dub.txt
+
+? echo "parsing positive examples ...; storing trees in passive.pos.new ..."
+rf -lines -file="passive.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.pos.new"
+? echo "diff passive.pos.out passive.pos.new:" ; diff passive.pos.out passive.pos.new
+
+? echo "parsing negative examples ...; storing trees in passive.neg.new ..."
+rf -lines -file="passive.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.neg.new"
+? echo "diff passive.neg.out passive.neg.new:" ; diff passive.neg.out passive.neg.new
+
+? echo "parsing dubious examples ...; storing trees in passive.dub.new ..."
+rf -lines -file="passive.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.dub.new"
+? echo "diff passive.dub.out passive.dub.new:" ; diff passive.dub.out passive.dub.new

--- a/tests/german/passive.neg.out
+++ b/tests/german/passive.neg.out
@@ -1,0 +1,24 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond AAnter) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt haben bekommen wollen
+TestLangEng: we would have wanted to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))) (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N)))))) NoVoc
+TestLangGer: wir lehren die Wissenschaft unseren Freund
+TestLangEng: we teach the science our friend
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))) (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N)))))) NoVoc
+TestLangGer: wir lehren die Wissenschaft unseren Freund
+TestLangEng: we teach our friend the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (ComplVA become_VA (PastPartAP (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science becomes taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (ComplVA become_VA (PastPartAP (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science becomes taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends

--- a/tests/german/passive.pos.out
+++ b/tests/german/passive.pos.out
@@ -1,0 +1,195 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 give_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives us the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 give_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives the cars us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives the cars us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives us the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 give_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wird uns gegeben
+TestLangEng: the car is given us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash2V3 give_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen wird uns gegeben
+TestLangEng: the car is given us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekommen den Wagen gegeben
+TestLangEng: we are given the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wurde uns geschickt
+TestLangEng: the car was sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen wurde uns geschickt
+TestLangEng: the car was sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekamen den Wagen geschickt
+TestLangEng: we were sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen würde uns geschickt werden
+TestLangEng: the car would be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen würde uns geschickt werden
+TestLangEng: the car would be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen würde uns nicht geschickt werden
+TestLangEng: the car wouldn't be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt bekommen
+TestLangEng: we would be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir würden den Wagen nicht geschickt bekommen
+TestLangEng: we wouldn't be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden nicht den Wagen geschickt bekommen
+TestLangEng: we would be sent not the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir wollen den Wagen geschickt bekommen
+TestLangEng: we want to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash3V3 erklaeren_dat_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 erklaeren_dat_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 erklaeren_dat_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wurde uns nicht erklärt
+TestLangEng: the car wasn't explained to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekamen den Wagen nicht erklärt
+TestLangEng: we weren't explained the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN gold_N)))))) NoVoc
+TestLangGer: wir danken euch nicht für das Gold
+TestLangEng: we don't thank you for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))) (UsePron youPl_Pron))))) NoVoc
+TestLangGer: wir danken euch nicht für das Gold
+TestLangEng: we don't thank you for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youPl_Pron) (PassVPSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))))))) NoVoc
+TestLangGer: euch wird nicht für das Gold gedankt
+TestLangEng: you aren't thanked for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+TestLangGer: für die Bücher wird euch gedankt
+TestLangEng: the books are thanked you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (ComplSlashSlash (Slash3V4 kaufen_bei_fuer_V4 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (MassNP (UseN gold_N)))))) NoVoc
+TestLangGer: wir kaufen den Wagen bei dir für Gold
+TestLangEng: we buy for gold from you the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (ComplSlashSlash (Slash2V4 kaufen_bei_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron youSg_Pron)) (MassNP (UseN gold_N)))))) NoVoc
+TestLangGer: wir kaufen den Wagen bei dir für Gold
+TestLangEng: we buy for gold the car from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (ComplSlash (Pass2V4 kaufen_bei_fuer_V4 (DetCN much_Det (UseN gold_N))) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: der Wagen wurde für viel Gold bei dir gekauft
+TestLangEng: the car was bought for much gold from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: sie debattieren mit mir über das Buch
+TestLangEng: they debate with me about the book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: sie debattieren nicht mit mir über das Buch
+TestLangEng: they don't debate with me about the book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: mit mir wurde über das Buch debattiert
+TestLangEng: I was debated about the book with
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: mit mir wurde nicht über das Buch debattiert
+TestLangEng: I wasn't debated about the book with
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist mit mir debattiert worden
+TestLangEng: the book has been debated with me about
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist nicht mit mir debattiert worden
+TestLangEng: the book hasn't been debated with me about
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N))) (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: wir lehren unseren Freund die Wissenschaft
+TestLangEng: we teach our friend the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N))) (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: wir lehren unseren Freund die Wissenschaft
+TestLangEng: we teach the science our friend
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron she_Pron))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron they_Pron))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (Pass2V3 lehren_V3 (UsePron he_Pron))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him

--- a/tests/german/passive.trees
+++ b/tests/german/passive.trees
@@ -1,0 +1,37 @@
+PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 give_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash2V3 give_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 erklaeren_dat_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youPl_Pron) (PassVPSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (ComplSlash (Pass2V4 kaufen_bei_fuer_V4 (DetCN much_Det (UseN gold_N))) (UsePron youSg_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron she_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron they_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (Pass2V3 lehren_V3 (UsePron he_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron he_Pron)))))) NoVoc

--- a/tests/german/passive.txt
+++ b/tests/german/passive.txt
@@ -1,3 +1,30 @@
+-- Passive of V2 
+
+du wirst unterrichtet                      -- accept (dirV2)
+sie wird nicht angeschaut                  -- accept (dirV2 + prefixV)
+auf euch wird nicht gewartet               -- accept (prepV2)
+es wird auf euch gewartet                  -- accept (wrong trees: VPSlashPrep, become_VA, PrepNP)
+es wird auf euch nicht gewartet            -- accept (not recognized)
+
+ihr wurde nicht zugehört                   -- accept (V2 + dat) (PassVPSlash)
+
+-- Passive of V2A, V2S, V2Q
+
+der Wagen wurde nicht blau gemalt          -- accept (V2A) (PassVPSlash)
+wir fragen dich , ob du kommen wirst       -- accept 
+du wirst gefragt , ob du kommen wirst      -- accept (V2Q) (PassVPSlash)
+du wirst nicht gefragt , ob du nicht kommen willst -- accept 
+wir antworten dir , dass es regnet         -- accept
+dir wird geantwortet , dass es regnet      -- accept (V2S) (PassVPSlash)
+
+wir bitten dich , das Buch zu lesen        -- accept
+du wirst gebeten , das Buch zu lesen       -- accept (V2V) 
+du wirst gebeten das Buch zu lesen         -- accept (V2V) (not recognized)
+du wirst das Buch zu lesen gebeten         -- accept (V2V) (recognized)
+
+er wird gebeten , sich das Buch zu merken  -- accept (V2V) (PassVPSlash)
+ich werde gebeten , mir das Buch zu merken -- accept (not recognized) ext:Str, need ext:Agr=>Str
+
 -- Passive of VPSlash and V3
 
 sie gibt uns den Wagen                     -- accept
@@ -29,6 +56,7 @@ wir würden den Wagen geschickt haben bekommen wollen -- reject, dubious
 sie erklärten uns den Wagen nicht         -- accept
 der Wagen wurde uns nicht erklärt         -- accept
 wir bekamen den Wagen nicht erklärt       -- accept
+uns wurde den Wagen erklärt               -- reject (bug in PassVPSlash)
 
 wir danken euch nicht für das Gold        -- accept
 euch wird nicht für das Gold gedankt      -- accept
@@ -63,3 +91,20 @@ die Wissenschaft wird die Freunde gelehrt         -- reject
 er wird die Wissenschaft gelehrt                  -- accept
 er wird sie gelehrt                               -- accept
 sie wird ihn gelehrt                              -- accept
+
+-- Passive of V2Q, V2S, V2V 
+
+du wirst nicht gefragt , ob du kommen willst      -- accept (V2Q)
+uns wurde nicht geantwortet , daß ihr kommt       -- accept (V2S)
+
+du wirst gebeten , zu kommen                      -- accept (PassV2V)
+du wirst nicht gebeten , zu kommen                -- accept (PassV2V)
+du wirst nicht gebeten , nicht zu kommen          -- accept (not recognized, dubious)
+du wirst nicht gebeten , das Buch zu lesen        -- accept
+du wirst nicht gebeten , sich zu ändern           -- accept (dubious: dich/sich)
+du wirst nicht gebeten , dich zu fragen , ob du mir das Buch schicken willst -- accept
+mir wurde versprochen , das Buch zu lesen         -- accept (PassV2V)
+
+wir bitten euch euch zu fragen , ob ihr kommt     -- accept (dubious : missing comma)
+wir bitten dich dich zu ändern                    -- dubious (comma)
+

--- a/tests/german/passive.txt
+++ b/tests/german/passive.txt
@@ -1,0 +1,65 @@
+-- Passive of VPSlash and V3
+
+sie gibt uns den Wagen                     -- accept
+
+der Wagen wird uns gegeben                 -- accept, via PassVPSlash or Pass2V3
+uns wird der Wagen gegeben                 -- accept, word order variant (not recognized)
+wir bekommen den Wagen gegeben             -- accept, via Pass3V3
+
+sie schickte uns den Wagen                 -- accept (Eng with prep)
+                                           -- uns:dat+Wagen:sg,acc | uns:acc,Wagen:pl,dat
+
+der Wagen wurde uns geschickt              -- accept, via PassVPSlash
+uns wurde der Wagen geschickt              -- accept, word order variant (not recognized)
+wir bekamen den Wagen geschickt            -- accept, via Pass3V3
+
+der Wagen würde uns geschickt werden       -- accept
+der Wagen würde uns nicht geschickt werden -- accept
+wir würden den Wagen geschickt bekommen    -- accept
+wir würden den Wagen nicht geschickt bekommen -- accept
+wir würden nicht den Wagen geschickt bekommen -- accept ?
+
+der Wagen sei uns geschickt worden         -- accept
+wir hätten den Wagen geschickt bekommen    -- accept
+
+wir wollen den Wagen geschickt bekommen    -- accept
+wir würden den Wagen geschickt bekommen wollen haben -- accept, dubiuos
+wir würden den Wagen geschickt haben bekommen wollen -- reject, dubious
+
+sie erklärten uns den Wagen nicht         -- accept
+der Wagen wurde uns nicht erklärt         -- accept
+wir bekamen den Wagen nicht erklärt       -- accept
+
+wir danken euch nicht für das Gold        -- accept
+euch wird nicht für das Gold gedankt      -- accept
+für die Bücher wird euch gedankt          -- accept
+für die Bücher wird euch nicht gedankt    -- accept, dubious
+für die Bücher wird nicht euch gedankt    -- dubious
+
+wir kaufen den Wagen bei dir für Gold     -- accept
+der Wagen wird bei dir für Gold gekauft   -- accept (not parsed)
+der Wagen wurde für viel Gold bei dir gekauft -- accept (Obj.order: kaufen_bei_fuer)
+
+-- Passive with main verb v:V4
+
+sie debattieren mit mir über das Buch             -- accept 
+sie debattieren nicht mit mir über das Buch       -- accept 
+
+mit mir wurde über das Buch debattiert            -- accept
+mit mir wurde nicht über das Buch debattiert      -- accept
+über das Buch ist mit mir debattiert worden       -- accept 
+über das Buch ist nicht mit mir debattiert worden -- accept, dubious 
+über das Buch ist mit mir nicht debattiert worden -- accept, dubious
+
+-- Passive with main verb v:3 + acc + acc
+
+wir lehren unseren Freund die Wissenschaft        -- accept
+wir lehren die Wissenschaft unseren Freund        -- reject
+wir lehren sie ihn                                -- accept  (die Frau den Bauchtanz)
+wir lehren ihn sie                                -- accept
+
+die Freunde werden die Wissenschaft gelehrt       -- accept
+die Wissenschaft wird die Freunde gelehrt         -- reject
+er wird die Wissenschaft gelehrt                  -- accept
+er wird sie gelehrt                               -- accept
+sie wird ihn gelehrt                              -- accept

--- a/tests/german/vp-paradigm.README
+++ b/tests/german/vp-paradigm.README
@@ -1,0 +1,8 @@
+Since ../run.hs could not find module `Test.Framework.BlackBoxTest', I used
+
+      gf --run < vp-paradigm.gfs | diff vp-paradigm.out - > vp-paradigm.diff
+
+to produce the diff between the corrections shown in vp-paradigms.out and
+the original output of gf-rgl of 4/07/2019.                   
+
+vp-paradigms.gfs now loads the original alltenses/LangGer.gfo.  HL 3/7/2019

--- a/tests/german/vp-paradigm.diff
+++ b/tests/german/vp-paradigm.diff
@@ -1,0 +1,790 @@
+7,8c7,8
+< s MIndic Pres Anter Pos Main : er hat schlafen wollen
+< s MIndic Pres Anter Pos Inv : hat er schlafen wollen
+---
+> s MIndic Pres Anter Pos Main : er hat wollen schlafen
+> s MIndic Pres Anter Pos Inv : hat er wollen schlafen
+10,11c10,11
+< s MIndic Pres Anter Neg Main : er hat nicht schlafen wollen
+< s MIndic Pres Anter Neg Inv : hat er nicht schlafen wollen
+---
+> s MIndic Pres Anter Neg Main : er hat nicht wollen schlafen
+> s MIndic Pres Anter Neg Inv : hat er nicht wollen schlafen
+19,20c19,20
+< s MIndic Past Anter Pos Main : er hatte schlafen wollen
+< s MIndic Past Anter Pos Inv : hatte er schlafen wollen
+---
+> s MIndic Past Anter Pos Main : er hatte wollen schlafen
+> s MIndic Past Anter Pos Inv : hatte er wollen schlafen
+22,23c22,23
+< s MIndic Past Anter Neg Main : er hatte nicht schlafen wollen
+< s MIndic Past Anter Neg Inv : hatte er nicht schlafen wollen
+---
+> s MIndic Past Anter Neg Main : er hatte nicht wollen schlafen
+> s MIndic Past Anter Neg Inv : hatte er nicht wollen schlafen
+25,26c25,26
+< s MIndic Fut Simul Pos Main : er wird schlafen wollen
+< s MIndic Fut Simul Pos Inv : wird er schlafen wollen
+---
+> s MIndic Fut Simul Pos Main : er wird wollen schlafen
+> s MIndic Fut Simul Pos Inv : wird er wollen schlafen
+28,29c28,29
+< s MIndic Fut Simul Neg Main : er wird nicht schlafen wollen
+< s MIndic Fut Simul Neg Inv : wird er nicht schlafen wollen
+---
+> s MIndic Fut Simul Neg Main : er wird nicht wollen schlafen
+> s MIndic Fut Simul Neg Inv : wird er nicht wollen schlafen
+31,38c31,38
+< s MIndic Fut Anter Pos Main : er wird haben schlafen wollen
+< s MIndic Fut Anter Pos Inv : wird er haben schlafen wollen
+< s MIndic Fut Anter Pos Sub : er wird haben schlafen wollen
+< s MIndic Fut Anter Neg Main : er wird nicht haben schlafen wollen
+< s MIndic Fut Anter Neg Inv : wird er nicht haben schlafen wollen
+< s MIndic Fut Anter Neg Sub : er nicht wird haben schlafen wollen
+< s MIndic Cond Simul Pos Main : er würde schlafen wollen
+< s MIndic Cond Simul Pos Inv : würde er schlafen wollen
+---
+> s MIndic Fut Anter Pos Main : er wird wollen haben schlafen
+> s MIndic Fut Anter Pos Inv : wird er wollen haben schlafen
+> s MIndic Fut Anter Pos Sub : er wird schlafen wollen haben
+> s MIndic Fut Anter Neg Main : er wird nicht wollen haben schlafen
+> s MIndic Fut Anter Neg Inv : wird er nicht wollen haben schlafen
+> s MIndic Fut Anter Neg Sub : er nicht wird schlafen wollen haben
+> s MIndic Cond Simul Pos Main : er würde wollen schlafen
+> s MIndic Cond Simul Pos Inv : würde er wollen schlafen
+40,41c40,41
+< s MIndic Cond Simul Neg Main : er würde nicht schlafen wollen
+< s MIndic Cond Simul Neg Inv : würde er nicht schlafen wollen
+---
+> s MIndic Cond Simul Neg Main : er würde nicht wollen schlafen
+> s MIndic Cond Simul Neg Inv : würde er nicht wollen schlafen
+43,48c43,48
+< s MIndic Cond Anter Pos Main : er würde haben schlafen wollen
+< s MIndic Cond Anter Pos Inv : würde er haben schlafen wollen
+< s MIndic Cond Anter Pos Sub : er würde haben schlafen wollen
+< s MIndic Cond Anter Neg Main : er würde nicht haben schlafen wollen
+< s MIndic Cond Anter Neg Inv : würde er nicht haben schlafen wollen
+< s MIndic Cond Anter Neg Sub : er nicht würde haben schlafen wollen
+---
+> s MIndic Cond Anter Pos Main : er würde wollen haben schlafen
+> s MIndic Cond Anter Pos Inv : würde er wollen haben schlafen
+> s MIndic Cond Anter Pos Sub : er würde schlafen wollen haben
+> s MIndic Cond Anter Neg Main : er würde nicht wollen haben schlafen
+> s MIndic Cond Anter Neg Inv : würde er nicht wollen haben schlafen
+> s MIndic Cond Anter Neg Sub : er nicht würde schlafen wollen haben
+55,56c55,56
+< s MConjunct Pres Anter Pos Main : er habe schlafen wollen
+< s MConjunct Pres Anter Pos Inv : habe er schlafen wollen
+---
+> s MConjunct Pres Anter Pos Main : er habe wollen schlafen
+> s MConjunct Pres Anter Pos Inv : habe er wollen schlafen
+58,59c58,59
+< s MConjunct Pres Anter Neg Main : er habe nicht schlafen wollen
+< s MConjunct Pres Anter Neg Inv : habe er nicht schlafen wollen
+---
+> s MConjunct Pres Anter Neg Main : er habe nicht wollen schlafen
+> s MConjunct Pres Anter Neg Inv : habe er nicht wollen schlafen
+67,68c67,68
+< s MConjunct Past Anter Pos Main : er hätte schlafen wollen
+< s MConjunct Past Anter Pos Inv : hätte er schlafen wollen
+---
+> s MConjunct Past Anter Pos Main : er hätte wollen schlafen
+> s MConjunct Past Anter Pos Inv : hätte er wollen schlafen
+70,71c70,71
+< s MConjunct Past Anter Neg Main : er hätte nicht schlafen wollen
+< s MConjunct Past Anter Neg Inv : hätte er nicht schlafen wollen
+---
+> s MConjunct Past Anter Neg Main : er hätte nicht wollen schlafen
+> s MConjunct Past Anter Neg Inv : hätte er nicht wollen schlafen
+73,74c73,74
+< s MConjunct Fut Simul Pos Main : er werde schlafen wollen
+< s MConjunct Fut Simul Pos Inv : werde er schlafen wollen
+---
+> s MConjunct Fut Simul Pos Main : er werde wollen schlafen
+> s MConjunct Fut Simul Pos Inv : werde er wollen schlafen
+76,77c76,77
+< s MConjunct Fut Simul Neg Main : er werde nicht schlafen wollen
+< s MConjunct Fut Simul Neg Inv : werde er nicht schlafen wollen
+---
+> s MConjunct Fut Simul Neg Main : er werde nicht wollen schlafen
+> s MConjunct Fut Simul Neg Inv : werde er nicht wollen schlafen
+79,86c79,86
+< s MConjunct Fut Anter Pos Main : er werde haben schlafen wollen
+< s MConjunct Fut Anter Pos Inv : werde er haben schlafen wollen
+< s MConjunct Fut Anter Pos Sub : er werde haben schlafen wollen
+< s MConjunct Fut Anter Neg Main : er werde nicht haben schlafen wollen
+< s MConjunct Fut Anter Neg Inv : werde er nicht haben schlafen wollen
+< s MConjunct Fut Anter Neg Sub : er nicht werde haben schlafen wollen
+< s MConjunct Cond Simul Pos Main : er würde schlafen wollen
+< s MConjunct Cond Simul Pos Inv : würde er schlafen wollen
+---
+> s MConjunct Fut Anter Pos Main : er werde wollen haben schlafen
+> s MConjunct Fut Anter Pos Inv : werde er wollen haben schlafen
+> s MConjunct Fut Anter Pos Sub : er werde schlafen wollen haben
+> s MConjunct Fut Anter Neg Main : er werde nicht wollen haben schlafen
+> s MConjunct Fut Anter Neg Inv : werde er nicht wollen haben schlafen
+> s MConjunct Fut Anter Neg Sub : er nicht werde schlafen wollen haben
+> s MConjunct Cond Simul Pos Main : er würde wollen schlafen
+> s MConjunct Cond Simul Pos Inv : würde er wollen schlafen
+88,89c88,89
+< s MConjunct Cond Simul Neg Main : er würde nicht schlafen wollen
+< s MConjunct Cond Simul Neg Inv : würde er nicht schlafen wollen
+---
+> s MConjunct Cond Simul Neg Main : er würde nicht wollen schlafen
+> s MConjunct Cond Simul Neg Inv : würde er nicht wollen schlafen
+91,96c91,96
+< s MConjunct Cond Anter Pos Main : er würde haben schlafen wollen
+< s MConjunct Cond Anter Pos Inv : würde er haben schlafen wollen
+< s MConjunct Cond Anter Pos Sub : er würde haben schlafen wollen
+< s MConjunct Cond Anter Neg Main : er würde nicht haben schlafen wollen
+< s MConjunct Cond Anter Neg Inv : würde er nicht haben schlafen wollen
+< s MConjunct Cond Anter Neg Sub : er nicht würde haben schlafen wollen
+---
+> s MConjunct Cond Anter Pos Main : er würde wollen haben schlafen
+> s MConjunct Cond Anter Pos Inv : würde er wollen haben schlafen
+> s MConjunct Cond Anter Pos Sub : er würde schlafen wollen haben
+> s MConjunct Cond Anter Neg Main : er würde nicht wollen haben schlafen
+> s MConjunct Cond Anter Neg Inv : würde er nicht wollen haben schlafen
+> s MConjunct Cond Anter Neg Sub : er nicht würde schlafen wollen haben
+104,105c104,105
+< s MIndic Pres Anter Pos Main : er hat das Buch lesen wollen
+< s MIndic Pres Anter Pos Inv : hat er das Buch lesen wollen
+---
+> s MIndic Pres Anter Pos Main : er hat das Buch wollen lesen
+> s MIndic Pres Anter Pos Inv : hat er das Buch wollen lesen
+107,108c107,108
+< s MIndic Pres Anter Neg Main : er hat das Buch nicht lesen wollen
+< s MIndic Pres Anter Neg Inv : hat er das Buch nicht lesen wollen
+---
+> s MIndic Pres Anter Neg Main : er hat das Buch nicht wollen lesen
+> s MIndic Pres Anter Neg Inv : hat er das Buch nicht wollen lesen
+116,117c116,117
+< s MIndic Past Anter Pos Main : er hatte das Buch lesen wollen
+< s MIndic Past Anter Pos Inv : hatte er das Buch lesen wollen
+---
+> s MIndic Past Anter Pos Main : er hatte das Buch wollen lesen
+> s MIndic Past Anter Pos Inv : hatte er das Buch wollen lesen
+119,120c119,120
+< s MIndic Past Anter Neg Main : er hatte das Buch nicht lesen wollen
+< s MIndic Past Anter Neg Inv : hatte er das Buch nicht lesen wollen
+---
+> s MIndic Past Anter Neg Main : er hatte das Buch nicht wollen lesen
+> s MIndic Past Anter Neg Inv : hatte er das Buch nicht wollen lesen
+122,123c122,123
+< s MIndic Fut Simul Pos Main : er wird das Buch lesen wollen
+< s MIndic Fut Simul Pos Inv : wird er das Buch lesen wollen
+---
+> s MIndic Fut Simul Pos Main : er wird das Buch wollen lesen
+> s MIndic Fut Simul Pos Inv : wird er das Buch wollen lesen
+125,126c125,126
+< s MIndic Fut Simul Neg Main : er wird das Buch nicht lesen wollen
+< s MIndic Fut Simul Neg Inv : wird er das Buch nicht lesen wollen
+---
+> s MIndic Fut Simul Neg Main : er wird das Buch nicht wollen lesen
+> s MIndic Fut Simul Neg Inv : wird er das Buch nicht wollen lesen
+128,135c128,135
+< s MIndic Fut Anter Pos Main : er wird das Buch haben lesen wollen
+< s MIndic Fut Anter Pos Inv : wird er das Buch haben lesen wollen
+< s MIndic Fut Anter Pos Sub : er das Buch wird haben lesen wollen
+< s MIndic Fut Anter Neg Main : er wird das Buch nicht haben lesen wollen
+< s MIndic Fut Anter Neg Inv : wird er das Buch nicht haben lesen wollen
+< s MIndic Fut Anter Neg Sub : er das Buch nicht wird haben lesen wollen
+< s MIndic Cond Simul Pos Main : er würde das Buch lesen wollen
+< s MIndic Cond Simul Pos Inv : würde er das Buch lesen wollen
+---
+> s MIndic Fut Anter Pos Main : er wird das Buch wollen haben lesen
+> s MIndic Fut Anter Pos Inv : wird er das Buch wollen haben lesen
+> s MIndic Fut Anter Pos Sub : er das Buch wird lesen wollen haben
+> s MIndic Fut Anter Neg Main : er wird das Buch nicht wollen haben lesen
+> s MIndic Fut Anter Neg Inv : wird er das Buch nicht wollen haben lesen
+> s MIndic Fut Anter Neg Sub : er das Buch nicht wird lesen wollen haben
+> s MIndic Cond Simul Pos Main : er würde das Buch wollen lesen
+> s MIndic Cond Simul Pos Inv : würde er das Buch wollen lesen
+137,138c137,138
+< s MIndic Cond Simul Neg Main : er würde das Buch nicht lesen wollen
+< s MIndic Cond Simul Neg Inv : würde er das Buch nicht lesen wollen
+---
+> s MIndic Cond Simul Neg Main : er würde das Buch nicht wollen lesen
+> s MIndic Cond Simul Neg Inv : würde er das Buch nicht wollen lesen
+140,145c140,145
+< s MIndic Cond Anter Pos Main : er würde das Buch haben lesen wollen
+< s MIndic Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+< s MIndic Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+< s MIndic Cond Anter Neg Main : er würde das Buch nicht haben lesen wollen
+< s MIndic Cond Anter Neg Inv : würde er das Buch nicht haben lesen wollen
+< s MIndic Cond Anter Neg Sub : er das Buch nicht würde haben lesen wollen
+---
+> s MIndic Cond Anter Pos Main : er würde das Buch wollen haben lesen
+> s MIndic Cond Anter Pos Inv : würde er das Buch wollen haben lesen
+> s MIndic Cond Anter Pos Sub : er das Buch würde lesen wollen haben
+> s MIndic Cond Anter Neg Main : er würde das Buch nicht wollen haben lesen
+> s MIndic Cond Anter Neg Inv : würde er das Buch nicht wollen haben lesen
+> s MIndic Cond Anter Neg Sub : er das Buch nicht würde lesen wollen haben
+152,153c152,153
+< s MConjunct Pres Anter Pos Main : er habe das Buch lesen wollen
+< s MConjunct Pres Anter Pos Inv : habe er das Buch lesen wollen
+---
+> s MConjunct Pres Anter Pos Main : er habe das Buch wollen lesen
+> s MConjunct Pres Anter Pos Inv : habe er das Buch wollen lesen
+155,156c155,156
+< s MConjunct Pres Anter Neg Main : er habe das Buch nicht lesen wollen
+< s MConjunct Pres Anter Neg Inv : habe er das Buch nicht lesen wollen
+---
+> s MConjunct Pres Anter Neg Main : er habe das Buch nicht wollen lesen
+> s MConjunct Pres Anter Neg Inv : habe er das Buch nicht wollen lesen
+164,165c164,165
+< s MConjunct Past Anter Pos Main : er hätte das Buch lesen wollen
+< s MConjunct Past Anter Pos Inv : hätte er das Buch lesen wollen
+---
+> s MConjunct Past Anter Pos Main : er hätte das Buch wollen lesen
+> s MConjunct Past Anter Pos Inv : hätte er das Buch wollen lesen
+167,168c167,168
+< s MConjunct Past Anter Neg Main : er hätte das Buch nicht lesen wollen
+< s MConjunct Past Anter Neg Inv : hätte er das Buch nicht lesen wollen
+---
+> s MConjunct Past Anter Neg Main : er hätte das Buch nicht wollen lesen
+> s MConjunct Past Anter Neg Inv : hätte er das Buch nicht wollen lesen
+170,171c170,171
+< s MConjunct Fut Simul Pos Main : er werde das Buch lesen wollen
+< s MConjunct Fut Simul Pos Inv : werde er das Buch lesen wollen
+---
+> s MConjunct Fut Simul Pos Main : er werde das Buch wollen lesen
+> s MConjunct Fut Simul Pos Inv : werde er das Buch wollen lesen
+173,174c173,174
+< s MConjunct Fut Simul Neg Main : er werde das Buch nicht lesen wollen
+< s MConjunct Fut Simul Neg Inv : werde er das Buch nicht lesen wollen
+---
+> s MConjunct Fut Simul Neg Main : er werde das Buch nicht wollen lesen
+> s MConjunct Fut Simul Neg Inv : werde er das Buch nicht wollen lesen
+176,183c176,183
+< s MConjunct Fut Anter Pos Main : er werde das Buch haben lesen wollen
+< s MConjunct Fut Anter Pos Inv : werde er das Buch haben lesen wollen
+< s MConjunct Fut Anter Pos Sub : er das Buch werde haben lesen wollen
+< s MConjunct Fut Anter Neg Main : er werde das Buch nicht haben lesen wollen
+< s MConjunct Fut Anter Neg Inv : werde er das Buch nicht haben lesen wollen
+< s MConjunct Fut Anter Neg Sub : er das Buch nicht werde haben lesen wollen
+< s MConjunct Cond Simul Pos Main : er würde das Buch lesen wollen
+< s MConjunct Cond Simul Pos Inv : würde er das Buch lesen wollen
+---
+> s MConjunct Fut Anter Pos Main : er werde das Buch wollen haben lesen
+> s MConjunct Fut Anter Pos Inv : werde er das Buch wollen haben lesen
+> s MConjunct Fut Anter Pos Sub : er das Buch werde lesen wollen haben
+> s MConjunct Fut Anter Neg Main : er werde das Buch nicht wollen haben lesen
+> s MConjunct Fut Anter Neg Inv : werde er das Buch nicht wollen haben lesen
+> s MConjunct Fut Anter Neg Sub : er das Buch nicht werde lesen wollen haben
+> s MConjunct Cond Simul Pos Main : er würde das Buch wollen lesen
+> s MConjunct Cond Simul Pos Inv : würde er das Buch wollen lesen
+185,186c185,186
+< s MConjunct Cond Simul Neg Main : er würde das Buch nicht lesen wollen
+< s MConjunct Cond Simul Neg Inv : würde er das Buch nicht lesen wollen
+---
+> s MConjunct Cond Simul Neg Main : er würde das Buch nicht wollen lesen
+> s MConjunct Cond Simul Neg Inv : würde er das Buch nicht wollen lesen
+188,193c188,193
+< s MConjunct Cond Anter Pos Main : er würde das Buch haben lesen wollen
+< s MConjunct Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+< s MConjunct Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+< s MConjunct Cond Anter Neg Main : er würde das Buch nicht haben lesen wollen
+< s MConjunct Cond Anter Neg Inv : würde er das Buch nicht haben lesen wollen
+< s MConjunct Cond Anter Neg Sub : er das Buch nicht würde haben lesen wollen
+---
+> s MConjunct Cond Anter Pos Main : er würde das Buch wollen haben lesen
+> s MConjunct Cond Anter Pos Inv : würde er das Buch wollen haben lesen
+> s MConjunct Cond Anter Pos Sub : er das Buch würde lesen wollen haben
+> s MConjunct Cond Anter Neg Main : er würde das Buch nicht wollen haben lesen
+> s MConjunct Cond Anter Neg Inv : würde er das Buch nicht wollen haben lesen
+> s MConjunct Cond Anter Neg Sub : er das Buch nicht würde lesen wollen haben
+201,202c201,202
+< s MIndic Pres Anter Pos Main : er hat das Buch lesen wollen
+< s MIndic Pres Anter Pos Inv : hat er das Buch lesen wollen
+---
+> s MIndic Pres Anter Pos Main : er hat das Buch wollen lesen
+> s MIndic Pres Anter Pos Inv : hat er das Buch wollen lesen
+204,205c204,205
+< s MIndic Pres Anter Neg Main : er hat nicht das Buch lesen wollen
+< s MIndic Pres Anter Neg Inv : hat er nicht das Buch lesen wollen
+---
+> s MIndic Pres Anter Neg Main : er hat nicht das Buch wollen lesen
+> s MIndic Pres Anter Neg Inv : hat er nicht das Buch wollen lesen
+213,214c213,214
+< s MIndic Past Anter Pos Main : er hatte das Buch lesen wollen
+< s MIndic Past Anter Pos Inv : hatte er das Buch lesen wollen
+---
+> s MIndic Past Anter Pos Main : er hatte das Buch wollen lesen
+> s MIndic Past Anter Pos Inv : hatte er das Buch wollen lesen
+216,217c216,217
+< s MIndic Past Anter Neg Main : er hatte nicht das Buch lesen wollen
+< s MIndic Past Anter Neg Inv : hatte er nicht das Buch lesen wollen
+---
+> s MIndic Past Anter Neg Main : er hatte nicht das Buch wollen lesen
+> s MIndic Past Anter Neg Inv : hatte er nicht das Buch wollen lesen
+219,220c219,220
+< s MIndic Fut Simul Pos Main : er wird das Buch lesen wollen
+< s MIndic Fut Simul Pos Inv : wird er das Buch lesen wollen
+---
+> s MIndic Fut Simul Pos Main : er wird das Buch wollen lesen
+> s MIndic Fut Simul Pos Inv : wird er das Buch wollen lesen
+222,223c222,223
+< s MIndic Fut Simul Neg Main : er wird nicht das Buch lesen wollen
+< s MIndic Fut Simul Neg Inv : wird er nicht das Buch lesen wollen
+---
+> s MIndic Fut Simul Neg Main : er wird nicht das Buch wollen lesen
+> s MIndic Fut Simul Neg Inv : wird er nicht das Buch wollen lesen
+225,232c225,232
+< s MIndic Fut Anter Pos Main : er wird das Buch haben lesen wollen
+< s MIndic Fut Anter Pos Inv : wird er das Buch haben lesen wollen
+< s MIndic Fut Anter Pos Sub : er das Buch wird haben lesen wollen
+< s MIndic Fut Anter Neg Main : er wird nicht das Buch haben lesen wollen
+< s MIndic Fut Anter Neg Inv : wird er nicht das Buch haben lesen wollen
+< s MIndic Fut Anter Neg Sub : er nicht das Buch wird haben lesen wollen
+< s MIndic Cond Simul Pos Main : er würde das Buch lesen wollen
+< s MIndic Cond Simul Pos Inv : würde er das Buch lesen wollen
+---
+> s MIndic Fut Anter Pos Main : er wird das Buch wollen haben lesen
+> s MIndic Fut Anter Pos Inv : wird er das Buch wollen haben lesen
+> s MIndic Fut Anter Pos Sub : er das Buch wird lesen wollen haben
+> s MIndic Fut Anter Neg Main : er wird nicht das Buch wollen haben lesen
+> s MIndic Fut Anter Neg Inv : wird er nicht das Buch wollen haben lesen
+> s MIndic Fut Anter Neg Sub : er nicht das Buch wird lesen wollen haben
+> s MIndic Cond Simul Pos Main : er würde das Buch wollen lesen
+> s MIndic Cond Simul Pos Inv : würde er das Buch wollen lesen
+234,235c234,235
+< s MIndic Cond Simul Neg Main : er würde nicht das Buch lesen wollen
+< s MIndic Cond Simul Neg Inv : würde er nicht das Buch lesen wollen
+---
+> s MIndic Cond Simul Neg Main : er würde nicht das Buch wollen lesen
+> s MIndic Cond Simul Neg Inv : würde er nicht das Buch wollen lesen
+237,242c237,242
+< s MIndic Cond Anter Pos Main : er würde das Buch haben lesen wollen
+< s MIndic Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+< s MIndic Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+< s MIndic Cond Anter Neg Main : er würde nicht das Buch haben lesen wollen
+< s MIndic Cond Anter Neg Inv : würde er nicht das Buch haben lesen wollen
+< s MIndic Cond Anter Neg Sub : er nicht das Buch würde haben lesen wollen
+---
+> s MIndic Cond Anter Pos Main : er würde das Buch wollen haben lesen
+> s MIndic Cond Anter Pos Inv : würde er das Buch wollen haben lesen
+> s MIndic Cond Anter Pos Sub : er das Buch würde lesen wollen haben
+> s MIndic Cond Anter Neg Main : er würde nicht das Buch wollen haben lesen
+> s MIndic Cond Anter Neg Inv : würde er nicht das Buch wollen haben lesen
+> s MIndic Cond Anter Neg Sub : er nicht das Buch würde lesen wollen haben
+249,250c249,250
+< s MConjunct Pres Anter Pos Main : er habe das Buch lesen wollen
+< s MConjunct Pres Anter Pos Inv : habe er das Buch lesen wollen
+---
+> s MConjunct Pres Anter Pos Main : er habe das Buch wollen lesen
+> s MConjunct Pres Anter Pos Inv : habe er das Buch wollen lesen
+252,253c252,253
+< s MConjunct Pres Anter Neg Main : er habe nicht das Buch lesen wollen
+< s MConjunct Pres Anter Neg Inv : habe er nicht das Buch lesen wollen
+---
+> s MConjunct Pres Anter Neg Main : er habe nicht das Buch wollen lesen
+> s MConjunct Pres Anter Neg Inv : habe er nicht das Buch wollen lesen
+261,262c261,262
+< s MConjunct Past Anter Pos Main : er hätte das Buch lesen wollen
+< s MConjunct Past Anter Pos Inv : hätte er das Buch lesen wollen
+---
+> s MConjunct Past Anter Pos Main : er hätte das Buch wollen lesen
+> s MConjunct Past Anter Pos Inv : hätte er das Buch wollen lesen
+264,265c264,265
+< s MConjunct Past Anter Neg Main : er hätte nicht das Buch lesen wollen
+< s MConjunct Past Anter Neg Inv : hätte er nicht das Buch lesen wollen
+---
+> s MConjunct Past Anter Neg Main : er hätte nicht das Buch wollen lesen
+> s MConjunct Past Anter Neg Inv : hätte er nicht das Buch wollen lesen
+267,268c267,268
+< s MConjunct Fut Simul Pos Main : er werde das Buch lesen wollen
+< s MConjunct Fut Simul Pos Inv : werde er das Buch lesen wollen
+---
+> s MConjunct Fut Simul Pos Main : er werde das Buch wollen lesen
+> s MConjunct Fut Simul Pos Inv : werde er das Buch wollen lesen
+270,271c270,271
+< s MConjunct Fut Simul Neg Main : er werde nicht das Buch lesen wollen
+< s MConjunct Fut Simul Neg Inv : werde er nicht das Buch lesen wollen
+---
+> s MConjunct Fut Simul Neg Main : er werde nicht das Buch wollen lesen
+> s MConjunct Fut Simul Neg Inv : werde er nicht das Buch wollen lesen
+273,280c273,280
+< s MConjunct Fut Anter Pos Main : er werde das Buch haben lesen wollen
+< s MConjunct Fut Anter Pos Inv : werde er das Buch haben lesen wollen
+< s MConjunct Fut Anter Pos Sub : er das Buch werde haben lesen wollen
+< s MConjunct Fut Anter Neg Main : er werde nicht das Buch haben lesen wollen
+< s MConjunct Fut Anter Neg Inv : werde er nicht das Buch haben lesen wollen
+< s MConjunct Fut Anter Neg Sub : er nicht das Buch werde haben lesen wollen
+< s MConjunct Cond Simul Pos Main : er würde das Buch lesen wollen
+< s MConjunct Cond Simul Pos Inv : würde er das Buch lesen wollen
+---
+> s MConjunct Fut Anter Pos Main : er werde das Buch wollen haben lesen
+> s MConjunct Fut Anter Pos Inv : werde er das Buch wollen haben lesen
+> s MConjunct Fut Anter Pos Sub : er das Buch werde lesen wollen haben
+> s MConjunct Fut Anter Neg Main : er werde nicht das Buch wollen haben lesen
+> s MConjunct Fut Anter Neg Inv : werde er nicht das Buch wollen haben lesen
+> s MConjunct Fut Anter Neg Sub : er nicht das Buch werde lesen wollen haben
+> s MConjunct Cond Simul Pos Main : er würde das Buch wollen lesen
+> s MConjunct Cond Simul Pos Inv : würde er das Buch wollen lesen
+282,283c282,283
+< s MConjunct Cond Simul Neg Main : er würde nicht das Buch lesen wollen
+< s MConjunct Cond Simul Neg Inv : würde er nicht das Buch lesen wollen
+---
+> s MConjunct Cond Simul Neg Main : er würde nicht das Buch wollen lesen
+> s MConjunct Cond Simul Neg Inv : würde er nicht das Buch wollen lesen
+285,290c285,290
+< s MConjunct Cond Anter Pos Main : er würde das Buch haben lesen wollen
+< s MConjunct Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+< s MConjunct Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+< s MConjunct Cond Anter Neg Main : er würde nicht das Buch haben lesen wollen
+< s MConjunct Cond Anter Neg Inv : würde er nicht das Buch haben lesen wollen
+< s MConjunct Cond Anter Neg Sub : er nicht das Buch würde haben lesen wollen
+---
+> s MConjunct Cond Anter Pos Main : er würde das Buch wollen haben lesen
+> s MConjunct Cond Anter Pos Inv : würde er das Buch wollen haben lesen
+> s MConjunct Cond Anter Pos Sub : er das Buch würde lesen wollen haben
+> s MConjunct Cond Anter Neg Main : er würde nicht das Buch wollen haben lesen
+> s MConjunct Cond Anter Neg Inv : würde er nicht das Buch wollen haben lesen
+> s MConjunct Cond Anter Neg Sub : er nicht das Buch würde lesen wollen haben
+292,293c292,293
+< s MIndic Pres Simul Pos Main : wir wollen sagen , dass sie kommt
+< s MIndic Pres Simul Pos Inv : wollen wir sagen , dass sie kommt
+---
+> s MIndic Pres Simul Pos Main : wir wollen , dass sie kommt sagen
+> s MIndic Pres Simul Pos Inv : wollen wir , dass sie kommt sagen
+295,296c295,296
+< s MIndic Pres Simul Neg Main : wir wollen nicht sagen , dass sie kommt
+< s MIndic Pres Simul Neg Inv : wollen wir nicht sagen , dass sie kommt
+---
+> s MIndic Pres Simul Neg Main : wir wollen nicht , dass sie kommt sagen
+> s MIndic Pres Simul Neg Inv : wollen wir nicht , dass sie kommt sagen
+298,299c298,299
+< s MIndic Pres Anter Pos Main : wir haben sagen wollen , dass sie kommt
+< s MIndic Pres Anter Pos Inv : haben wir sagen wollen , dass sie kommt
+---
+> s MIndic Pres Anter Pos Main : wir haben wollen , dass sie kommt sagen
+> s MIndic Pres Anter Pos Inv : haben wir wollen , dass sie kommt sagen
+301,302c301,302
+< s MIndic Pres Anter Neg Main : wir haben nicht sagen wollen , dass sie kommt
+< s MIndic Pres Anter Neg Inv : haben wir nicht sagen wollen , dass sie kommt
+---
+> s MIndic Pres Anter Neg Main : wir haben nicht wollen , dass sie kommt sagen
+> s MIndic Pres Anter Neg Inv : haben wir nicht wollen , dass sie kommt sagen
+304,305c304,305
+< s MIndic Past Simul Pos Main : wir wollten sagen , dass sie kommt
+< s MIndic Past Simul Pos Inv : wollten wir sagen , dass sie kommt
+---
+> s MIndic Past Simul Pos Main : wir wollten , dass sie kommt sagen
+> s MIndic Past Simul Pos Inv : wollten wir , dass sie kommt sagen
+307,308c307,308
+< s MIndic Past Simul Neg Main : wir wollten nicht sagen , dass sie kommt
+< s MIndic Past Simul Neg Inv : wollten wir nicht sagen , dass sie kommt
+---
+> s MIndic Past Simul Neg Main : wir wollten nicht , dass sie kommt sagen
+> s MIndic Past Simul Neg Inv : wollten wir nicht , dass sie kommt sagen
+310,311c310,311
+< s MIndic Past Anter Pos Main : wir hatten sagen wollen , dass sie kommt
+< s MIndic Past Anter Pos Inv : hatten wir sagen wollen , dass sie kommt
+---
+> s MIndic Past Anter Pos Main : wir hatten wollen , dass sie kommt sagen
+> s MIndic Past Anter Pos Inv : hatten wir wollen , dass sie kommt sagen
+313,314c313,314
+< s MIndic Past Anter Neg Main : wir hatten nicht sagen wollen , dass sie kommt
+< s MIndic Past Anter Neg Inv : hatten wir nicht sagen wollen , dass sie kommt
+---
+> s MIndic Past Anter Neg Main : wir hatten nicht wollen , dass sie kommt sagen
+> s MIndic Past Anter Neg Inv : hatten wir nicht wollen , dass sie kommt sagen
+316,317c316,317
+< s MIndic Fut Simul Pos Main : wir werden sagen wollen , dass sie kommt
+< s MIndic Fut Simul Pos Inv : werden wir sagen wollen , dass sie kommt
+---
+> s MIndic Fut Simul Pos Main : wir werden wollen , dass sie kommt sagen
+> s MIndic Fut Simul Pos Inv : werden wir wollen , dass sie kommt sagen
+319,320c319,320
+< s MIndic Fut Simul Neg Main : wir werden nicht sagen wollen , dass sie kommt
+< s MIndic Fut Simul Neg Inv : werden wir nicht sagen wollen , dass sie kommt
+---
+> s MIndic Fut Simul Neg Main : wir werden nicht wollen , dass sie kommt sagen
+> s MIndic Fut Simul Neg Inv : werden wir nicht wollen , dass sie kommt sagen
+322,329c322,329
+< s MIndic Fut Anter Pos Main : wir werden haben sagen wollen , dass sie kommt
+< s MIndic Fut Anter Pos Inv : werden wir haben sagen wollen , dass sie kommt
+< s MIndic Fut Anter Pos Sub : wir werden haben sagen wollen , dass sie kommt
+< s MIndic Fut Anter Neg Main : wir werden nicht haben sagen wollen , dass sie kommt
+< s MIndic Fut Anter Neg Inv : werden wir nicht haben sagen wollen , dass sie kommt
+< s MIndic Fut Anter Neg Sub : wir nicht werden haben sagen wollen , dass sie kommt
+< s MIndic Cond Simul Pos Main : wir würden sagen wollen , dass sie kommt
+< s MIndic Cond Simul Pos Inv : würden wir sagen wollen , dass sie kommt
+---
+> s MIndic Fut Anter Pos Main : wir werden wollen haben , dass sie kommt sagen
+> s MIndic Fut Anter Pos Inv : werden wir wollen haben , dass sie kommt sagen
+> s MIndic Fut Anter Pos Sub : wir werden sagen wollen haben , dass sie kommt
+> s MIndic Fut Anter Neg Main : wir werden nicht wollen haben , dass sie kommt sagen
+> s MIndic Fut Anter Neg Inv : werden wir nicht wollen haben , dass sie kommt sagen
+> s MIndic Fut Anter Neg Sub : wir nicht werden sagen wollen haben , dass sie kommt
+> s MIndic Cond Simul Pos Main : wir würden wollen , dass sie kommt sagen
+> s MIndic Cond Simul Pos Inv : würden wir wollen , dass sie kommt sagen
+331,332c331,332
+< s MIndic Cond Simul Neg Main : wir würden nicht sagen wollen , dass sie kommt
+< s MIndic Cond Simul Neg Inv : würden wir nicht sagen wollen , dass sie kommt
+---
+> s MIndic Cond Simul Neg Main : wir würden nicht wollen , dass sie kommt sagen
+> s MIndic Cond Simul Neg Inv : würden wir nicht wollen , dass sie kommt sagen
+334,341c334,341
+< s MIndic Cond Anter Pos Main : wir würden haben sagen wollen , dass sie kommt
+< s MIndic Cond Anter Pos Inv : würden wir haben sagen wollen , dass sie kommt
+< s MIndic Cond Anter Pos Sub : wir würden haben sagen wollen , dass sie kommt
+< s MIndic Cond Anter Neg Main : wir würden nicht haben sagen wollen , dass sie kommt
+< s MIndic Cond Anter Neg Inv : würden wir nicht haben sagen wollen , dass sie kommt
+< s MIndic Cond Anter Neg Sub : wir nicht würden haben sagen wollen , dass sie kommt
+< s MConjunct Pres Simul Pos Main : wir wollen sagen , dass sie kommt
+< s MConjunct Pres Simul Pos Inv : wollen wir sagen , dass sie kommt
+---
+> s MIndic Cond Anter Pos Main : wir würden wollen haben , dass sie kommt sagen
+> s MIndic Cond Anter Pos Inv : würden wir wollen haben , dass sie kommt sagen
+> s MIndic Cond Anter Pos Sub : wir würden sagen wollen haben , dass sie kommt
+> s MIndic Cond Anter Neg Main : wir würden nicht wollen haben , dass sie kommt sagen
+> s MIndic Cond Anter Neg Inv : würden wir nicht wollen haben , dass sie kommt sagen
+> s MIndic Cond Anter Neg Sub : wir nicht würden sagen wollen haben , dass sie kommt
+> s MConjunct Pres Simul Pos Main : wir wollen , dass sie kommt sagen
+> s MConjunct Pres Simul Pos Inv : wollen wir , dass sie kommt sagen
+343,344c343,344
+< s MConjunct Pres Simul Neg Main : wir wollen nicht sagen , dass sie kommt
+< s MConjunct Pres Simul Neg Inv : wollen wir nicht sagen , dass sie kommt
+---
+> s MConjunct Pres Simul Neg Main : wir wollen nicht , dass sie kommt sagen
+> s MConjunct Pres Simul Neg Inv : wollen wir nicht , dass sie kommt sagen
+346,347c346,347
+< s MConjunct Pres Anter Pos Main : wir haben sagen wollen , dass sie kommt
+< s MConjunct Pres Anter Pos Inv : haben wir sagen wollen , dass sie kommt
+---
+> s MConjunct Pres Anter Pos Main : wir haben wollen , dass sie kommt sagen
+> s MConjunct Pres Anter Pos Inv : haben wir wollen , dass sie kommt sagen
+349,350c349,350
+< s MConjunct Pres Anter Neg Main : wir haben nicht sagen wollen , dass sie kommt
+< s MConjunct Pres Anter Neg Inv : haben wir nicht sagen wollen , dass sie kommt
+---
+> s MConjunct Pres Anter Neg Main : wir haben nicht wollen , dass sie kommt sagen
+> s MConjunct Pres Anter Neg Inv : haben wir nicht wollen , dass sie kommt sagen
+352,353c352,353
+< s MConjunct Past Simul Pos Main : wir wollten sagen , dass sie kommt
+< s MConjunct Past Simul Pos Inv : wollten wir sagen , dass sie kommt
+---
+> s MConjunct Past Simul Pos Main : wir wollten , dass sie kommt sagen
+> s MConjunct Past Simul Pos Inv : wollten wir , dass sie kommt sagen
+355,356c355,356
+< s MConjunct Past Simul Neg Main : wir wollten nicht sagen , dass sie kommt
+< s MConjunct Past Simul Neg Inv : wollten wir nicht sagen , dass sie kommt
+---
+> s MConjunct Past Simul Neg Main : wir wollten nicht , dass sie kommt sagen
+> s MConjunct Past Simul Neg Inv : wollten wir nicht , dass sie kommt sagen
+358,359c358,359
+< s MConjunct Past Anter Pos Main : wir hätten sagen wollen , dass sie kommt
+< s MConjunct Past Anter Pos Inv : hätten wir sagen wollen , dass sie kommt
+---
+> s MConjunct Past Anter Pos Main : wir hätten wollen , dass sie kommt sagen
+> s MConjunct Past Anter Pos Inv : hätten wir wollen , dass sie kommt sagen
+361,362c361,362
+< s MConjunct Past Anter Neg Main : wir hätten nicht sagen wollen , dass sie kommt
+< s MConjunct Past Anter Neg Inv : hätten wir nicht sagen wollen , dass sie kommt
+---
+> s MConjunct Past Anter Neg Main : wir hätten nicht wollen , dass sie kommt sagen
+> s MConjunct Past Anter Neg Inv : hätten wir nicht wollen , dass sie kommt sagen
+364,365c364,365
+< s MConjunct Fut Simul Pos Main : wir werden sagen wollen , dass sie kommt
+< s MConjunct Fut Simul Pos Inv : werden wir sagen wollen , dass sie kommt
+---
+> s MConjunct Fut Simul Pos Main : wir werden wollen , dass sie kommt sagen
+> s MConjunct Fut Simul Pos Inv : werden wir wollen , dass sie kommt sagen
+367,368c367,368
+< s MConjunct Fut Simul Neg Main : wir werden nicht sagen wollen , dass sie kommt
+< s MConjunct Fut Simul Neg Inv : werden wir nicht sagen wollen , dass sie kommt
+---
+> s MConjunct Fut Simul Neg Main : wir werden nicht wollen , dass sie kommt sagen
+> s MConjunct Fut Simul Neg Inv : werden wir nicht wollen , dass sie kommt sagen
+370,377c370,377
+< s MConjunct Fut Anter Pos Main : wir werden haben sagen wollen , dass sie kommt
+< s MConjunct Fut Anter Pos Inv : werden wir haben sagen wollen , dass sie kommt
+< s MConjunct Fut Anter Pos Sub : wir werden haben sagen wollen , dass sie kommt
+< s MConjunct Fut Anter Neg Main : wir werden nicht haben sagen wollen , dass sie kommt
+< s MConjunct Fut Anter Neg Inv : werden wir nicht haben sagen wollen , dass sie kommt
+< s MConjunct Fut Anter Neg Sub : wir nicht werden haben sagen wollen , dass sie kommt
+< s MConjunct Cond Simul Pos Main : wir würden sagen wollen , dass sie kommt
+< s MConjunct Cond Simul Pos Inv : würden wir sagen wollen , dass sie kommt
+---
+> s MConjunct Fut Anter Pos Main : wir werden wollen haben , dass sie kommt sagen
+> s MConjunct Fut Anter Pos Inv : werden wir wollen haben , dass sie kommt sagen
+> s MConjunct Fut Anter Pos Sub : wir werden sagen wollen haben , dass sie kommt
+> s MConjunct Fut Anter Neg Main : wir werden nicht wollen haben , dass sie kommt sagen
+> s MConjunct Fut Anter Neg Inv : werden wir nicht wollen haben , dass sie kommt sagen
+> s MConjunct Fut Anter Neg Sub : wir nicht werden sagen wollen haben , dass sie kommt
+> s MConjunct Cond Simul Pos Main : wir würden wollen , dass sie kommt sagen
+> s MConjunct Cond Simul Pos Inv : würden wir wollen , dass sie kommt sagen
+379,380c379,380
+< s MConjunct Cond Simul Neg Main : wir würden nicht sagen wollen , dass sie kommt
+< s MConjunct Cond Simul Neg Inv : würden wir nicht sagen wollen , dass sie kommt
+---
+> s MConjunct Cond Simul Neg Main : wir würden nicht wollen , dass sie kommt sagen
+> s MConjunct Cond Simul Neg Inv : würden wir nicht wollen , dass sie kommt sagen
+382,387c382,387
+< s MConjunct Cond Anter Pos Main : wir würden haben sagen wollen , dass sie kommt
+< s MConjunct Cond Anter Pos Inv : würden wir haben sagen wollen , dass sie kommt
+< s MConjunct Cond Anter Pos Sub : wir würden haben sagen wollen , dass sie kommt
+< s MConjunct Cond Anter Neg Main : wir würden nicht haben sagen wollen , dass sie kommt
+< s MConjunct Cond Anter Neg Inv : würden wir nicht haben sagen wollen , dass sie kommt
+< s MConjunct Cond Anter Neg Sub : wir nicht würden haben sagen wollen , dass sie kommt
+---
+> s MConjunct Cond Anter Pos Main : wir würden wollen haben , dass sie kommt sagen
+> s MConjunct Cond Anter Pos Inv : würden wir wollen haben , dass sie kommt sagen
+> s MConjunct Cond Anter Pos Sub : wir würden sagen wollen haben , dass sie kommt
+> s MConjunct Cond Anter Neg Main : wir würden nicht wollen haben , dass sie kommt sagen
+> s MConjunct Cond Anter Neg Inv : würden wir nicht wollen haben , dass sie kommt sagen
+> s MConjunct Cond Anter Neg Sub : wir nicht würden sagen wollen haben , dass sie kommt
+395,396c395,396
+< s MIndic Pres Anter Pos Main : das Buch ist gelesen worden
+< s MIndic Pres Anter Pos Inv : ist das Buch gelesen worden
+---
+> s MIndic Pres Anter Pos Main : das Buch ist worden gelesen
+> s MIndic Pres Anter Pos Inv : ist das Buch worden gelesen
+398,399c398,399
+< s MIndic Pres Anter Neg Main : das Buch ist nicht gelesen worden
+< s MIndic Pres Anter Neg Inv : ist das Buch nicht gelesen worden
+---
+> s MIndic Pres Anter Neg Main : das Buch ist nicht worden gelesen
+> s MIndic Pres Anter Neg Inv : ist das Buch nicht worden gelesen
+407,408c407,408
+< s MIndic Past Anter Pos Main : das Buch war gelesen worden
+< s MIndic Past Anter Pos Inv : war das Buch gelesen worden
+---
+> s MIndic Past Anter Pos Main : das Buch war worden gelesen
+> s MIndic Past Anter Pos Inv : war das Buch worden gelesen
+410,411c410,411
+< s MIndic Past Anter Neg Main : das Buch war nicht gelesen worden
+< s MIndic Past Anter Neg Inv : war das Buch nicht gelesen worden
+---
+> s MIndic Past Anter Neg Main : das Buch war nicht worden gelesen
+> s MIndic Past Anter Neg Inv : war das Buch nicht worden gelesen
+413,414c413,414
+< s MIndic Fut Simul Pos Main : das Buch wird gelesen werden
+< s MIndic Fut Simul Pos Inv : wird das Buch gelesen werden
+---
+> s MIndic Fut Simul Pos Main : das Buch wird werden gelesen
+> s MIndic Fut Simul Pos Inv : wird das Buch werden gelesen
+416,417c416,417
+< s MIndic Fut Simul Neg Main : das Buch wird nicht gelesen werden
+< s MIndic Fut Simul Neg Inv : wird das Buch nicht gelesen werden
+---
+> s MIndic Fut Simul Neg Main : das Buch wird nicht werden gelesen
+> s MIndic Fut Simul Neg Inv : wird das Buch nicht werden gelesen
+419,420c419,420
+< s MIndic Fut Anter Pos Main : das Buch wird gelesen worden sein
+< s MIndic Fut Anter Pos Inv : wird das Buch gelesen worden sein
+---
+> s MIndic Fut Anter Pos Main : das Buch wird worden sein gelesen
+> s MIndic Fut Anter Pos Inv : wird das Buch worden sein gelesen
+422,423c422,423
+< s MIndic Fut Anter Neg Main : das Buch wird nicht gelesen worden sein
+< s MIndic Fut Anter Neg Inv : wird das Buch nicht gelesen worden sein
+---
+> s MIndic Fut Anter Neg Main : das Buch wird nicht worden sein gelesen
+> s MIndic Fut Anter Neg Inv : wird das Buch nicht worden sein gelesen
+425,426c425,426
+< s MIndic Cond Simul Pos Main : das Buch würde gelesen werden
+< s MIndic Cond Simul Pos Inv : würde das Buch gelesen werden
+---
+> s MIndic Cond Simul Pos Main : das Buch würde werden gelesen
+> s MIndic Cond Simul Pos Inv : würde das Buch werden gelesen
+428,429c428,429
+< s MIndic Cond Simul Neg Main : das Buch würde nicht gelesen werden
+< s MIndic Cond Simul Neg Inv : würde das Buch nicht gelesen werden
+---
+> s MIndic Cond Simul Neg Main : das Buch würde nicht werden gelesen
+> s MIndic Cond Simul Neg Inv : würde das Buch nicht werden gelesen
+431,432c431,432
+< s MIndic Cond Anter Pos Main : das Buch würde gelesen worden sein
+< s MIndic Cond Anter Pos Inv : würde das Buch gelesen worden sein
+---
+> s MIndic Cond Anter Pos Main : das Buch würde worden sein gelesen
+> s MIndic Cond Anter Pos Inv : würde das Buch worden sein gelesen
+434,435c434,435
+< s MIndic Cond Anter Neg Main : das Buch würde nicht gelesen worden sein
+< s MIndic Cond Anter Neg Inv : würde das Buch nicht gelesen worden sein
+---
+> s MIndic Cond Anter Neg Main : das Buch würde nicht worden sein gelesen
+> s MIndic Cond Anter Neg Inv : würde das Buch nicht worden sein gelesen
+443,444c443,444
+< s MConjunct Pres Anter Pos Main : das Buch sei gelesen worden
+< s MConjunct Pres Anter Pos Inv : sei das Buch gelesen worden
+---
+> s MConjunct Pres Anter Pos Main : das Buch sei worden gelesen
+> s MConjunct Pres Anter Pos Inv : sei das Buch worden gelesen
+446,447c446,447
+< s MConjunct Pres Anter Neg Main : das Buch sei nicht gelesen worden
+< s MConjunct Pres Anter Neg Inv : sei das Buch nicht gelesen worden
+---
+> s MConjunct Pres Anter Neg Main : das Buch sei nicht worden gelesen
+> s MConjunct Pres Anter Neg Inv : sei das Buch nicht worden gelesen
+455,456c455,456
+< s MConjunct Past Anter Pos Main : das Buch wäre gelesen worden
+< s MConjunct Past Anter Pos Inv : wäre das Buch gelesen worden
+---
+> s MConjunct Past Anter Pos Main : das Buch wäre worden gelesen
+> s MConjunct Past Anter Pos Inv : wäre das Buch worden gelesen
+458,459c458,459
+< s MConjunct Past Anter Neg Main : das Buch wäre nicht gelesen worden
+< s MConjunct Past Anter Neg Inv : wäre das Buch nicht gelesen worden
+---
+> s MConjunct Past Anter Neg Main : das Buch wäre nicht worden gelesen
+> s MConjunct Past Anter Neg Inv : wäre das Buch nicht worden gelesen
+461,462c461,462
+< s MConjunct Fut Simul Pos Main : das Buch werde gelesen werden
+< s MConjunct Fut Simul Pos Inv : werde das Buch gelesen werden
+---
+> s MConjunct Fut Simul Pos Main : das Buch werde werden gelesen
+> s MConjunct Fut Simul Pos Inv : werde das Buch werden gelesen
+464,465c464,465
+< s MConjunct Fut Simul Neg Main : das Buch werde nicht gelesen werden
+< s MConjunct Fut Simul Neg Inv : werde das Buch nicht gelesen werden
+---
+> s MConjunct Fut Simul Neg Main : das Buch werde nicht werden gelesen
+> s MConjunct Fut Simul Neg Inv : werde das Buch nicht werden gelesen
+467,468c467,468
+< s MConjunct Fut Anter Pos Main : das Buch werde gelesen worden sein
+< s MConjunct Fut Anter Pos Inv : werde das Buch gelesen worden sein
+---
+> s MConjunct Fut Anter Pos Main : das Buch werde worden sein gelesen
+> s MConjunct Fut Anter Pos Inv : werde das Buch worden sein gelesen
+470,471c470,471
+< s MConjunct Fut Anter Neg Main : das Buch werde nicht gelesen worden sein
+< s MConjunct Fut Anter Neg Inv : werde das Buch nicht gelesen worden sein
+---
+> s MConjunct Fut Anter Neg Main : das Buch werde nicht worden sein gelesen
+> s MConjunct Fut Anter Neg Inv : werde das Buch nicht worden sein gelesen
+473,474c473,474
+< s MConjunct Cond Simul Pos Main : das Buch würde gelesen werden
+< s MConjunct Cond Simul Pos Inv : würde das Buch gelesen werden
+---
+> s MConjunct Cond Simul Pos Main : das Buch würde werden gelesen
+> s MConjunct Cond Simul Pos Inv : würde das Buch werden gelesen
+476,477c476,477
+< s MConjunct Cond Simul Neg Main : das Buch würde nicht gelesen werden
+< s MConjunct Cond Simul Neg Inv : würde das Buch nicht gelesen werden
+---
+> s MConjunct Cond Simul Neg Main : das Buch würde nicht werden gelesen
+> s MConjunct Cond Simul Neg Inv : würde das Buch nicht werden gelesen
+479,480c479,480
+< s MConjunct Cond Anter Pos Main : das Buch würde gelesen worden sein
+< s MConjunct Cond Anter Pos Inv : würde das Buch gelesen worden sein
+---
+> s MConjunct Cond Anter Pos Main : das Buch würde worden sein gelesen
+> s MConjunct Cond Anter Pos Inv : würde das Buch worden sein gelesen
+482,483c482,483
+< s MConjunct Cond Anter Neg Main : das Buch würde nicht gelesen worden sein
+< s MConjunct Cond Anter Neg Inv : würde das Buch nicht gelesen worden sein
+---
+> s MConjunct Cond Anter Neg Main : das Buch würde nicht worden sein gelesen
+> s MConjunct Cond Anter Neg Inv : würde das Buch nicht worden sein gelesen
+486c486
+< ich schicke der Frau das Buch
+---
+> ich schicke dem Buch die Frau
+488c488
+< ich schicke es ihr
+---
+> ich schicke ihm sie

--- a/tests/german/vp-paradigm.gfs
+++ b/tests/german/vp-paradigm.gfs
@@ -1,0 +1,21 @@
+-- To create vp-paradigm.out, I used changes of 30/6/2019 (in git branch vp-paradigm):
+-- i ../../src/german/LangGer.gf  
+-- Use gf --run < vp-paradigm.gfs > vp-paradigm.tmp to compare with gf-rgl.  HL 3/7/2019
+i alltenses/LangGer.gfo
+  
+-- verb phrases with modal verb
+l -lang=Ger -table (PredVP (UsePron he_Pron) (ComplVV want_VV (UseV sleep_V)))
+
+l -table (PredVP (UsePron he_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+l -table (PredVP (UsePron he_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+l -table (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplVS say_VS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (UseV come_V))))))
+
+-- verb phrase with PassV2
+l -table (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassV2 read_V2))
+
+-- pronoun switch:
+l PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+
+l PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc

--- a/tests/german/vp-paradigm.gfs
+++ b/tests/german/vp-paradigm.gfs
@@ -1,7 +1,7 @@
 -- To create vp-paradigm.out, I used changes of 30/6/2019 (in git branch vp-paradigm):
 -- i ../../src/german/LangGer.gf  
 -- Use gf --run < vp-paradigm.gfs > vp-paradigm.tmp to compare with gf-rgl.  HL 3/7/2019
-i alltenses/LangGer.gfo
+--i alltenses/LangGer.gfo
   
 -- verb phrases with modal verb
 l -lang=Ger -table (PredVP (UsePron he_Pron) (ComplVV want_VV (UseV sleep_V)))

--- a/tests/german/vp-paradigm.out
+++ b/tests/german/vp-paradigm.out
@@ -1,0 +1,489 @@
+s MIndic Pres Simul Pos Main : er will schlafen
+s MIndic Pres Simul Pos Inv : will er schlafen
+s MIndic Pres Simul Pos Sub : er schlafen will
+s MIndic Pres Simul Neg Main : er will nicht schlafen
+s MIndic Pres Simul Neg Inv : will er nicht schlafen
+s MIndic Pres Simul Neg Sub : er nicht schlafen will
+s MIndic Pres Anter Pos Main : er hat schlafen wollen
+s MIndic Pres Anter Pos Inv : hat er schlafen wollen
+s MIndic Pres Anter Pos Sub : er hat schlafen wollen
+s MIndic Pres Anter Neg Main : er hat nicht schlafen wollen
+s MIndic Pres Anter Neg Inv : hat er nicht schlafen wollen
+s MIndic Pres Anter Neg Sub : er nicht hat schlafen wollen
+s MIndic Past Simul Pos Main : er wollte schlafen
+s MIndic Past Simul Pos Inv : wollte er schlafen
+s MIndic Past Simul Pos Sub : er schlafen wollte
+s MIndic Past Simul Neg Main : er wollte nicht schlafen
+s MIndic Past Simul Neg Inv : wollte er nicht schlafen
+s MIndic Past Simul Neg Sub : er nicht schlafen wollte
+s MIndic Past Anter Pos Main : er hatte schlafen wollen
+s MIndic Past Anter Pos Inv : hatte er schlafen wollen
+s MIndic Past Anter Pos Sub : er hatte schlafen wollen
+s MIndic Past Anter Neg Main : er hatte nicht schlafen wollen
+s MIndic Past Anter Neg Inv : hatte er nicht schlafen wollen
+s MIndic Past Anter Neg Sub : er nicht hatte schlafen wollen
+s MIndic Fut Simul Pos Main : er wird schlafen wollen
+s MIndic Fut Simul Pos Inv : wird er schlafen wollen
+s MIndic Fut Simul Pos Sub : er schlafen wollen wird
+s MIndic Fut Simul Neg Main : er wird nicht schlafen wollen
+s MIndic Fut Simul Neg Inv : wird er nicht schlafen wollen
+s MIndic Fut Simul Neg Sub : er nicht schlafen wollen wird
+s MIndic Fut Anter Pos Main : er wird haben schlafen wollen
+s MIndic Fut Anter Pos Inv : wird er haben schlafen wollen
+s MIndic Fut Anter Pos Sub : er wird haben schlafen wollen
+s MIndic Fut Anter Neg Main : er wird nicht haben schlafen wollen
+s MIndic Fut Anter Neg Inv : wird er nicht haben schlafen wollen
+s MIndic Fut Anter Neg Sub : er nicht wird haben schlafen wollen
+s MIndic Cond Simul Pos Main : er würde schlafen wollen
+s MIndic Cond Simul Pos Inv : würde er schlafen wollen
+s MIndic Cond Simul Pos Sub : er schlafen wollen würde
+s MIndic Cond Simul Neg Main : er würde nicht schlafen wollen
+s MIndic Cond Simul Neg Inv : würde er nicht schlafen wollen
+s MIndic Cond Simul Neg Sub : er nicht schlafen wollen würde
+s MIndic Cond Anter Pos Main : er würde haben schlafen wollen
+s MIndic Cond Anter Pos Inv : würde er haben schlafen wollen
+s MIndic Cond Anter Pos Sub : er würde haben schlafen wollen
+s MIndic Cond Anter Neg Main : er würde nicht haben schlafen wollen
+s MIndic Cond Anter Neg Inv : würde er nicht haben schlafen wollen
+s MIndic Cond Anter Neg Sub : er nicht würde haben schlafen wollen
+s MConjunct Pres Simul Pos Main : er wolle schlafen
+s MConjunct Pres Simul Pos Inv : wolle er schlafen
+s MConjunct Pres Simul Pos Sub : er schlafen wolle
+s MConjunct Pres Simul Neg Main : er wolle nicht schlafen
+s MConjunct Pres Simul Neg Inv : wolle er nicht schlafen
+s MConjunct Pres Simul Neg Sub : er nicht schlafen wolle
+s MConjunct Pres Anter Pos Main : er habe schlafen wollen
+s MConjunct Pres Anter Pos Inv : habe er schlafen wollen
+s MConjunct Pres Anter Pos Sub : er habe schlafen wollen
+s MConjunct Pres Anter Neg Main : er habe nicht schlafen wollen
+s MConjunct Pres Anter Neg Inv : habe er nicht schlafen wollen
+s MConjunct Pres Anter Neg Sub : er nicht habe schlafen wollen
+s MConjunct Past Simul Pos Main : er wollte schlafen
+s MConjunct Past Simul Pos Inv : wollte er schlafen
+s MConjunct Past Simul Pos Sub : er schlafen wollte
+s MConjunct Past Simul Neg Main : er wollte nicht schlafen
+s MConjunct Past Simul Neg Inv : wollte er nicht schlafen
+s MConjunct Past Simul Neg Sub : er nicht schlafen wollte
+s MConjunct Past Anter Pos Main : er hätte schlafen wollen
+s MConjunct Past Anter Pos Inv : hätte er schlafen wollen
+s MConjunct Past Anter Pos Sub : er hätte schlafen wollen
+s MConjunct Past Anter Neg Main : er hätte nicht schlafen wollen
+s MConjunct Past Anter Neg Inv : hätte er nicht schlafen wollen
+s MConjunct Past Anter Neg Sub : er nicht hätte schlafen wollen
+s MConjunct Fut Simul Pos Main : er werde schlafen wollen
+s MConjunct Fut Simul Pos Inv : werde er schlafen wollen
+s MConjunct Fut Simul Pos Sub : er schlafen wollen werde
+s MConjunct Fut Simul Neg Main : er werde nicht schlafen wollen
+s MConjunct Fut Simul Neg Inv : werde er nicht schlafen wollen
+s MConjunct Fut Simul Neg Sub : er nicht schlafen wollen werde
+s MConjunct Fut Anter Pos Main : er werde haben schlafen wollen
+s MConjunct Fut Anter Pos Inv : werde er haben schlafen wollen
+s MConjunct Fut Anter Pos Sub : er werde haben schlafen wollen
+s MConjunct Fut Anter Neg Main : er werde nicht haben schlafen wollen
+s MConjunct Fut Anter Neg Inv : werde er nicht haben schlafen wollen
+s MConjunct Fut Anter Neg Sub : er nicht werde haben schlafen wollen
+s MConjunct Cond Simul Pos Main : er würde schlafen wollen
+s MConjunct Cond Simul Pos Inv : würde er schlafen wollen
+s MConjunct Cond Simul Pos Sub : er schlafen wollen würde
+s MConjunct Cond Simul Neg Main : er würde nicht schlafen wollen
+s MConjunct Cond Simul Neg Inv : würde er nicht schlafen wollen
+s MConjunct Cond Simul Neg Sub : er nicht schlafen wollen würde
+s MConjunct Cond Anter Pos Main : er würde haben schlafen wollen
+s MConjunct Cond Anter Pos Inv : würde er haben schlafen wollen
+s MConjunct Cond Anter Pos Sub : er würde haben schlafen wollen
+s MConjunct Cond Anter Neg Main : er würde nicht haben schlafen wollen
+s MConjunct Cond Anter Neg Inv : würde er nicht haben schlafen wollen
+s MConjunct Cond Anter Neg Sub : er nicht würde haben schlafen wollen
+
+s MIndic Pres Simul Pos Main : er will das Buch lesen
+s MIndic Pres Simul Pos Inv : will er das Buch lesen
+s MIndic Pres Simul Pos Sub : er das Buch lesen will
+s MIndic Pres Simul Neg Main : er will das Buch nicht lesen
+s MIndic Pres Simul Neg Inv : will er das Buch nicht lesen
+s MIndic Pres Simul Neg Sub : er das Buch nicht lesen will
+s MIndic Pres Anter Pos Main : er hat das Buch lesen wollen
+s MIndic Pres Anter Pos Inv : hat er das Buch lesen wollen
+s MIndic Pres Anter Pos Sub : er das Buch hat lesen wollen
+s MIndic Pres Anter Neg Main : er hat das Buch nicht lesen wollen
+s MIndic Pres Anter Neg Inv : hat er das Buch nicht lesen wollen
+s MIndic Pres Anter Neg Sub : er das Buch nicht hat lesen wollen
+s MIndic Past Simul Pos Main : er wollte das Buch lesen
+s MIndic Past Simul Pos Inv : wollte er das Buch lesen
+s MIndic Past Simul Pos Sub : er das Buch lesen wollte
+s MIndic Past Simul Neg Main : er wollte das Buch nicht lesen
+s MIndic Past Simul Neg Inv : wollte er das Buch nicht lesen
+s MIndic Past Simul Neg Sub : er das Buch nicht lesen wollte
+s MIndic Past Anter Pos Main : er hatte das Buch lesen wollen
+s MIndic Past Anter Pos Inv : hatte er das Buch lesen wollen
+s MIndic Past Anter Pos Sub : er das Buch hatte lesen wollen
+s MIndic Past Anter Neg Main : er hatte das Buch nicht lesen wollen
+s MIndic Past Anter Neg Inv : hatte er das Buch nicht lesen wollen
+s MIndic Past Anter Neg Sub : er das Buch nicht hatte lesen wollen
+s MIndic Fut Simul Pos Main : er wird das Buch lesen wollen
+s MIndic Fut Simul Pos Inv : wird er das Buch lesen wollen
+s MIndic Fut Simul Pos Sub : er das Buch lesen wollen wird
+s MIndic Fut Simul Neg Main : er wird das Buch nicht lesen wollen
+s MIndic Fut Simul Neg Inv : wird er das Buch nicht lesen wollen
+s MIndic Fut Simul Neg Sub : er das Buch nicht lesen wollen wird
+s MIndic Fut Anter Pos Main : er wird das Buch haben lesen wollen
+s MIndic Fut Anter Pos Inv : wird er das Buch haben lesen wollen
+s MIndic Fut Anter Pos Sub : er das Buch wird haben lesen wollen
+s MIndic Fut Anter Neg Main : er wird das Buch nicht haben lesen wollen
+s MIndic Fut Anter Neg Inv : wird er das Buch nicht haben lesen wollen
+s MIndic Fut Anter Neg Sub : er das Buch nicht wird haben lesen wollen
+s MIndic Cond Simul Pos Main : er würde das Buch lesen wollen
+s MIndic Cond Simul Pos Inv : würde er das Buch lesen wollen
+s MIndic Cond Simul Pos Sub : er das Buch lesen wollen würde
+s MIndic Cond Simul Neg Main : er würde das Buch nicht lesen wollen
+s MIndic Cond Simul Neg Inv : würde er das Buch nicht lesen wollen
+s MIndic Cond Simul Neg Sub : er das Buch nicht lesen wollen würde
+s MIndic Cond Anter Pos Main : er würde das Buch haben lesen wollen
+s MIndic Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+s MIndic Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+s MIndic Cond Anter Neg Main : er würde das Buch nicht haben lesen wollen
+s MIndic Cond Anter Neg Inv : würde er das Buch nicht haben lesen wollen
+s MIndic Cond Anter Neg Sub : er das Buch nicht würde haben lesen wollen
+s MConjunct Pres Simul Pos Main : er wolle das Buch lesen
+s MConjunct Pres Simul Pos Inv : wolle er das Buch lesen
+s MConjunct Pres Simul Pos Sub : er das Buch lesen wolle
+s MConjunct Pres Simul Neg Main : er wolle das Buch nicht lesen
+s MConjunct Pres Simul Neg Inv : wolle er das Buch nicht lesen
+s MConjunct Pres Simul Neg Sub : er das Buch nicht lesen wolle
+s MConjunct Pres Anter Pos Main : er habe das Buch lesen wollen
+s MConjunct Pres Anter Pos Inv : habe er das Buch lesen wollen
+s MConjunct Pres Anter Pos Sub : er das Buch habe lesen wollen
+s MConjunct Pres Anter Neg Main : er habe das Buch nicht lesen wollen
+s MConjunct Pres Anter Neg Inv : habe er das Buch nicht lesen wollen
+s MConjunct Pres Anter Neg Sub : er das Buch nicht habe lesen wollen
+s MConjunct Past Simul Pos Main : er wollte das Buch lesen
+s MConjunct Past Simul Pos Inv : wollte er das Buch lesen
+s MConjunct Past Simul Pos Sub : er das Buch lesen wollte
+s MConjunct Past Simul Neg Main : er wollte das Buch nicht lesen
+s MConjunct Past Simul Neg Inv : wollte er das Buch nicht lesen
+s MConjunct Past Simul Neg Sub : er das Buch nicht lesen wollte
+s MConjunct Past Anter Pos Main : er hätte das Buch lesen wollen
+s MConjunct Past Anter Pos Inv : hätte er das Buch lesen wollen
+s MConjunct Past Anter Pos Sub : er das Buch hätte lesen wollen
+s MConjunct Past Anter Neg Main : er hätte das Buch nicht lesen wollen
+s MConjunct Past Anter Neg Inv : hätte er das Buch nicht lesen wollen
+s MConjunct Past Anter Neg Sub : er das Buch nicht hätte lesen wollen
+s MConjunct Fut Simul Pos Main : er werde das Buch lesen wollen
+s MConjunct Fut Simul Pos Inv : werde er das Buch lesen wollen
+s MConjunct Fut Simul Pos Sub : er das Buch lesen wollen werde
+s MConjunct Fut Simul Neg Main : er werde das Buch nicht lesen wollen
+s MConjunct Fut Simul Neg Inv : werde er das Buch nicht lesen wollen
+s MConjunct Fut Simul Neg Sub : er das Buch nicht lesen wollen werde
+s MConjunct Fut Anter Pos Main : er werde das Buch haben lesen wollen
+s MConjunct Fut Anter Pos Inv : werde er das Buch haben lesen wollen
+s MConjunct Fut Anter Pos Sub : er das Buch werde haben lesen wollen
+s MConjunct Fut Anter Neg Main : er werde das Buch nicht haben lesen wollen
+s MConjunct Fut Anter Neg Inv : werde er das Buch nicht haben lesen wollen
+s MConjunct Fut Anter Neg Sub : er das Buch nicht werde haben lesen wollen
+s MConjunct Cond Simul Pos Main : er würde das Buch lesen wollen
+s MConjunct Cond Simul Pos Inv : würde er das Buch lesen wollen
+s MConjunct Cond Simul Pos Sub : er das Buch lesen wollen würde
+s MConjunct Cond Simul Neg Main : er würde das Buch nicht lesen wollen
+s MConjunct Cond Simul Neg Inv : würde er das Buch nicht lesen wollen
+s MConjunct Cond Simul Neg Sub : er das Buch nicht lesen wollen würde
+s MConjunct Cond Anter Pos Main : er würde das Buch haben lesen wollen
+s MConjunct Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+s MConjunct Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+s MConjunct Cond Anter Neg Main : er würde das Buch nicht haben lesen wollen
+s MConjunct Cond Anter Neg Inv : würde er das Buch nicht haben lesen wollen
+s MConjunct Cond Anter Neg Sub : er das Buch nicht würde haben lesen wollen
+
+s MIndic Pres Simul Pos Main : er will das Buch lesen
+s MIndic Pres Simul Pos Inv : will er das Buch lesen
+s MIndic Pres Simul Pos Sub : er das Buch lesen will
+s MIndic Pres Simul Neg Main : er will nicht das Buch lesen
+s MIndic Pres Simul Neg Inv : will er nicht das Buch lesen
+s MIndic Pres Simul Neg Sub : er nicht das Buch lesen will
+s MIndic Pres Anter Pos Main : er hat das Buch lesen wollen
+s MIndic Pres Anter Pos Inv : hat er das Buch lesen wollen
+s MIndic Pres Anter Pos Sub : er das Buch hat lesen wollen
+s MIndic Pres Anter Neg Main : er hat nicht das Buch lesen wollen
+s MIndic Pres Anter Neg Inv : hat er nicht das Buch lesen wollen
+s MIndic Pres Anter Neg Sub : er nicht das Buch hat lesen wollen
+s MIndic Past Simul Pos Main : er wollte das Buch lesen
+s MIndic Past Simul Pos Inv : wollte er das Buch lesen
+s MIndic Past Simul Pos Sub : er das Buch lesen wollte
+s MIndic Past Simul Neg Main : er wollte nicht das Buch lesen
+s MIndic Past Simul Neg Inv : wollte er nicht das Buch lesen
+s MIndic Past Simul Neg Sub : er nicht das Buch lesen wollte
+s MIndic Past Anter Pos Main : er hatte das Buch lesen wollen
+s MIndic Past Anter Pos Inv : hatte er das Buch lesen wollen
+s MIndic Past Anter Pos Sub : er das Buch hatte lesen wollen
+s MIndic Past Anter Neg Main : er hatte nicht das Buch lesen wollen
+s MIndic Past Anter Neg Inv : hatte er nicht das Buch lesen wollen
+s MIndic Past Anter Neg Sub : er nicht das Buch hatte lesen wollen
+s MIndic Fut Simul Pos Main : er wird das Buch lesen wollen
+s MIndic Fut Simul Pos Inv : wird er das Buch lesen wollen
+s MIndic Fut Simul Pos Sub : er das Buch lesen wollen wird
+s MIndic Fut Simul Neg Main : er wird nicht das Buch lesen wollen
+s MIndic Fut Simul Neg Inv : wird er nicht das Buch lesen wollen
+s MIndic Fut Simul Neg Sub : er nicht das Buch lesen wollen wird
+s MIndic Fut Anter Pos Main : er wird das Buch haben lesen wollen
+s MIndic Fut Anter Pos Inv : wird er das Buch haben lesen wollen
+s MIndic Fut Anter Pos Sub : er das Buch wird haben lesen wollen
+s MIndic Fut Anter Neg Main : er wird nicht das Buch haben lesen wollen
+s MIndic Fut Anter Neg Inv : wird er nicht das Buch haben lesen wollen
+s MIndic Fut Anter Neg Sub : er nicht das Buch wird haben lesen wollen
+s MIndic Cond Simul Pos Main : er würde das Buch lesen wollen
+s MIndic Cond Simul Pos Inv : würde er das Buch lesen wollen
+s MIndic Cond Simul Pos Sub : er das Buch lesen wollen würde
+s MIndic Cond Simul Neg Main : er würde nicht das Buch lesen wollen
+s MIndic Cond Simul Neg Inv : würde er nicht das Buch lesen wollen
+s MIndic Cond Simul Neg Sub : er nicht das Buch lesen wollen würde
+s MIndic Cond Anter Pos Main : er würde das Buch haben lesen wollen
+s MIndic Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+s MIndic Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+s MIndic Cond Anter Neg Main : er würde nicht das Buch haben lesen wollen
+s MIndic Cond Anter Neg Inv : würde er nicht das Buch haben lesen wollen
+s MIndic Cond Anter Neg Sub : er nicht das Buch würde haben lesen wollen
+s MConjunct Pres Simul Pos Main : er wolle das Buch lesen
+s MConjunct Pres Simul Pos Inv : wolle er das Buch lesen
+s MConjunct Pres Simul Pos Sub : er das Buch lesen wolle
+s MConjunct Pres Simul Neg Main : er wolle nicht das Buch lesen
+s MConjunct Pres Simul Neg Inv : wolle er nicht das Buch lesen
+s MConjunct Pres Simul Neg Sub : er nicht das Buch lesen wolle
+s MConjunct Pres Anter Pos Main : er habe das Buch lesen wollen
+s MConjunct Pres Anter Pos Inv : habe er das Buch lesen wollen
+s MConjunct Pres Anter Pos Sub : er das Buch habe lesen wollen
+s MConjunct Pres Anter Neg Main : er habe nicht das Buch lesen wollen
+s MConjunct Pres Anter Neg Inv : habe er nicht das Buch lesen wollen
+s MConjunct Pres Anter Neg Sub : er nicht das Buch habe lesen wollen
+s MConjunct Past Simul Pos Main : er wollte das Buch lesen
+s MConjunct Past Simul Pos Inv : wollte er das Buch lesen
+s MConjunct Past Simul Pos Sub : er das Buch lesen wollte
+s MConjunct Past Simul Neg Main : er wollte nicht das Buch lesen
+s MConjunct Past Simul Neg Inv : wollte er nicht das Buch lesen
+s MConjunct Past Simul Neg Sub : er nicht das Buch lesen wollte
+s MConjunct Past Anter Pos Main : er hätte das Buch lesen wollen
+s MConjunct Past Anter Pos Inv : hätte er das Buch lesen wollen
+s MConjunct Past Anter Pos Sub : er das Buch hätte lesen wollen
+s MConjunct Past Anter Neg Main : er hätte nicht das Buch lesen wollen
+s MConjunct Past Anter Neg Inv : hätte er nicht das Buch lesen wollen
+s MConjunct Past Anter Neg Sub : er nicht das Buch hätte lesen wollen
+s MConjunct Fut Simul Pos Main : er werde das Buch lesen wollen
+s MConjunct Fut Simul Pos Inv : werde er das Buch lesen wollen
+s MConjunct Fut Simul Pos Sub : er das Buch lesen wollen werde
+s MConjunct Fut Simul Neg Main : er werde nicht das Buch lesen wollen
+s MConjunct Fut Simul Neg Inv : werde er nicht das Buch lesen wollen
+s MConjunct Fut Simul Neg Sub : er nicht das Buch lesen wollen werde
+s MConjunct Fut Anter Pos Main : er werde das Buch haben lesen wollen
+s MConjunct Fut Anter Pos Inv : werde er das Buch haben lesen wollen
+s MConjunct Fut Anter Pos Sub : er das Buch werde haben lesen wollen
+s MConjunct Fut Anter Neg Main : er werde nicht das Buch haben lesen wollen
+s MConjunct Fut Anter Neg Inv : werde er nicht das Buch haben lesen wollen
+s MConjunct Fut Anter Neg Sub : er nicht das Buch werde haben lesen wollen
+s MConjunct Cond Simul Pos Main : er würde das Buch lesen wollen
+s MConjunct Cond Simul Pos Inv : würde er das Buch lesen wollen
+s MConjunct Cond Simul Pos Sub : er das Buch lesen wollen würde
+s MConjunct Cond Simul Neg Main : er würde nicht das Buch lesen wollen
+s MConjunct Cond Simul Neg Inv : würde er nicht das Buch lesen wollen
+s MConjunct Cond Simul Neg Sub : er nicht das Buch lesen wollen würde
+s MConjunct Cond Anter Pos Main : er würde das Buch haben lesen wollen
+s MConjunct Cond Anter Pos Inv : würde er das Buch haben lesen wollen
+s MConjunct Cond Anter Pos Sub : er das Buch würde haben lesen wollen
+s MConjunct Cond Anter Neg Main : er würde nicht das Buch haben lesen wollen
+s MConjunct Cond Anter Neg Inv : würde er nicht das Buch haben lesen wollen
+s MConjunct Cond Anter Neg Sub : er nicht das Buch würde haben lesen wollen
+
+s MIndic Pres Simul Pos Main : wir wollen sagen , dass sie kommt
+s MIndic Pres Simul Pos Inv : wollen wir sagen , dass sie kommt
+s MIndic Pres Simul Pos Sub : wir sagen wollen , dass sie kommt
+s MIndic Pres Simul Neg Main : wir wollen nicht sagen , dass sie kommt
+s MIndic Pres Simul Neg Inv : wollen wir nicht sagen , dass sie kommt
+s MIndic Pres Simul Neg Sub : wir nicht sagen wollen , dass sie kommt
+s MIndic Pres Anter Pos Main : wir haben sagen wollen , dass sie kommt
+s MIndic Pres Anter Pos Inv : haben wir sagen wollen , dass sie kommt
+s MIndic Pres Anter Pos Sub : wir haben sagen wollen , dass sie kommt
+s MIndic Pres Anter Neg Main : wir haben nicht sagen wollen , dass sie kommt
+s MIndic Pres Anter Neg Inv : haben wir nicht sagen wollen , dass sie kommt
+s MIndic Pres Anter Neg Sub : wir nicht haben sagen wollen , dass sie kommt
+s MIndic Past Simul Pos Main : wir wollten sagen , dass sie kommt
+s MIndic Past Simul Pos Inv : wollten wir sagen , dass sie kommt
+s MIndic Past Simul Pos Sub : wir sagen wollten , dass sie kommt
+s MIndic Past Simul Neg Main : wir wollten nicht sagen , dass sie kommt
+s MIndic Past Simul Neg Inv : wollten wir nicht sagen , dass sie kommt
+s MIndic Past Simul Neg Sub : wir nicht sagen wollten , dass sie kommt
+s MIndic Past Anter Pos Main : wir hatten sagen wollen , dass sie kommt
+s MIndic Past Anter Pos Inv : hatten wir sagen wollen , dass sie kommt
+s MIndic Past Anter Pos Sub : wir hatten sagen wollen , dass sie kommt
+s MIndic Past Anter Neg Main : wir hatten nicht sagen wollen , dass sie kommt
+s MIndic Past Anter Neg Inv : hatten wir nicht sagen wollen , dass sie kommt
+s MIndic Past Anter Neg Sub : wir nicht hatten sagen wollen , dass sie kommt
+s MIndic Fut Simul Pos Main : wir werden sagen wollen , dass sie kommt
+s MIndic Fut Simul Pos Inv : werden wir sagen wollen , dass sie kommt
+s MIndic Fut Simul Pos Sub : wir sagen wollen werden , dass sie kommt
+s MIndic Fut Simul Neg Main : wir werden nicht sagen wollen , dass sie kommt
+s MIndic Fut Simul Neg Inv : werden wir nicht sagen wollen , dass sie kommt
+s MIndic Fut Simul Neg Sub : wir nicht sagen wollen werden , dass sie kommt
+s MIndic Fut Anter Pos Main : wir werden haben sagen wollen , dass sie kommt
+s MIndic Fut Anter Pos Inv : werden wir haben sagen wollen , dass sie kommt
+s MIndic Fut Anter Pos Sub : wir werden haben sagen wollen , dass sie kommt
+s MIndic Fut Anter Neg Main : wir werden nicht haben sagen wollen , dass sie kommt
+s MIndic Fut Anter Neg Inv : werden wir nicht haben sagen wollen , dass sie kommt
+s MIndic Fut Anter Neg Sub : wir nicht werden haben sagen wollen , dass sie kommt
+s MIndic Cond Simul Pos Main : wir würden sagen wollen , dass sie kommt
+s MIndic Cond Simul Pos Inv : würden wir sagen wollen , dass sie kommt
+s MIndic Cond Simul Pos Sub : wir sagen wollen würden , dass sie kommt
+s MIndic Cond Simul Neg Main : wir würden nicht sagen wollen , dass sie kommt
+s MIndic Cond Simul Neg Inv : würden wir nicht sagen wollen , dass sie kommt
+s MIndic Cond Simul Neg Sub : wir nicht sagen wollen würden , dass sie kommt
+s MIndic Cond Anter Pos Main : wir würden haben sagen wollen , dass sie kommt
+s MIndic Cond Anter Pos Inv : würden wir haben sagen wollen , dass sie kommt
+s MIndic Cond Anter Pos Sub : wir würden haben sagen wollen , dass sie kommt
+s MIndic Cond Anter Neg Main : wir würden nicht haben sagen wollen , dass sie kommt
+s MIndic Cond Anter Neg Inv : würden wir nicht haben sagen wollen , dass sie kommt
+s MIndic Cond Anter Neg Sub : wir nicht würden haben sagen wollen , dass sie kommt
+s MConjunct Pres Simul Pos Main : wir wollen sagen , dass sie kommt
+s MConjunct Pres Simul Pos Inv : wollen wir sagen , dass sie kommt
+s MConjunct Pres Simul Pos Sub : wir sagen wollen , dass sie kommt
+s MConjunct Pres Simul Neg Main : wir wollen nicht sagen , dass sie kommt
+s MConjunct Pres Simul Neg Inv : wollen wir nicht sagen , dass sie kommt
+s MConjunct Pres Simul Neg Sub : wir nicht sagen wollen , dass sie kommt
+s MConjunct Pres Anter Pos Main : wir haben sagen wollen , dass sie kommt
+s MConjunct Pres Anter Pos Inv : haben wir sagen wollen , dass sie kommt
+s MConjunct Pres Anter Pos Sub : wir haben sagen wollen , dass sie kommt
+s MConjunct Pres Anter Neg Main : wir haben nicht sagen wollen , dass sie kommt
+s MConjunct Pres Anter Neg Inv : haben wir nicht sagen wollen , dass sie kommt
+s MConjunct Pres Anter Neg Sub : wir nicht haben sagen wollen , dass sie kommt
+s MConjunct Past Simul Pos Main : wir wollten sagen , dass sie kommt
+s MConjunct Past Simul Pos Inv : wollten wir sagen , dass sie kommt
+s MConjunct Past Simul Pos Sub : wir sagen wollten , dass sie kommt
+s MConjunct Past Simul Neg Main : wir wollten nicht sagen , dass sie kommt
+s MConjunct Past Simul Neg Inv : wollten wir nicht sagen , dass sie kommt
+s MConjunct Past Simul Neg Sub : wir nicht sagen wollten , dass sie kommt
+s MConjunct Past Anter Pos Main : wir hätten sagen wollen , dass sie kommt
+s MConjunct Past Anter Pos Inv : hätten wir sagen wollen , dass sie kommt
+s MConjunct Past Anter Pos Sub : wir hätten sagen wollen , dass sie kommt
+s MConjunct Past Anter Neg Main : wir hätten nicht sagen wollen , dass sie kommt
+s MConjunct Past Anter Neg Inv : hätten wir nicht sagen wollen , dass sie kommt
+s MConjunct Past Anter Neg Sub : wir nicht hätten sagen wollen , dass sie kommt
+s MConjunct Fut Simul Pos Main : wir werden sagen wollen , dass sie kommt
+s MConjunct Fut Simul Pos Inv : werden wir sagen wollen , dass sie kommt
+s MConjunct Fut Simul Pos Sub : wir sagen wollen werden , dass sie kommt
+s MConjunct Fut Simul Neg Main : wir werden nicht sagen wollen , dass sie kommt
+s MConjunct Fut Simul Neg Inv : werden wir nicht sagen wollen , dass sie kommt
+s MConjunct Fut Simul Neg Sub : wir nicht sagen wollen werden , dass sie kommt
+s MConjunct Fut Anter Pos Main : wir werden haben sagen wollen , dass sie kommt
+s MConjunct Fut Anter Pos Inv : werden wir haben sagen wollen , dass sie kommt
+s MConjunct Fut Anter Pos Sub : wir werden haben sagen wollen , dass sie kommt
+s MConjunct Fut Anter Neg Main : wir werden nicht haben sagen wollen , dass sie kommt
+s MConjunct Fut Anter Neg Inv : werden wir nicht haben sagen wollen , dass sie kommt
+s MConjunct Fut Anter Neg Sub : wir nicht werden haben sagen wollen , dass sie kommt
+s MConjunct Cond Simul Pos Main : wir würden sagen wollen , dass sie kommt
+s MConjunct Cond Simul Pos Inv : würden wir sagen wollen , dass sie kommt
+s MConjunct Cond Simul Pos Sub : wir sagen wollen würden , dass sie kommt
+s MConjunct Cond Simul Neg Main : wir würden nicht sagen wollen , dass sie kommt
+s MConjunct Cond Simul Neg Inv : würden wir nicht sagen wollen , dass sie kommt
+s MConjunct Cond Simul Neg Sub : wir nicht sagen wollen würden , dass sie kommt
+s MConjunct Cond Anter Pos Main : wir würden haben sagen wollen , dass sie kommt
+s MConjunct Cond Anter Pos Inv : würden wir haben sagen wollen , dass sie kommt
+s MConjunct Cond Anter Pos Sub : wir würden haben sagen wollen , dass sie kommt
+s MConjunct Cond Anter Neg Main : wir würden nicht haben sagen wollen , dass sie kommt
+s MConjunct Cond Anter Neg Inv : würden wir nicht haben sagen wollen , dass sie kommt
+s MConjunct Cond Anter Neg Sub : wir nicht würden haben sagen wollen , dass sie kommt
+
+s MIndic Pres Simul Pos Main : das Buch wird gelesen
+s MIndic Pres Simul Pos Inv : wird das Buch gelesen
+s MIndic Pres Simul Pos Sub : das Buch gelesen wird
+s MIndic Pres Simul Neg Main : das Buch wird nicht gelesen
+s MIndic Pres Simul Neg Inv : wird das Buch nicht gelesen
+s MIndic Pres Simul Neg Sub : das Buch nicht gelesen wird
+s MIndic Pres Anter Pos Main : das Buch ist gelesen worden
+s MIndic Pres Anter Pos Inv : ist das Buch gelesen worden
+s MIndic Pres Anter Pos Sub : das Buch gelesen worden ist
+s MIndic Pres Anter Neg Main : das Buch ist nicht gelesen worden
+s MIndic Pres Anter Neg Inv : ist das Buch nicht gelesen worden
+s MIndic Pres Anter Neg Sub : das Buch nicht gelesen worden ist
+s MIndic Past Simul Pos Main : das Buch wurde gelesen
+s MIndic Past Simul Pos Inv : wurde das Buch gelesen
+s MIndic Past Simul Pos Sub : das Buch gelesen wurde
+s MIndic Past Simul Neg Main : das Buch wurde nicht gelesen
+s MIndic Past Simul Neg Inv : wurde das Buch nicht gelesen
+s MIndic Past Simul Neg Sub : das Buch nicht gelesen wurde
+s MIndic Past Anter Pos Main : das Buch war gelesen worden
+s MIndic Past Anter Pos Inv : war das Buch gelesen worden
+s MIndic Past Anter Pos Sub : das Buch gelesen worden war
+s MIndic Past Anter Neg Main : das Buch war nicht gelesen worden
+s MIndic Past Anter Neg Inv : war das Buch nicht gelesen worden
+s MIndic Past Anter Neg Sub : das Buch nicht gelesen worden war
+s MIndic Fut Simul Pos Main : das Buch wird gelesen werden
+s MIndic Fut Simul Pos Inv : wird das Buch gelesen werden
+s MIndic Fut Simul Pos Sub : das Buch gelesen werden wird
+s MIndic Fut Simul Neg Main : das Buch wird nicht gelesen werden
+s MIndic Fut Simul Neg Inv : wird das Buch nicht gelesen werden
+s MIndic Fut Simul Neg Sub : das Buch nicht gelesen werden wird
+s MIndic Fut Anter Pos Main : das Buch wird gelesen worden sein
+s MIndic Fut Anter Pos Inv : wird das Buch gelesen worden sein
+s MIndic Fut Anter Pos Sub : das Buch gelesen worden sein wird
+s MIndic Fut Anter Neg Main : das Buch wird nicht gelesen worden sein
+s MIndic Fut Anter Neg Inv : wird das Buch nicht gelesen worden sein
+s MIndic Fut Anter Neg Sub : das Buch nicht gelesen worden sein wird
+s MIndic Cond Simul Pos Main : das Buch würde gelesen werden
+s MIndic Cond Simul Pos Inv : würde das Buch gelesen werden
+s MIndic Cond Simul Pos Sub : das Buch gelesen werden würde
+s MIndic Cond Simul Neg Main : das Buch würde nicht gelesen werden
+s MIndic Cond Simul Neg Inv : würde das Buch nicht gelesen werden
+s MIndic Cond Simul Neg Sub : das Buch nicht gelesen werden würde
+s MIndic Cond Anter Pos Main : das Buch würde gelesen worden sein
+s MIndic Cond Anter Pos Inv : würde das Buch gelesen worden sein
+s MIndic Cond Anter Pos Sub : das Buch gelesen worden sein würde
+s MIndic Cond Anter Neg Main : das Buch würde nicht gelesen worden sein
+s MIndic Cond Anter Neg Inv : würde das Buch nicht gelesen worden sein
+s MIndic Cond Anter Neg Sub : das Buch nicht gelesen worden sein würde
+s MConjunct Pres Simul Pos Main : das Buch werde gelesen
+s MConjunct Pres Simul Pos Inv : werde das Buch gelesen
+s MConjunct Pres Simul Pos Sub : das Buch gelesen werde
+s MConjunct Pres Simul Neg Main : das Buch werde nicht gelesen
+s MConjunct Pres Simul Neg Inv : werde das Buch nicht gelesen
+s MConjunct Pres Simul Neg Sub : das Buch nicht gelesen werde
+s MConjunct Pres Anter Pos Main : das Buch sei gelesen worden
+s MConjunct Pres Anter Pos Inv : sei das Buch gelesen worden
+s MConjunct Pres Anter Pos Sub : das Buch gelesen worden sei
+s MConjunct Pres Anter Neg Main : das Buch sei nicht gelesen worden
+s MConjunct Pres Anter Neg Inv : sei das Buch nicht gelesen worden
+s MConjunct Pres Anter Neg Sub : das Buch nicht gelesen worden sei
+s MConjunct Past Simul Pos Main : das Buch würde gelesen
+s MConjunct Past Simul Pos Inv : würde das Buch gelesen
+s MConjunct Past Simul Pos Sub : das Buch gelesen würde
+s MConjunct Past Simul Neg Main : das Buch würde nicht gelesen
+s MConjunct Past Simul Neg Inv : würde das Buch nicht gelesen
+s MConjunct Past Simul Neg Sub : das Buch nicht gelesen würde
+s MConjunct Past Anter Pos Main : das Buch wäre gelesen worden
+s MConjunct Past Anter Pos Inv : wäre das Buch gelesen worden
+s MConjunct Past Anter Pos Sub : das Buch gelesen worden wäre
+s MConjunct Past Anter Neg Main : das Buch wäre nicht gelesen worden
+s MConjunct Past Anter Neg Inv : wäre das Buch nicht gelesen worden
+s MConjunct Past Anter Neg Sub : das Buch nicht gelesen worden wäre
+s MConjunct Fut Simul Pos Main : das Buch werde gelesen werden
+s MConjunct Fut Simul Pos Inv : werde das Buch gelesen werden
+s MConjunct Fut Simul Pos Sub : das Buch gelesen werden werde
+s MConjunct Fut Simul Neg Main : das Buch werde nicht gelesen werden
+s MConjunct Fut Simul Neg Inv : werde das Buch nicht gelesen werden
+s MConjunct Fut Simul Neg Sub : das Buch nicht gelesen werden werde
+s MConjunct Fut Anter Pos Main : das Buch werde gelesen worden sein
+s MConjunct Fut Anter Pos Inv : werde das Buch gelesen worden sein
+s MConjunct Fut Anter Pos Sub : das Buch gelesen worden sein werde
+s MConjunct Fut Anter Neg Main : das Buch werde nicht gelesen worden sein
+s MConjunct Fut Anter Neg Inv : werde das Buch nicht gelesen worden sein
+s MConjunct Fut Anter Neg Sub : das Buch nicht gelesen worden sein werde
+s MConjunct Cond Simul Pos Main : das Buch würde gelesen werden
+s MConjunct Cond Simul Pos Inv : würde das Buch gelesen werden
+s MConjunct Cond Simul Pos Sub : das Buch gelesen werden würde
+s MConjunct Cond Simul Neg Main : das Buch würde nicht gelesen werden
+s MConjunct Cond Simul Neg Inv : würde das Buch nicht gelesen werden
+s MConjunct Cond Simul Neg Sub : das Buch nicht gelesen werden würde
+s MConjunct Cond Anter Pos Main : das Buch würde gelesen worden sein
+s MConjunct Cond Anter Pos Inv : würde das Buch gelesen worden sein
+s MConjunct Cond Anter Pos Sub : das Buch gelesen worden sein würde
+s MConjunct Cond Anter Neg Main : das Buch würde nicht gelesen worden sein
+s MConjunct Cond Anter Neg Inv : würde das Buch nicht gelesen worden sein
+s MConjunct Cond Anter Neg Sub : das Buch nicht gelesen worden sein würde
+
+ich schicke der Frau das Buch
+
+ich schicke es ihr
+


### PR DESCRIPTION
Ger: Some variations of passive and improvements of infinitives

         Passive (prelim. in tests/german/TestLangGer) to be added to ExtraGer,
         NP with w:Weight instead of isPron and isLight to regulate pronoun- and np-order in clauses,
         Refined versions of infinitives in SlashV2V, SlashVV, ComplVV (SlashV2VNP hardly compiles!),
         Tests with more VV and V2V verbs in tests/german/TestLang(Ger,Eng) infinitives.trees,gfs

Warning: Maybe VerbGer.SlashV2VNP has to be commented out to enable compiling
         