### PR TITLE
Ger: improved infinitives (and passives); tests with more verbs in te…

### DIFF
--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -89,7 +89,7 @@ concrete CatGer of Cat =
     V, VS, VQ = ResGer.Verb ; -- = {s : VForm => Str} ;
     VV = Verb ** {isAux : Bool} ;
     V2, VA, V2A, V2S, V2Q = Verb ** {c2 : Preposition} ;
-    V2V = Verb ** {c2 : Preposition ; isAux : Bool} ;
+    V2V = Verb ** {c2 : Preposition ; isAux : Bool ; ctrl : Control} ;
     V3 = Verb ** {c2, c3 : Preposition} ;
 
     A  = {s : Degree => AForm => Str} ;
@@ -106,7 +106,7 @@ concrete CatGer of Cat =
     Tense = {s : Str ; t : ResGer.Tense ; m : Mood} ;
 
   linref
-    NP = \np -> np.s!(NPC Nom) ++ np.adv ++ np.ext ++ np.rc ; -- HL 6/2019
+    NP = \np -> np.s!(NPC Nom) ++ np.ext ++ np.rc ; -- HL 6/2019
     CN = \cn -> cn.s ! Strong ! Pl ! Nom ++ cn.adv ++ cn.ext ++ cn.rc ! Pl ;
 
     SSlash = \ss -> ss.s ! Main ++ ss.c2.s  ;

--- a/src/german/DictGer.gf
+++ b/src/german/DictGer.gf
@@ -16980,7 +16980,7 @@ lin
   heldin_N = mkN  "Heldin" "Heldinnen" feminine ;
   heldisch_A = mk3A "heldisch" "heldischer" "heldischste" ;
   helena_N = mkN  "Helena" "Helenas" feminine ;
-  helfen_V = irregV "helfen" "helft" "half" "hälfe" "geholfen" ; 
+  helfen_V = irregV "helfen" "hilft" "half" "hälfe" "geholfen" ; 
   helfensteiner_N = mkN  "Helfensteiner" "Helfensteiner" masculine ;
   helfer_N = mkN  "Helfer" "Helfer" masculine ;
   helferlein_N = mkN  "Helferlein" "Helferlein" neuter ;
@@ -26112,7 +26112,7 @@ lin
   nachgruebeln_V = prefixV "nach" (regV "grübeln") ;
   nachhaken_5_V = prefixV "nach" (regV "haken") ;
   nachhaltig_A = mk3A "nachhaltig" "nachhaltiger" "nachhaltigste" ;
-  nachhelfen_6_V = prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen") ; 
+  nachhelfen_6_V = prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen") ; 
   nachher_Adv = mkAdv "nachher" ;
   nachhilfe_N = mkN  "Nachhilfe" "Nachhilfen" feminine ;
   nachhut_N = mkN  "Nachhut" "Nachhuten" feminine ;

--- a/src/german/DictVerbsGer.gf
+++ b/src/german/DictVerbsGer.gf
@@ -1032,8 +1032,8 @@ lin
   aussortieren_V2 = dirV2 (prefixV "aus" (regV "sortieren"))  ;
   ausspeichern_V2 = dirV2 (prefixV "aus" (regV "speichern"))  ;
   ausspionieren_V2 = dirV2 (prefixV "aus" (regV "spionieren"))  ;
-  aussprechen_V2 = dirV2 (prefixV "aus" (irregV "sprechen" "sprecht" "sprach" "spräche" "gesprochen"))  ;
-  aussprechen_VS = mkVS (prefixV "aus" (irregV "sprechen" "sprecht" "sprach" "spräche" "gesprochen"))  ;
+  aussprechen_V2 = dirV2 (prefixV "aus" (irregV "sprechen" "spricht" "sprach" "spräche" "gesprochen"))  ;
+  aussprechen_VS = mkVS (prefixV "aus" (irregV "sprechen" "spricht" "sprach" "spräche" "gesprochen"))  ;
   ausspucken_vor_V2 = prepV2 (prefixV "aus" (regV "spucken")) (mkPrep "vor" dative) ;
   ausspucken_V = prefixV "aus" (regV "spucken") ;
   ausstatten_mit_V3 = dirV3 (prefixV "aus" (regV "statten")) mit_Prep ;
@@ -1358,8 +1358,8 @@ lin
   besorgen_dat_V3 = accdatV3 (regV "besorgen")  ;
   besorgen_V2 = dirV2 (regV "besorgen")  ;
   bespassen_V2 = dirV2 (regV "bespaßen")  ;
-  besprechen_mit_V3 = dirV3 (irregV "besprechen" "besprecht" "besprach" "bespräche" "besprochen") mit_Prep ;
-  besprechen_plV2 = pldirV2 (irregV "besprechen" "besprecht" "besprach" "bespräche" "besprochen")  ;
+  besprechen_mit_V3 = dirV3 (irregV "besprechen" "bespricht" "besprach" "bespräche" "besprochen") mit_Prep ;
+  besprechen_plV2 = pldirV2 (irregV "besprechen" "bespricht" "besprach" "bespräche" "besprochen")  ;
   bespruehen_mit_V3 = dirV3 (regV "besprühen") mit_Prep ;
   bespruehen_V2 = dirV2 (regV "besprühen")  ;
   besseren_rV = reflV (regV "besseren") accusative ;
@@ -2146,8 +2146,8 @@ lin
   entsichern_V2 = dirV2 (irregV "entsichern" "entsichert" "entsicherte" "entsicherte" "entsichert")  ;
   entsorgen_V2 = dirV2 (irregV "entsorgen" "entsorgt" "entsorgte" "entsorgte" "entsorgt")  ;
   entspannen_rV = reflV (irregV "entspannen" "entspannt" "entspannte" "entspannte" "entspannt") accusative ;
-  entsprechen_dat_V2 = mkV2 (irregV "entsprechen" "entsprecht" "entsprach" "entspräche" "entsprochen") datPrep ;
-  entsprechen_rcV = reciV (irregV "entsprechen" "entsprecht" "entsprach" "entspräche" "entsprochen") dative ;
+  entsprechen_dat_V2 = mkV2 (irregV "entsprechen" "entspricht" "entsprach" "entspräche" "entsprochen") datPrep ;
+  entsprechen_rcV = reciV (irregV "entsprechen" "entspricht" "entsprach" "entspräche" "entsprochen") dative ;
   entspringen_loc_V2 = prepV2 (irregV "entspringen" "entspringt" "entsprang" "entspränge" "entsprungen") loc_Prep ;
   entstaatlichen_V2 = dirV2 (irregV "entstaatlichen" "entstaatlicht" "entstaatlichte" "entstaatlichte" "entstaatlicht")  ;
   entstammen_gen_V2 = mkV2 (irregV "entstammen" "entstammt" "entstammte" "entstammte" "entstammt") genPrep ;
@@ -3019,8 +3019,8 @@ lin
   heissen_V3 = dirV3 (irregV "heißen" "heißt" "hieß" "hieße" "geheißen") accPrep ;
   heizen_V2 = dirV2 (regV "heizen")  ;
   heizen_V = regV "heizen" ;
+  helfen_dat_V2V = mkV2V (irregV "helfen" "hilft" "half" "hälfe" "geholfen") datPrep ;
   helfen_dat_bei_V3 = mkV3 (irregV "helfen" "hilft" "half" "hülfe" "geholfen") datPrep bei_Prep ;
---  helfen_V = irregV "helfen" "helft" "half" "hälfe" "geholfen" ;
   hellen_es_esV = esV (regV "hellen")  ;
   hellenisieren_V2 = dirV2 (regV "hellenisieren")  ;
   hemmen_sV2 = dassV2 (regV "hemmen") accPrep ;
@@ -4142,8 +4142,8 @@ lin
   nachgruebeln_ueber_V2 = prepV2 (prefixV "nach" (regV "grübeln")) (mkPrep "über" dative) ;
   nachhaken_bei_V2 = prepV2 (prefixV "nach" (regV "haken")) bei_Prep ;
   nachhaken_V = prefixV "nach" (regV "haken") ;
-  nachhelfen_dat_V2 = mkV2 (prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen")) datPrep ;
-  nachhelfen_dat_V2V = mkV2V (prefixV "nach" (irregV "helfen" "helft" "half" "hälfe" "geholfen")) datPrep ;
+  nachhelfen_dat_V2 = mkV2 (prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen")) datPrep ;
+  nachhelfen_dat_V2V = mkV2V (prefixV "nach" (irregV "helfen" "hilft" "half" "hälfe" "geholfen")) datPrep ;
   nachkarten_V = prefixV "nach" (regV "karten") ;
   nachlassen_dat_V3 = accdatV3 (prefixV "nach" (irregV "lassen" "lasst" "ließ" "ließe" "gelassen"))  ;
   nachlassen_im_V2 = prepV2 (prefixV "nach" (irregV "lassen" "lasst" "ließ" "ließe" "gelassen")) (mkPrep "in" dative) ;
@@ -6492,7 +6492,7 @@ lin
   verspielen_rV = reflV (irregV "verspielen" "verspielt" "verspielte" "verspielte" "verspielt") accusative ;
   verspielen_V2 = dirV2 (irregV "verspielen" "verspielt" "verspielte" "verspielte" "verspielt")  ;
   verspotten_V2 = dirV2 (irregV "verspotten" "verspottet" "verspottete" "verspotte" "verspottet")  ;
-  versprechen_dat_V2V = mkV2V (irregV "versprechen" "versprecht" "versprach" "verspräche" "versprochen") datPrep ;
+  versprechen_dat_V2V = mkV2V (irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") datPrep ;
   versprengen_V2 = dirV2 (irregV "versprengen" "versprengt" "versprengte" "versprengte" "versprengt")  ;
   verspueren_V2 = dirV2 (irregV "verspüren" "verspürt" "verspürte" "verspürte" "verspürt")  ;
   verstaatlichen_V2 = dirV2 (irregV "verstaatlichen" "verstaatlicht" "verstaatlichte" "verstaatlichte" "verstaatlicht")  ;

--- a/src/german/DictVerbsGerAbs.gf
+++ b/src/german/DictVerbsGerAbs.gf
@@ -2882,6 +2882,7 @@ fun
   heissen_V3 : V3 ;
   heizen_V2 : V2 ;
   heizen_V : V ;
+  helfen_dat_V2V : V2V ;
   helfen_dat_bei_V3 : V3 ;
   hellen_es_esV : V ;
   hellenisieren_V2 : V2 ;

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -13,7 +13,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     ConjVPI = conjunctDistrTable Bool ;
 
     ComplVPIVV v vpi = 
-        insertInf (vpi.s ! v.isAux) (
+--        insertInf (vpi.s ! v.isAux) (
+      insertInf {s=(vpi.s ! v.isAux);isAux=v.isAux;ctrl=SubjC} ( -- HL ??
             predVGen v.isAux v) ; ----
 {-
       insertExtrapos vpi.p3 (
@@ -42,15 +43,19 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     DetNPMasc det = {
       s = \\c => det.sp ! Masc ! c ; ---- genders
       a = agrP3 det.n ;
-      isPron = False ;
-      ext, adv, rc = []
+      -- isPron = False ;
+      -- isLight = True ; 
+      w = WLight ;
+      ext, rc = []
       } ;
 
     DetNPFem det = {
       s = \\c => det.sp ! Fem ! c ; ---- genders
       a = agrP3 det.n ;
-      isPron = False ;
-      ext, adv, rc = []
+      -- isPron = False ;
+      -- isLight = True ; 
+      w = WLight ;
+      ext, rc = []
       } ;
 
     EmptyRelSlash slash = {
@@ -63,7 +68,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     PassVPSlash vp = 
 		let c = case <vp.c2.c,vp.c2.isPrep> of {
                <NPC Acc,False> => NPC Nom ;
-                                    _ => vp.c2.c}
+               _ => vp.c2.c}
 			in insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
 				{subjc = vp.c2 ** {c= c}} ;
 		-- regulates passivised object: accusative objects -> nom; all others: same case
@@ -73,8 +78,12 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     PassAgentVPSlash vp np = ---- "von" here, "durch" in StructuralGer
       insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
 
+    Pass3V3 v = -- HL 7/19
+      let bekommenPass : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") 
+      in insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommenPass) ** { subjc = PrepNom ; c2 = v.c2 } ;      
+
     PastPartAP vp = {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf ++ 
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf.s ++ 
                   vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
@@ -85,7 +94,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     let agent = appPrepNP P.von_Prep np
     in {
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ agent ++ 
-                   vp.inf ++ 
+                   vp.inf.s ++ 
                    vp.c2.s ++ --- junk if not TV
                    vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
       isPre = True ;
@@ -129,7 +138,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           m = tm.m ;
           subj  = [] ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
-          neg   = tm.s ++ p.s ++ vp.a1 ! b ;
+          neg   = tm.s ++ p.s ++ vp.a1 ++ negation ! b ; -- HL 8/19 ++ vp.a1 ! b ;
           -- obj1  = (vp.nn ! agr).p1 ;
           -- obj   = (vp.nn ! agr).p2 ; 
           -- compl = obj1 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
@@ -137,19 +146,19 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          inf   = vp.inf ++ verb.inf ++ verb.inf2 ;
+          inf   = vp.inf.s ++ verb.inf ++ verb.inf2 ;
           extra = vp.ext ;
           infE : Str =                              -- HL 30/6/2019
             case <t,a,vp.isAux> of {
               <Fut|Cond,Simul,True> => inf ;                           --# notpresent
               <Fut|Cond,Anter,True> -- Duden 318: kommen wollen haben => haben kommen wollen --# notpresent
-                => verb.inf2 ++ vp.inf ++ verb.inf ;                   --# notpresent
+                => verb.inf2 ++ vp.inf.s ++ verb.inf ;                   --# notpresent
               <_,Anter,True> => inf ;                                  --# notpresent
-              _ => verb.inf ++ verb.inf2 ++ vp.inf } ;
+              _ => verb.inf ++ verb.inf2 ++ vp.inf.s } ;
           inffin : Str =
             case <t,a,vp.isAux> of {
 	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => verb.fin ++ verb.inf2 ++ vp.inf ++ verb.inf ;  --# notpresent
+                     => verb.fin ++ verb.inf2 ++ vp.inf.s ++ verb.inf ;  --# notpresent
 	           <_,Anter,True>                                      --# notpresent
                      => verb.fin ++ inf ;            -- double inf     --# notpresent
                    _ => inf ++ verb.fin              --- or just auxiliary vp
@@ -204,8 +213,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
   lin
 	EsVV vv vp = predV vv ** {
-		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1 , n.p2 , n.p3, n.p4> ;
-		inf = vp.s.s ! (VInf True) ++ vp.inf ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
+		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1, n.p2, n.p3, n.p4, n.p5, n.p6> ;
+		inf = vp.inf ** {s = vp.s.s ! (VInf True) ++ vp.inf.s} ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
 		a1 = vp.a1 ;
 		a2 = vp.a2 ;
 		ext = vp.ext ;
@@ -213,7 +222,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 		adj = vp.adj } ;
 		
 	EsV2A v2a ap s = predV v2a ** {
-		nn = \\_ => <"es",[],[],[]> ; 
+		nn = \\_ => <"es",[],[],[],[],[]> ; 
 		adj = ap.s ! APred ; 
 		ext = "," ++ "dass" ++ s.s ! Sub} ;
 
@@ -228,7 +237,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
   		let vp = predV werdenPass ;
 		in vp ** {
 			subj = esSubj ; 
-			inf = v.s ! VPastPart APred } ; -- construct the formal clause
+			inf = vp.inf ** {s = v.s ! VPastPart APred } } ; -- construct the formal clause
 
 	AdvFor adv fcl = fcl ** {a2 = adv.s} ;
 	
@@ -244,9 +253,12 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
 	esSubj : NP = lin NP {
 		s = \\_ => "es" ; 
-		rc, ext, adv = [] ;
+		rc, ext = [] ;
 		a = Ag Neutr Sg P3 ;
-		isPron = True} ;
+                -- isLight = True ; 
+		-- isPron = True
+                w = WPron
+          } ;
 
 	DisToCl : Str -> Agr -> FClause -> Clause = \subj,agr,vp ->  
 	  let vps = useVP vp in {
@@ -257,11 +269,11 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
             _ => False
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
-          neg   = vp.a1 ! b ;
+          neg   = vp.a1 ++ negation ! b ; -- HL 8/19 vp.a1 ! b ;
           obj1  = (vp.nn ! agr).p1 ;
           obj2  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ;
           compl = obj1 ++ neg  ++ vp.adj ++ obj2 ++ vp.a2 ; -- adj added
-          inf   = vp.inf ++ verb.inf ; -- not used for linearisation of Main/Inv
+          inf   = vp.inf.s ++ verb.inf ; -- not used for linearisation of Main/Inv
           extra = vp.ext ;
           inffin : Str = 
             case <a,vp.isAux> of {                       
@@ -270,8 +282,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
             }                                            
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
-	    Inv  => verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf ;
+	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
+	    Inv  => verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
 	    Sub  => compl ++ vp.infExt ++ inffin ++ extra }
     		} ; 
 		

--- a/src/german/ExtraGerAbs.gf
+++ b/src/german/ExtraGerAbs.gf
@@ -26,4 +26,5 @@ abstract ExtraGerAbs = Extra [
   	AdvFor : Adv -> FClause -> FClause ; -- es wird heute gelacht - addition of adverbs
   	FtoCl : FClause -> Cl ;  -- embedding FClause within the RGL, to allow generation of S, Utt, etc.
 
+     Pass3V3 : V3 -> VPSlash ; -- wir bekommen den Beweis erklärt
 }

--- a/src/german/MorphoGer.gf
+++ b/src/german/MorphoGer.gf
@@ -20,10 +20,12 @@ oper
   mkPrep : Str -> PCase -> Preposition = \s,c -> 
     {s = s ; s2 = [] ; c = c ; isPrep = True} ;
 
-  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; isPron : Bool ; ext,adv,rc : Str} = \name -> heavyNP {
+  nameNounPhrase : {s : Case => Str} ->  {s : PCase => Str ; a : Agr ; 
+                                          -- isLight, isPron : Bool ; 
+                                          w : Weight ;
+                                          ext,rc : Str} = \name -> heavyNP {
       s = \\c => usePrepC c (\k -> name.s ! k) ;
-      a = agrP3 Sg ;
-	  ext, adv, rc = [] -- added
+      a = agrP3 Sg 
       } ;
 
   detLikeAdj : Bool -> Number -> Str -> 

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -2,39 +2,46 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
 
   flags optimize=all_subs ;
 
+-- Remark: np.isLight makes ResGer.insertObjNP expensive, for ComplSlash, SlashVP
+
   lin
     DetCN det cn = {
       s = \\c => det.s ! cn.g ! c ++ 
-                 (let k = (prepC c).c in cn.s ! adjfCase det.a k ! det.n ! k) ;
+                 (let k = (prepC c).c in cn.s ! adjfCase det.a k ! det.n ! k ++ cn.adv) ;
       a = agrgP3 cn.g det.n ;  
---      isPron = det.isDef ;   -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
-      isPron = False ;       -- HL 6/2019 (but:) sehe (die|einige) Männer nicht
-      rc = cn.rc ! det.n ;   --                  don't see a|no man = sehe keinen Mann
-      adv = cn.adv ;
+      -- isLight = det.isDef ;  -- ich sehe den Mann nicht vs. ich sehe nicht einen Mann
+      -- isPron = False ;       -- HL 6/2019 (but:) sehe (die|einige) Männer nicht
+                                --                  don't see a|no man = sehe keinen Mann
+      w = case det.isDef of { True => WLight ; _ => WHeavy } ;
+      rc = cn.rc ! det.n ;   
       ext = cn.ext 
       } ;
 
     DetNP det = {
       s = \\c => det.sp ! Neutr ! c ; -- more genders in ExtraGer -- HL: der+er,den+en ; der drei,den drei+en
       a = agrP3 det.n ;
-      -- isPron = det.isDef ;   
-      isPron = False ; -- HL 6/2019: don't apply pronoun switch: ich gebe ihr das  vs. ich gebe es ihr
-      rc, adv, ext = []
+      -- isLight = det.isDef ;
+      -- isPron = False ; -- HL 6/2019: don't apply pronoun switch: ich gebe ihr das  vs. ich gebe es ihr
+      w = case det.isDef of { True => WLight ; _ => WHeavy } ;
+      rc, ext = []
       } ;
 
     UsePN pn = {
       s = \\c => usePrepC c (\k -> pn.s ! k) ;
       a = agrgP3 pn.g Sg ;
---      isPron = True ; --- means: this is not a heavy NP, but comes before negation
-      isPron = False ;  -- HL 6/2019: to regulate Pron/NonPronNP order 
- 	  rc, adv, ext = []
+--      isLight = True ;  -- means: this is not a heavy NP, but comes before negation
+--      isPron = False ;  -- HL 6/2019: to regulate Pron/NonPronNP order 
+      w = WLight ;  
+      rc, ext = []
       } ;
 
     UsePron pron = {
       s = \\c => usePrepC c (\k -> pron.s ! NPCase k) ;
       a = pron.a ;
-      isPron = True ;
-	  rc, adv, ext = []
+      -- isLight = True ;
+      -- isPron = True ;
+      w = WPron ;
+      rc, ext = []
       } ;
 
     PredetNP pred np = 
@@ -43,25 +50,32 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
           let c = case pred.c.k of {NoCase => c0 ; PredCase k => k} in
           pred.s ! numberAgr ag ! genderAgr np.a ! c0 ++ pred.c.p ++ np.s ! c ; 
         a = ag ;
-        isPron = False
+        -- isLight = False ;
+        -- isPron = False
+        w = WHeavy 
         } ;
 
     PPartNP np v2 = np ** {
-      s = \\c => np.s ! c ++ v2.s ! VPastPart APred ; --- invar part
-      isPron = False
+      s = \\c => np.s ! c ++ embedInCommas (v2.s ! VPastPart APred) ; --- invar part
+--      isPron = False
+      w = WHeavy 
       } ;
-	{- possibly structures such as
-		"sie ist eine erfolgreiche Frau geliebt von vielen"
-	 but only with v2 not possible in German? -}
+	{- "eine erfolgreiche Frau, geliebt von vielen,"  but only with v2 not possible in German?
+            HL: PPartNP np vps|vp: "der Autor, heute vergessen" , "der Mond, gerade aufgegangen,"
+         -}
 	
     AdvNP np adv = np ** {
-      adv = np.adv ++ adv.s ;
-      isPron = False
+      s = \\c => np.s ! c ++ adv.s ;
+      -- isLight = False ;
+      -- isPron = False
+      w = WHeavy 
       } ;
 
     ExtAdvNP np adv = np ** {
-      adv = np.adv ++ embedInCommas adv.s ;
-      isPron = False
+      s = \\c => np.s ! c ++ embedInCommas adv.s ;
+      -- isLight = False ;
+      -- isPron = False
+      w = WHeavy 
       } ;
 
     DetQuantOrd quant num ord = 
@@ -151,19 +165,20 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       } ;
 
     MassNP cn = {
-      s = \\c => usePrepC c (\k -> cn.s ! Strong ! Sg ! k) ;
+      s = \\c => usePrepC c (\k -> cn.s ! Strong ! Sg ! k) ++ cn.adv ;
       a = agrgP3 cn.g Sg ;
-      isPron = False ;
-	  rc = cn.rc ! Sg ;
-	  adv = cn.adv ;
-	  ext = cn.ext 
+      -- isLight = True ;  -- ich trinke Bier nicht vs. ich trinke kein Bier
+      -- isPron = False ;
+      w = WLight ;
+      rc = cn.rc ! Sg ;
+      ext = cn.ext
       } ;
 
     UseN, UseN2 = \n -> {
       s = \\_ => n.s ;
       g = n.g ;
-	  rc = \\_ => [] ;
-	  ext,adv = [] 
+      rc = \\_ => [] ;
+      ext,adv = [] 
       } ;
 
     ComplN2 f x = {
@@ -182,8 +197,6 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
        } ;
       g = f.g ; 
       c2 = f.c3 ;
-	  rc = \\_ => [] ;
-	  ext,adv = [] 
       } ;
 
     Use2N3 f = f ;
@@ -209,7 +222,9 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     
     RelNP np rs = np ** {
       rc = (np.rc ++ embedInCommas (rs.s ! RGenNum (gennum (genderAgr np.a) (numberAgr np.a)))) ;
-      isPron = False } ;
+      -- isPron = False 
+      w = case isPron np of { True => WLight ; _ => np.w } 
+      } ;
 
     SentCN cn s = cn ** {ext = cn.ext ++ embedInCommas s.s} ;
 

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -302,7 +302,7 @@ mkV2 : overload {
   mkV0  : V -> V0 ; --%
   mkVS  : V -> VS ;
 
-  mkV2V : overload { -- with zu
+  mkV2V : overload { -- with zu; object-control
     mkV2V : V -> V2V ;
     mkV2V : V -> Prep -> V2V ;
     } ;
@@ -310,6 +310,8 @@ mkV2 : overload {
     auxV2V : V -> V2V ;
     auxV2V : V -> Prep -> V2V ;
     } ;
+  subjV2V : V2V -> V2V ; -- force subject-control
+
   mkV2A : overload {
     mkV2A : V -> V2A ; 
     mkV2A : V -> Prep -> V2A ;
@@ -596,24 +598,25 @@ mkV2 : overload {
   auxVV v = v ** {isAux = True ; lock_VV = <>} ;
 
   V0 : Type = V ;
---  V2S, V2V, V2Q : Type = V2 ;
   AS, A2S, AV : Type = A ;
   A2V : Type = A2 ;
 
   mkV0  v = v ** {lock_V = <>} ;
 
-  mkV2V = overload {
+  mkV2V = overload { -- default: object-control
     mkV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = False ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
     mkV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = False ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
     } ;
   auxV2V = overload {
     auxV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = True ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
     auxV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = True ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
     } ;
+  subjV2V v = v ** {ctrl = SubjC} ;
+
   mkV2A = overload {
     mkV2A : V -> V2A 
       = \v -> dirV2 v ** {isAux = False ; lock_V2A = <>} ;

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -26,10 +26,11 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
             } ;
           agr  = Ag Fem (numImp n) ps.p1 ; --- g does not matter
           verb = vps.s ! False ! agr ! VPImperat ps.p3 ;
-          inf  = vp.inf ++ verb.inf ;  -- HL .nn
+          inf  = vp.inf.s ++ verb.inf ;  -- HL .nn
           obj  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4
         in
-        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
+--        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
+        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ++ negation ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
     } ; 
 
     SlashVP np vp = 
@@ -49,7 +50,7 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
 			(insertExtrapos (conjThat ++ slash.s ! Sub) (predV vs)) **
         			{c2 = slash.c2} ;
 
-    EmbedS  s  = {s = conjThat ++ s.s ! Sub} ;
+    EmbedS  s  = {s = conjThat ++ s.s ! Sub} ;  -- no leading comma, if sentence-initial
     EmbedQS qs = {s = qs.s ! QIndir} ;
     EmbedVP vp = {s = useInfVP False vp} ;
 

--- a/src/german/SymbolGer.gf
+++ b/src/german/SymbolGer.gf
@@ -11,21 +11,27 @@ lin
   CNIntNP cn i = {
     s = \\c => cn.s ! Weak ! Sg ! Nom ++ i.s ;
     a = agrP3 Sg ;
-    isPron = False ;
-	ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
   CNSymbNP det cn xs = let g = cn.g in {
     s = \\c => det.s ! g ! c ++ 
                (let k = (prepC c).c in cn.s !  adjfCase det.a k ! det.n ! k) ++ xs.s ; 
     a = agrP3 det.n ;
-    isPron = False ;
-    ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
   CNNumNP cn i = {
     s = \\c => artDefContr (GSg cn.g) c ++ cn.s ! Weak ! Sg ! Nom ++ i.s ! Neutr ! (prepC c).c ;
     a = agrP3 Sg ;
-    isPron = False ;
-	ext,rc,adv = [] -- added
+    -- isPron = False ;
+    -- isLight = True ; 
+    w = WLight ;
+    ext,rc = [] -- added
     } ;
 
   SymbS sy = {s = \\_ => sy.s} ;

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -4,7 +4,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
 
   lin
     UseV = predV ;
-
+{-
     ComplVV v vp = 
       let 
         vpi = infVP v.isAux vp ;
@@ -14,6 +14,32 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInfExt vpi.p3 (
           insertInf vpi.p2 (
             insertObjc vpi.p1 vps))) ;
+-}  
+    -- HL 7/19
+    ComplVV v vp = -- will|wage (es ([]|zu) tun [] | ihn [es tun] ([]|zu) lassen
+      let
+        vps = predVGen v.isAux v ;
+        vpi = infzuVP v.isAux SubjC Simul Pos vp ;
+        -- { objs: ihm ; pred: []/zu versprechen, objInf: sich/es zu tun }
+        -- (ich) vfin:werde (ihm ([]/zu) versprechen) vinf:(wollen/gewagt haben) (, es zu tun)
+        -- (ich) vfin:werde (ihn (es tun) lassen)/[]  vinf:(wollen/gewagt haben) []/(, ihn (es tun) zu lassen)
+        extInfzu = case <vp.isAux,vp.inf.isAux> of {<True,False> => (vp.nn!(Ag Masc Sg P3)).p6 ; _ => []} ;
+        comma = case vp.inf.ctrl of { NoC => [] ; _ => bindComma} ; -- es (zu) tun
+        embeddedInf : Agr => Str =
+          case <vp.isAux,vp.inf.isAux> of { -- vv + vp + [embeddedInf]
+            -- will [es lesen] können | will ihn [es lesen] lassen
+            <True,True>  => \\agr => (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;
+            -- will ihn [euch (extInfzu) bitten] lassen
+            <True,False> => \\agr => (vp.nn!agr).p5 ++ vpi.inf ; -- ++ (vp.nn!agr).p6 => extInfzu
+            -- will es lesen [] | will ihn bitten [, es zu lesen] | will ihn bitten [, sie es lesen zu lassen]
+            <False,True>  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;
+            -- will ihn bitten [, ihr zu helfen, es zu lesen]
+            <False,False> => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }
+      in
+      insertExtrapos (extInfzu ++ vpi.ext) ( -- vps.ext   <- vp's extracted embedded infzu + vp's object-sentence
+        insertInf vpi.pred (                 -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (       -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
 
     ComplVS v s = 
       insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predV v) ;
@@ -21,52 +47,90 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
       insertExtrapos (comma ++ q.s ! QIndir) (predV v) ;
     ComplVA v ap = insertAdj (v.c2.s ++ ap.s ! APred) ap.c ap.ext (predV v) ; -- changed
 
-    SlashV2a v = (predVc v) ** {missingAdv = True} ; -- HL 12/6/2019 for reflexive verbs with objects, rV2:V2, rV3:V3
+    SlashV2a v = (predVc v) ; 
       
-    Slash2V3 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; missingAdv = True} ; 
-    Slash3V3 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; missingAdv = True} ;
+    Slash2V3 v np = insertObjNP np v.c2 (predVc v) ** {c2 = v.c3} ; 
+    Slash3V3 v np = insertObjNP np v.c3 (predVc v) ; 
 
     SlashV2S v s = 
-      insertExtrapos (conjThat ++ s.s ! Sub) (predVc v) ;
+      insertExtrapos (comma ++ conjThat ++ s.s ! Sub) (predVc v) ;
     SlashV2Q v q = 
-      insertExtrapos (q.s ! QIndir) (predVc v) ;
+      insertExtrapos (comma ++ q.s ! QIndir) (predVc v) ;
+{-
     SlashV2V v vp = 
       let 
         vpi = infVP v.isAux vp ;
         vps = predVGen v.isAux v ** {c2 = v.c2} ;
-      in vps **
-      insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
-          insertObj vpi.p1 vps)) ;
+      in vps ** 
+       insertExtrapos vpi.p4 ( -- inplace vp; better extract it!
+        insertInfExt vpi.p3 (
+          insertInf vpi.p2 (
+            insertObjc vpi.p1 vps))) ;
+-}
+    SlashV2V v vp =   -- jmdn bitten, (\agr => sich!agr das Buch zu merken)  HL 7/19
+      let
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 ; objCtrl = case v.ctrl of {ObjC => True ; _ => False}} ;
+        vpi = infzuVP v.isAux v.ctrl Simul Pos vp ;
+        comma : Str = case <vp.isAux,vp.inf.ctrl> of { <True,_> | <_,NoC> => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = case vp.inf.isAux of {
+          True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
+          False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
 
-    SlashV2A v ap = 
+    SlashV2A v ap =
       insertAdj (ap.s ! APred) ap.c ap.ext (predVc v) ;
 
     ComplSlash vps np =
       let vp = insertObjNP np vps.c2 vps ;
-       in case vp.missingAdv of {
-        True  => vp ;
-        False => objAgr np vp } ; -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of the object introduced by ComplSlash.
-
+          -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of np.
+      in case vps.objCtrl of { True => objAgr np vp ; _  => vp } ;
+{-
     SlashVV v vp = 
-      let 
+      let
         vpi = infVP v.isAux vp ;
-        vps = predVGen v.isAux v ** {c2 = vp.c2} ;
+        vps = predVGen v.isAux v ** {c2 = vp.c2 } ;
       in vps **
       insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
+        insertInf {s=vpi.p2;isAux=vp.isAux;ctrl=SubjC} ( -- insertInf vpi.p2 (
           insertObj vpi.p1 vps)) ;
+-}
+    SlashVV v vp = -- will|hoffe ((zu) lesen | ihr (zu) geben | (zu) bitten, es zu lesen) 
+      let
+        vps = (predVGen v.isAux v) ** { c2 = vp.c2 } ;
+        vpi = infzuVP v.isAux SubjC Simul Pos vp ; -- (zu) (lesen | ihr geben | bitten, es zu lesen) 
+        comma : Str = case <vp.isAux,vp.inf.ctrl> of { <True,_> | <_,NoC> => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = case vp.inf.isAux of {
+          True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- es lesen (zu) lassen
+          False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- (zu) bitten, es zu lesen
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf vps))) ;
+
+-- {- HL 8/19: this slightly modified SlashV2VNP is expensive even with NP.w:Weight 
+
+    -- order of embedded objects wrong: 
+    -- Lang> p "the woman that you beg me to listen to" | l
+    --   the woman that you beg me to listen to
+    --   die Frau , der ihr mich zuzuhören bittet
+    -- better: die Frau , der zuzuhören ihr mich bittet 
 
     SlashV2VNP v np vp =
       let 
         vpi = infVP v.isAux vp ;
-        vps = predVGen v.isAux v ** {c2 = v.c2} ;
+        vps = predVGen v.isAux v ** {c2 = vp.c2} ; -- objCtrl = ?
       in vps **
       insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
+        insertInf {s=vpi.p2;isAux=v.isAux;ctrl=v.ctrl} ( -- insertInf vpi.p2
           insertObj vpi.p1 (
             insertObj (\\_ => appPrepNP v.c2 np) vps))) ;
---            insertObjNP v.c2 np vps))) ;
+
+    -- HL: version with infzuVP in tests/german/TestLangGer.gf, too expensive
 
     UseComp comp =
        insertExtrapos comp.ext (insertObj comp.s (predV sein_V)) ; -- agr not used
@@ -76,7 +140,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     UseCopula = predV sein_V ;
 
     CompAP ap = {s = \\_ => ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ; ext = ap.ext} ;
-    CompNP np = {s = \\_ => np.s ! NPC Nom ++ np.adv ++ np.rc ; ext = np.ext} ;
+    CompNP np = {s = \\_ => np.s ! NPC Nom ++ np.rc ; ext = np.ext} ;
     CompAdv a = {s = \\_ => a.s ; ext = []} ;
 
     CompCN cn = {s = \\a => case numberAgr a of {
@@ -112,14 +176,16 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
 
    from  "we live (in the city : Adv) : Cl"
 
-   But in German we cannot move the NP part of an Adv, we only have the
+   In German we cannot move the NP part of an Adv, we only have the
    full relative clauses like
 
         die Stadt, in der wir leben,
         die Stadt, worin wir leben,    --contracted Prep+Rel
 
-   but nothing like "die Stadt wir leben in".
+   But: VPSlashPrep is used to parse "sie ist mit mir verheiratet", 
+              (ist verheiratet:VP mit:Prep):VPSlash,
+        ComplA2 is used to parse "sie ist verheiratet mit mir"
 -}
-    VPSlashPrep vp prep = vp ** {c2 = prep ; missingAdv = True} ;
+    VPSlashPrep vp prep = vp ** {c2 = prep ; objCtrl = False} ;
 
 }

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -1,10 +1,12 @@
 abstract TestLang = 
   Grammar, 
-  Lexicon
-  , TestLexiconGerAbs
-  , Construction
+  TestLexiconGerAbs
+--  , Construction
   ** {    
   flags startcat=Phr ;
+
+  fun
+    SlashV2Vneg : V2V -> VP -> VPSlash ; -- negative use of VP: promise, not to vp
   cat 
     VPSlashSlash ;
   fun
@@ -17,4 +19,17 @@ abstract TestLang =
     Slash4V4 : V4 -> NP -> VPSlashSlash ;
 
     ComplSlashSlash: VPSlashSlash -> NP -> VPSlash ;
+
+    -- Passive
+    PastPartAP  : VPSlash -> AP ;  -- lost (opportunity) ; (opportunity) lost in space
+    PassVPSlash : VPSlash -> VP ;  -- from ExtraGer, to be corrected
+
+    PassV2S : V2S -> S -> VP ;
+    PassV2Q : V2Q -> QS -> VP ;
+    PassV2V : V2V -> VP -> VP ;
+
+    Pass3V3 : V3 -> NP -> VP ;  -- den Beweis erklärt bekommen
+    Pass2V3 : V3 -> NP -> VP ;  -- uns erklärt werden ; Eng give_V3[indir,dir]: we are given the book
+
+    Pass2V4 : V4 -> NP -> VPSlash ; -- bei dir (für Gold) gekauft werden
   } ;

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -2,26 +2,54 @@
 -- --# -path=.:../abstract:../common:../api:../prelude
 
 concrete TestLangEng of TestLang = 
-  GrammarEng,
-  LexiconEng
+  GrammarEng
   , TestLexiconEng
-  , ConstructionEng
-  ** open (R=ResEng),(P=ParadigmsEng),Prelude in {
+--  , ConstructionEng
+  ** open (R=ResEng), (P=ParadigmsEng), Prelude, (E=ExtendEng)
+  in {
 
   flags 
     startcat = Phr ; unlexer = text ; lexer = text ;
+
+  lin
+    SlashV2Vneg v vp = 
+      R.insertObjc (\\a => v.c3 ++ R.infVP v.typ vp False R.Simul (R.CNeg True) a) (R.predVc v) ;
 
   lincat
     VPSlashSlash = VPSlash ** {c3 : Str} ;
   lin 
     ReflVPSlash v3 = (R.predVc ((P.reflV (lin V v3)) ** {c2 = v3.c3 ; missingAdv = True})); 
 
-    ComplSlashSlash vpss np = R.insertObjc (appPrep vpss.c2 (lin NP np)) (vpss ** {c2 = vpss.c3 ; missingAdv = True }) ;
+    ComplSlashSlash vpss np = R.insertObjc 
+      (appPrep vpss.c2 (lin NP np)) (vpss ** {c2 = vpss.c3 ; missingAdv = True }) ;
 
-    Slash2V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c2 (lin NP np)) (R.predVc v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
-    Slash3V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c3 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
-    Slash4V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c4 (lin NP np)) (R.predVc v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
+    Slash2V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c2 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
+    Slash3V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c3 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
+    Slash4V4 v np = (lin VPSlash (R.insertObjc (appPrep v.c4 (lin NP np)) (R.predVc v) 
+                                    ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
 
   oper
     appPrep : Str -> NP -> (R.Agr => Str) = \p,np -> \\_ => p ++ np.s ! R.NPAcc ;
+
+    -- Passive
+  lin
+    Pass2V3 v np = 
+      let vps = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3} 
+      in R.insertObj (\\_ => vps.c2 ++ np.s ! R.NPAcc) vps ;
+
+    Pass3V3 v np = 
+      let vps = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c2} 
+      in R.insertObj (\\_ => vps.c2 ++ np.s ! R.NPAcc) vps ;
+
+    PastPartAP = E.PastPartAP ;
+    PassVPSlash = E.PassVPSlash ;
+
+    Pass2V4 v np =
+      let vpss = R.insertObj (\\_ => v.s ! R.VPPart ++ v.p) (R.predAux R.auxBe) ** {c2 = v.c3 ; c3 = v.c4} 
+      in R.insertObj (\\_ => vpss.c3 ++ np.s ! R.NPAcc) vpss ** {c2 = vpss.c2 ; 
+                                                                 missingAdv = True ; 
+                                                                 gapInMiddle = False } ;
+
 } ;

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -1,28 +1,173 @@
 --# -path=.:../../src/abstract:../../src/common:../../src/api:../../src/prelude:../../src/german
--- --# -path=.:../abstract:../common:../api:../prelude
+-- use the modified files in gf-rgl/src/german
 
 concrete TestLangGer of TestLang = 
-  GrammarGer,
-  LexiconGer
-  , TestLexiconGer
-  , ConstructionGer
-  ** open (R=ResGer),Prelude in {
+  GrammarGer - [PassV2] -- to improve these ,ComplVV,SlashVV,SlashV2V,SlashV2VNP
+  , TestLexiconGer - [helfen_V2V, warnen_V2V, versprechen_dat_V2V, lassen_V2V]
+--  , ConstructionGer -- needs SlashV2VNP of VerbGer
+  ** open ResGer,Prelude,(P=ParadigmsGer) in {
 
-flags startcat = Phr ; unlexer = text ; lexer = text ;
+  flags startcat = Phr ; unlexer = text ; lexer = text ;
+        optimize=all_subs ;
+{-
   lincat
-    VPSlashSlash = VPSlash ** {c3 : R.Preposition} ;
+    VPSlashSlash = CatGer.VPSlash ** {c3 : Preposition} ;
   lin 
-    ReflVPSlash v3 = (R.insertObjRefl (R.predVc v3) ** {c2 = v3.c3 ; missingAdv = True}); -- reflexive use of v:V3, untested
+    SlashV3a v = (predVc v) ** {c3 = v.c3} ;
 
-    -- SlashV3a v = (R.predVc v) ** {c3 = v.c3} ;
-
-    Slash2V4 v np = (lin VPSlash (R.insertObjNP np v.c2 (R.predV v) ** {c2 = v.c3 ; missingAdv = True})) ** { c3 = v.c4 } ; 
-    Slash3V4 v np = (lin VPSlash (R.insertObjNP np v.c3 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c4 } ;
-    Slash4V4 v np = (lin VPSlash (R.insertObjNP np v.c4 (R.predV v) ** {c2 = v.c2 ; missingAdv = True})) ** { c3 = v.c3 } ;
-
-    ComplSlashSlash vpss np = R.insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3 ; missingAdv = True } ;
-
+    Slash2V4 v np = insertObjNP np v.c2 (predV v) ** {c2 = v.c3 ; c3 = v.c4 } ; 
+    Slash3V4 v np = insertObjNP np v.c3 (predV v) ** {c2 = v.c2 ; c3 = v.c4 } ;
+    Slash4V4 v np = insertObjNP np v.c4 (predV v) ** {c2 = v.c2 ; c3 = v.c3 } ;
+    
+    ComplSlashSlash vpss np = insertObjNP np vpss.c2 vpss ** {c2 = vpss.c3} ;
     -- linref
-    --   V4 = \v -> useInfVP False (R.predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+    --   V4 = \v -> useInfVP False (predV v) ++ v.c2.s ++ v.c3.s ++ v.c4.s ;
+-}
+  lin
+    ReflVPSlash v3 = -- reflexive use of v:V3, untested
+      (insertObjRefl (predVc v3) ** {c2 = v3.c3}); 
 
-} ;
+    PassV2 v = -- insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} -- acc object -> nom; all others: same PCase
+      in insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) ** { subjc = v.c2 ** {c = c} } ;
+
+    PassV2Q v q = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ q.s ! QIndir) vp ;
+
+    PassV2S v s = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ conjThat ++ s.s ! Sub) vp ;
+
+    PassV2V v vp = 
+      let c = case <v.c2.c, v.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
+          vp2 = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
+            ** { subjc = v.c2 ** {c = c} } 
+      in insertExtrapos (bindComma ++ (useInfVP False vp)) vp2 ; -- misses subject agr for vp = ReflVP vps
+{-
+    PassVPSlash vp = 
+      let c = case <vp.c2.c,vp.c2.isPrep> of {
+            <NPC Acc, False> => NPC Nom ; _ => vp.c2.c}
+      in insertObjc (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) 
+      ** {ext = vp.ext ; subjc = vp.c2 ** {c = c}} ;
+                -- regulates passivised object: accusative objects -> nom; all others: same case
+		-- this also gives "mit dir wird gerechnet" ;
+		-- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
+       -- HL: does not work for vp = (Slash2V3 v np): uns wird den Beweis erklärt
+       --                       vp = (SlashV2V v2v reflVP): wir werden gebeten, uns zu fragen , ob S
+    PastPartAP vp = {
+      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ 
+        (vp.nn ! agrP3 Sg).p3 ++ (vp.nn ! agrP3 Sg).p4 ++ vp.adj ++ vp.a2 
+        ++ vp.inf.s ++ vp.infExt ++ vp.s.s ! VPastPart af ;
+      isPre = True ;
+      c = <[],[]> ;
+      adj = [] ;
+      ext = vp.ext 
+      } ;
+-}
+    Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
+      let vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+            ** { subjc = PrepNom ; c2 = v.c3 }
+      in insertObjNP np vps.c2 vps ;
+
+    Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
+      let bekommen : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
+          vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
+            ** { subjc = PrepNom ; c2 = v.c2 } 
+      in insertObjNP np vps.c2 vps ;
+{-      
+    Pass2V4 v np = 
+      let vps = -- : VPSlashSlash = 
+            insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+            ** { subjc = PrepNom ; c2 = v.c3 ; c3 = v.c4 } 
+      in (insertObjNP np vps.c3 vps) ;
+
+    -- Todo: Pass?V2S, Pass?V2Q, PassVS, PassVQ Pass?V2V
+-}
+
+    SlashV2Vneg v vp =   -- versprechen, (\agr => sich!agr es nicht zu merken) 
+      let 
+        vps = (predVGen v.isAux v) ** { c2 = v.c2 } ; --; ctrl = v.ctrl } ;
+        vpi = infzuVP v.isAux v.ctrl Simul Neg vp ;
+        comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = case vp.inf.isAux of {
+          True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
+          False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
+      in 
+      insertExtrapos vpi.ext (
+        insertInf vpi.pred (   
+          insertInfExtraObj vpi.objs (
+            insertInfExtraInf embeddedInf vps))) ;
+
+    lin -- with param Control in ../../src/german/ParadigmsGer.gf
+      helfen_V2V = P.mkV2V (P.irregV "helfen" "hilft" "half" "hälfe" "geholfen") P.datPrep ; 
+      warnen_V2V = P.mkV2V (P.regV "warnen") P.accPrep ;
+      versprechen_dat_V2V = 
+        P.subjV2V (P.mkV2V (P.irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") P.datPrep) ;
+      lassen_V2V = P.auxV2V (P.irregV "lassen" "lasst" "ließ" "ließe" "gelassen") P.accPrep ;  -- lasse dich (*zu) arbeiten
+
+-- SlashV2VNP : V2V -> NP -> VPSlash -> VPSlash ; -- beg me to buy
+-- -- (the book) that (she (begged:V2V me:NP (to buy ()):VPSlash):VPSlash):ClSlash
+
+-- very expensive:
+-- + SlashV2V 2332800 (6480,40)
+-- + SlashV2VNP 2267481600 (4320,270) vs. (1080,90) in VerbGer, 305460 msec
+-- Languages: TestLangGer
+-- 623657 msec
+{- 
+    SlashV2VNP v np vp =  
+      let
+        vps = (predVGen v.isAux v) ** { c2 = vp.c2 } ; -- objCtrl = 
+        vpi = infzuVP v.isAux v.ctrl Simul Pos vp ;
+        -- comma = case <vp.isAux,vp.inf.ctrl> of { <True,_> => [] ; <_,NoC> => [] ; _ => bindComma} ;
+        embeddedInf : Agr => Str = 
+          \\agr => "[" ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]";  
+        -- embeddedInf : Agr => Str = case vp.inf.isAux of {
+        --   True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
+        --   False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
+      in
+      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
+        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
+          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
+            insertInfExtraInf embeddedInf (
+              insertObjNP np v.c2 vps )))) ;
+-}
+{-
+TestLang> p "the book that we beg her to promise him to read" | l
+the book that we beg her to promise him to read
+das Buch , das wir sie bitten , ihn zu versprechen [ [ ] zu lesen ]
+
+TestLang> p "the book that we beg her to beg him to read" | l
+the book that we beg her to beg him to read
+das Buch , das wir sie bitten , ihn zu bitten [ [ ] zu lesen ]
+
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+TestLangEng: the book that we promise her to read
+TestLangGer: das Buch , dem wir ihr versprechen , zu lesen   Bug: dem => das
+
+TestLang> p "the book that we beg her to sell to him" | l
+the book that we beg her to sell to him
+das Buch , das wir ihm sie bitten , zu verkaufen
+=> das Buch , das wir sie bitten , ihm zu verkaufen
+~~> das Buch , das ihm zu verkaufen wir sie bitten
+ ~~ das Buch , an das zu glauben wir sie bitten
+
+Wrong in gf-3.9 as well:
+Lang> p "the woman that we beg him to listen to" | l
+the woman that we beg him to listen to
+die Frau , die wir ihn zuzuhören bitten  (Bug: die => der)
+
+Lang> p "the book that we beg her to sell to him" | l
+the book that we beg her to sell to him
+das Buch , das wir ihn sie zu verkaufen bitten (Bug: ihn sie => sie ihm)
+=> das Buch, das wir sie bitten, ihm zu verkaufen
+-}
+}

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -3,7 +3,7 @@
 -- translations and corresponding c2,c3,c4-objects under Slash?V3, Slash?V4.
 
 concrete TestLexiconEng of TestLexiconGerAbs = 
-  CatEng ** open (R=ResEng), (P=Prelude), ParadigmsEng
+  LexiconEng ** open (R=ResEng), (P=Prelude), ParadigmsEng, (I=IrregEng)
 in {
 
 lincat 
@@ -20,6 +20,8 @@ oper
   mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
          \v,p2,p3,p4 -> lin V4 (v ** { c2=p2.s ; c3=p3.s ; c4=p4.s }) ;
   dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v noPrep c d ;
+  -- control verbs:
+  defaultV2V : V -> V2V = \v -> lin V2V (dirV2 v ** {c3=[] ; typ = R.VVInf}) ;
 
 lin
   aendern_rV = (regV "change") ;
@@ -27,6 +29,7 @@ lin
                       compl : Str = "an effort" 
     in {s = \\vf => v.s!vf ++ compl ; isRefl = P.False ; p = []} ;
 
+  gedenken_gen_V2  = dirV2 (regV "remember") ;
   bedienen_gen_rV2 = dirV2 (regV "use") ;
   stuetzen_auf_rV2 = mkV2 (irregV "rely" "relied" "relied") (mkPrep "on") ;
   ergeben_dat_rV2 = mkV2 (regV "surrender") (mkPrep "to") ;
@@ -36,6 +39,7 @@ lin
   erklaeren_dat_V3 = dirV3 (regV "explain") (mkPrep "to") ;
   erinnern_an_V3 = dirV3 (regV "remind") (mkPrep "of") ;
   danken_dat_fuer_V3 = dirV3 (regV "thank") (mkPrep "for") ;
+  debattieren_mit_ueber_V3 = mkV3 (regV "debate") (mkPrep "with") (mkPrep "about") ;
   lehren_V3 = mkV3 (irregV "teach" "taught" "taught") noPrep noPrep ;
 
   abschauen_bei_rV3 = dirV3 (regV "copy") (mkPrep "from") ; 
@@ -48,4 +52,12 @@ lin
   mieten_von_fuer_V4 = dirV4 (regV "rent") (mkPrep "from") (mkPrep "for") ;
 
   neugierig_auf_A2 = mkA2 (regA "curious") (mkPrep "about") ;
+
+  wagen_VV = mkVV (regV "dare") ;                       -- typ=VVInf
+  versuchen_VV = mkVV (irregV "try" "tried" "tried") ;  -- typ=VVInf
+  helfen_V2V = defaultV2V (regV "help") ;
+  warnen_V2V = defaultV2V (regV "warn") ;               -- typ=VVInf
+  versprechen_dat_V2V = defaultV2V (regV "promise") ;   -- typ=VVInf
+  lassen_V2V = ParadigmsEng.mkV2V (I.let_V) ;           -- typ=VVAux
+
 }

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -1,7 +1,7 @@
 --# -path=.:../abstract:../common:../prelude: 
 
 concrete TestLexiconGer of TestLexiconGerAbs = 
-  CatGer ** open (R=ResGer), (P=Prelude), ParadigmsGer 
+  LexiconGer ** open (R=ResGer), (P=Prelude), ParadigmsGer 
 in {
 
 lincat 
@@ -16,25 +16,30 @@ oper
 
   bei_Prep   = mkPrep "bei" dative ; 
   fuer_Prep  = mkPrep "für" accusative ;
+  mit_Prep   = mkPrep "mit" dative ; 
 
   -- quaternary verbs:
   mkV4 : V -> Prep -> Prep -> Prep -> V4 = 
          \v,p2,p3,p4 -> lin V4 (v ** { c2=p2 ; c3=p3 ; c4=p4 }) ;
   dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v accPrep c d ;
+  -- control verbs
+  dirV2V : V -> V2V = \v -> mkV2V v ; 
 
 lin
   aendern_rV = reflV (regV "ändern") accusative ;
   anstrengen_rV = reflV (prefixV "an" (regV "strengen")) accusative ;
 
+  gedenken_gen_V2 = mkV2 (irregV "gedenken" "gedenkt" "gedachte" "gedächte" "gedacht") genPrep ;
   bedienen_gen_rV2 = reflV2 (regV "bedienen") accusative genPrep ;
   stuetzen_auf_rV2 = reflV2 (regV "stützen") accusative (mkPrep "auf" accusative) ;
   ergeben_dat_rV2 = reflV2 (irregV "ergeben" "ergibt" "ergab" "ergäbe" "ergeben") accusative datPrep ;
   merken_rV2 = reflV2 (regV "merken") dative accPrep ;
 
-  erklaeren_dat_V3 = accdatV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
+  erklaeren_dat_V3 = mkV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
   anklagen_gen_V3 = dirV3 (prefixV "an" (regV "klagen")) genPrep ;
   erinnern_an_V3 = dirV3 (irregV "erinnern" "erinnert" "erinnerte" "erinnerte" "erinnert") (mkPrep "an" accusative) ; 
   danken_dat_fuer_V3 = mkV3 (regV "danken") datPrep (mkPrep "für" accusative) ;
+  debattieren_mit_ueber_V3 = mkV3 (irregV "debattieren" "debattiert" "debattierte" "debattierte" "debattiert") mit_Prep (mkPrep "über" accusative) ;
   lehren_V3 = dirV3 (regV "lehren") accPrep ;
 
   abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;
@@ -48,5 +53,13 @@ lin
   mieten_von_fuer_V4 = dirV4 (regV "mieten") von_Prep fuer_Prep ;
 
   neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
+
+  wagen_VV = mkVV (regV "wagen")  ;
+  versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
+
+  helfen_V2V = mkV2V (irregV "helfen" "hilft" "half" "hälfe" "geholfen") datPrep ; 
+  warnen_V2V = dirV2V (regV "warnen")  ;
+--  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") datPrep) ;
+  lassen_V2V = auxV2V (irregV "lassen" "lasst" "ließ" "ließe" "gelassen") accPrep ;  -- lasse dich (*zu) arbeiten
 
 }

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -1,12 +1,11 @@
 --# -path=.:../abstract:../common:../prelude: -- partially extracted from DictVerbsGerAbs
-abstract TestLexiconGerAbs = Cat ** {
-cat 
-  V4 ;
+abstract TestLexiconGerAbs = Lexicon ** {
 
 fun
   aendern_rV : V ;
   anstrengen_rV : V ;
 
+  gedenken_gen_V2 : V2 ;
   bedienen_gen_rV2 : V2 ;
   stuetzen_auf_rV2 : V2 ;
   ergeben_dat_rV2 : V2 ;
@@ -17,6 +16,7 @@ fun
   lehren_V3 : V3 ;
   erinnern_an_V3 : V3 ;
   danken_dat_fuer_V3 : V3 ;
+  debattieren_mit_ueber_V3 : V3 ;
 
   abschauen_bei_rV3 : V3 ;
   leihen_von_rV3 : V3 ;
@@ -24,9 +24,20 @@ fun
   entschuldigen_bei_fuer_rV3 : V3 ;
   raechen_am_fuer_rV3 : V3 ;
 
+  neugierig_auf_A2 : A2 ;
+
+  wagen_VV : VV ;
+  versuchen_VV : VV ;
+
+  helfen_V2V : V2V ;          -- -aux(zu-inf), object control
+  warnen_V2V : V2V ;          -- -aux,         object control
+  versprechen_dat_V2V : V2V ; -- -aux,         subject control
+  lassen_V2V : V2V ;          -- +aux(inf),    object control
+
+cat 
+  V4 ;
+fun
   kaufen_bei_fuer_V4 : V4 ;
   mieten_von_fuer_V4 : V4 ;
-
-  neugierig_auf_A2 : A2 ;
 
 }

--- a/tests/german/examples.txt
+++ b/tests/german/examples.txt
@@ -331,3 +331,29 @@ ich bin nicht auf ihn neugierig            -- reject
 
 -- done
 
+-- Passive of VPSlash and V3
+
+sie gibt uns den Wagen                     -- accept
+
+der Wagen wird uns gegeben                 -- accept, via PassVPSlash or Pass2V3
+uns wird der Wagen gegeben                 -- accept, word order variant (not recognized)
+wir bekommen den Wagen gegeben             -- accept, via Pass3V3
+
+sie schickte uns den Wagen                 -- accept (Eng with prep)
+
+der Wagen wurde uns geschickt              -- accept, via PassVPSlash
+uns wurde der Wagen geschickt              -- accept, word order variant (not recognized)
+wir bekamen den Wagen geschickt            -- accept, via Pass3V3
+
+der Wagen würde uns geschickt werden       -- accept
+der Wagen würde uns nicht geschickt werden -- accept
+wir würden den Wagen geschickt bekommen    -- accept
+wir würden den Wagen nicht geschickt bekommen -- accept
+wir würden nicht den Wagen geschickt bekommen -- accept ?
+
+der Wagen sei uns geschickt worden         -- accept
+wir hätten den Wagen geschickt bekommen    -- accept
+
+wir wollen den Wagen geschickt bekommen    -- accept
+wir würden den Wagen geschickt bekommen wollen haben   -- accept
+

--- a/tests/german/infinitives.gfs
+++ b/tests/german/infinitives.gfs
@@ -1,0 +1,15 @@
+-- usage: gf --run < infinitives.gfs  or  gf> eh infinitives.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
+? ls -l infinitives.lin.out infinitives.lin.tmp
+? echo "remove infinitives.lin.tmp"
+? rm infinitives.lin.tmp
+? echo "linearizing infinitives.trees to infinitives.lin.tmp ... "
+rf -file="infinitives.trees" -lines -tree | l -lang="Ger,Eng" -treebank | wf -file="infinitives.lin.tmp" 
+rf -file="infinitives.trees" -lines -tree | l -lang=Ger -table | wf -file="infinitives.lin.tmp.txt" 
+? ls -l infinitives.lin.out infinitives.lin.tmp
+? echo "diff infinitives.lin.out infinitives.lin.tmp" 
+? diff infinitives.lin.out infinitives.lin.tmp
+? ls -l infinitives.lin.out.txt infinitives.lin.tmp.txt
+--? echo "diff infinitives.lin.out.txt infinitives.lin.tmp.txt" 
+--? diff infinitives.lin.out.txt infinitives.lin.tmp.txt

--- a/tests/german/infinitives.lin.out
+++ b/tests/german/infinitives.lin.out
@@ -1,0 +1,258 @@
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron))
+TestLangGer: ich verspreche euch , das Buch zu lesen
+TestLangEng: I promise you to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron))
+TestLangGer: ich lasse euch das Buch lesen
+TestLangEng: I let you read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , uns zu versprechen , das Buch zu lesen
+TestLangEng: I beg you to promise us to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich lasse dich uns versprechen , das Buch zu lesen
+TestLangEng: I let you promise us to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , uns das Buch lesen zu lassen
+TestLangEng: I beg you to let us read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich lasse dich uns das Buch lesen lassen
+TestLangEng: I let you let us read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich will das Buch lesen
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich wage , das Buch zu lesen
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich muss ihr versprechen , zu schlafen
+TestLangEng: I must promise her to sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich wage , ihr zu versprechen , zu schlafen
+TestLangEng: I dare to promise her to sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich muss sie schlafen lassen
+TestLangEng: I must let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron)))
+TestLangGer: ich wage , sie schlafen zu lassen
+TestLangEng: I dare to let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))) (UsePron she_Pron)))
+TestLangGer: ich muss ihr versprechen , sie schlafen zu lassen
+TestLangEng: I must promise her to let her sleep
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron)))
+TestLangGer: ich muss sie das Buch lesen lassen
+TestLangEng: I must let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron)))
+TestLangGer: ich will ihm versprechen , sie das Buch lesen zu lassen
+TestLangEng: I want to promise him to let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron))))
+TestLangGer: ich muss ihm versprechen wollen , sie das Buch lesen zu lassen
+TestLangEng: I must want to promise him to let her read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich muss das Buch lesen
+TestLangEng: I must read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich will das Buch lesen
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich wage das Buch , zu lesen -- wrong
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch lesen
+TestLangEng: I must read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich will das Buch lesen
+TestLangEng: I want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich wage , das Buch zu lesen
+TestLangEng: I dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich muss das Buch lesen wollen
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich muss das Buch wagen , zu lesen -- wrong
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich will das Buch wagen , zu lesen -- wrong
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich wage das Buch , lesen zu wollen -- wrong
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch lesen wollen
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch wagen , zu lesen -- wrong
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich will das Buch wagen , zu lesen -- wrong
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich wage , das Buch lesen zu wollen
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss das Buch lesen wollen
+TestLangEng: I must want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss wagen , das Buch zu lesen
+TestLangEng: I must dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich will wagen , das Buch zu lesen
+TestLangEng: I want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich wage , das Buch lesen zu wollen
+TestLangEng: I dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch wagen wollen , zu lesen -- wrong
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss das Buch wagen wollen , zu lesen -- wrong
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+TestLangGer: ich muss wagen wollen , das Buch zu lesen
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich muss das Buch wagen , lesen zu wollen -- wrong
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich muss das Buch wagen , zu lesen wollen -- wrong
+TestLangEng: I must want to dare to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+TestLangGer: ich muss das Buch wagen , lesen zu wollen -- wrong
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+TestLangGer: ich muss wagen , das Buch lesen zu wollen
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+TestLangGer: ich muss wagen , das Buch lesen zu wollen
+TestLangEng: I must dare to want to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich lasse ihn das Buch lesen
+TestLangEng: I let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich bitte ihn , das Buch zu lesen
+TestLangEng: I beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich verspreche ihm , das Buch zu lesen
+TestLangEng: I promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich bitte die , ihn das Buch lesen zu lassen
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron))
+TestLangGer: ich bitte sie , ihn das Buch lesen zu lassen
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich verspreche denen , ihn zu bitten , das Buch zu lesen
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron))
+TestLangGer: ich verspreche ihnen , ihn zu bitten , das Buch zu lesen
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron he_Pron))
+TestLangGer: ich bitte ihn , ihm zu versprechen , das Buch zu lesen
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich lasse das Buch ihn lesen -- wrong object order (3.9 SlashV2VNP)
+TestLangEng: I let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich bitte das Buch ihn , zu lesen -- wrong (SlashV2VNP)
+TestLangEng: I beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich verspreche das Buch ihm , zu lesen -- wrong (SlashV2VNP)
+TestLangEng: I promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich bitte das Buch ihn die , zu lassen lesen -- wrong (SlahV2VNP) bitte die, ihn es lesen zu lassen
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron they_Pron) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich bitte das Buch ihn sie , zu lassen lesen -- wrong (SlashV2VNP)
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich bitte die , das Buch ihn lesen zu lassen -- wrong obj order
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
+TestLangGer: ich bitte sie , das Buch ihn lesen zu lassen -- wrong obj order
+TestLangEng: I beg them to let him read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich verspreche das Buch ihn denen , zu bitten zu lesen -- wrong (SlashV2VNP gf-3.9))
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron they_Pron) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich verspreche das Buch ihn ihnen , zu bitten zu lesen -- wrong (SlashV2VNP)
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
+TestLangGer: ich verspreche denen , das Buch ihn zu bitten , zu lesen -- wrong obj order
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
+TestLangGer: ich verspreche ihnen , das Buch ihn zu bitten , zu lesen -- wrong obj order
+TestLangEng: I promise them to beg him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
+TestLangGer: ich bitte das Buch ihm ihn , zu versprechen zu lesen -- wrong (SlashV2VNP)
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
+TestLangGer: ich bitte ihn , das Buch ihm zu versprechen , zu lesen -- wrong (SlashV2VNP)
+TestLangEng: I beg him to promise him to read the book
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , dich zu lieben
+TestLangEng: I beg you to love yourself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V warnen_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youPl_Pron))
+TestLangGer: ich warne euch , euch zu hassen
+TestLangEng: I warn you to hate yourselves
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich zu lieben
+TestLangEng: I promise her to love herself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ReflVP (SlashV2a love_V2)))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich lieben zu wollen
+TestLangEng: I promise her to want to love herself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2Vneg versprechen_dat_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
+TestLangGer: ich will sie bitten , dir zu versprechen , sich nicht zu hassen
+TestLangEng: I want to beg her to promise you not to hate yourself -- wrong: herself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
+TestLangGer: ich verspreche ihr , mich bei mir für es zu entschuldigen
+TestLangEng: I promise her to apologize for it itself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron))
+TestLangGer: ich verspreche uns , es mir zu geben
+TestLangEng: I promise us to give it itself -- wrong: myself
+TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
+TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu hassen
+TestLangEng: I want to promise her to beg you to not hate yourself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , dich bei dir für es zu entschuldigen
+TestLangEng: I beg you to apologize for it itself -- wrong: yourself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich bitte dich , mir zu versprechen , dich zu lieben
+TestLangEng: I beg you to promise me to love myself
+TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
+TestLangGer: ich helfe dir , mir zu versprechen , dich zu lieben
+TestLangEng: I help you to promise me to love myself
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2))))))
+TestLangGer: das Buch , das wir nicht lesen wollten
+TestLangEng: the book that we didn't want to read
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2))))))
+TestLangGer: das Buch , das wir nicht lesen mussten
+TestLangEng: the book that we hadn't to read
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))
+TestLangGer: das Buch , das wir nicht wagten , zu lesen
+TestLangEng: the book that we didn't dare to read
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (Slash3V3 erklaeren_dat_V3 (UsePron she_Pron)))))))
+TestLangGer: das Buch , das wir nicht wagten , ihr zu erklären
+TestLangEng: the book that we didn't dare to explain to her
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+TestLangGer: das Buch , das wir ihr versprechen , zu lesen -- wrong: das zu lesen wir ihr versprechen
+TestLangEng: the book that we promise her to read
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP lassen_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+TestLangGer: das Buch , das wir sie lesen lassen
+TestLangEng: the book that we let her read
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+TestLangGer: der Junge , den ich das Buch lesen lasse
+TestLangEng: the boy that I let read the book
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch zu lesen
+TestLangEng: the boy that I promise to read the book
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch lesen zu wollen
+TestLangEng: the boy that I promise to want to read the book
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
+TestLangGer: der Junge , dem ich verspreche , das Buch lesen zu wollen
+TestLangEng: the boy that I promise to want to read the book
+TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V helfen_V2V (ReflVP (SlashV2a wash_V2)))))))
+TestLangGer: der Junge , dem ich helfe , mich zu waschen -- wrong: sich zu waschen
+TestLangEng: the boy that I help to wash myself          -- wrong: wash himself
+TestLang: PredVP (UsePN john_PN) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePron he_Pron))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))
+TestLangGer: Johann sagt , dass wir die Kinder ihm helfen lassen wollten , das Haus blau zu malen
+TestLangEng: John says that we wanted to let the children help him to paint the house blue

--- a/tests/german/infinitives.trees
+++ b/tests/german/infinitives.trees
@@ -1,0 +1,195 @@
+-- V2V o V2 and V2V o V2V o V2 works:
+
+-- -auxV2V o V2 
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron)))
+
+-- +auxV2V o V2
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron youPl_Pron)))
+
+-- -auxV2V o -auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- +auxV2V o -auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- -auxV2V o +auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- +auxV2V o +auxV2V
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron we_Pron))) (UsePron youSg_Pron)))
+
+-- ---------- VV combined with V2 and V2V ----------
+
+-- VV o V2 ok
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- VV o -auxV2V ok:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V versprechen_dat_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+-- VV o +auxV2V ok:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))))
+
+-- +auxVV o -auxV2V o +auxV2V:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (UseV sleep_V)) (UsePron she_Pron))) (UsePron she_Pron))))
+
+-- +auxVV o +auxV2V o V2:
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))))
+
+-- +auxVV o -auxV2V o +auxV2V o V2:
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron))))
+
+-- +auxVV o +auxVV o -auxV2V o +auxV2V o V2: 
+
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron she_Pron))) (UsePron he_Pron)))))
+
+-- ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+-- ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplSlash o SlashVV o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+-- ComplVV o ComplSlash o SlashVV 
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+(PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplSlash o SlashVV o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+- ComplVV o ComplVV o ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))
+
+-- ComplSlash o SlashVV o SlashVV o SlashVV
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+
+-- ComplVV o ComplSlash o SlashVV o SlashVV 
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
+
+-- ComplVV o ComplVV o ComplSlash o SlashVV
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
+
+-- ComplVV o ComplVV o ComplVV o ComplSlash
+(PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))
+
+-- ComplSlash o SlashV2V o ComplSlash
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+-- ComplSlash o SlashV2V o ComplSlash o SlashV2V o ComplSlash
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))) (UsePron he_Pron)))
+
+
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron they_Pron) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron they_Pron) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron)))
+
+-- V2V o ReflVP with object control (default)
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V warnen_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youPl_Pron)))
+
+-- V2V o ReflVP with subject control
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron she_Pron)))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ReflVP (SlashV2a love_V2)))) (UsePron she_Pron)))
+
+-- +auxVV o (V2V object control) o (V2V subject control) o ReflVP 
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2Vneg versprechen_dat_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
+
+-- V2V o ReflVPSlash with subject control
+
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
+(PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash give_V3) (UsePron it_Pron))) (UsePron we_Pron)))
+
+(PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron))))
+
+-- V2V o ReflVPSlash with object control
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
+
+-- SlashV2V o SlashV2V o ReflVP with object control o subject control
+
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
+
+PredVP (UsePron i_Pron) (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2V versprechen_dat_V2V (ReflVP (SlashV2a love_V2))) (UsePron i_Pron))) (UsePron youSg_Pron))
+
+-- VP.inf with extracted NP (testing SlashVV, SlashV2VNP)
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV want_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV must_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (Slash3V3 erklaeren_dat_V3 (UsePron she_Pron)))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP lassen_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
+
+--
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V lassen_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V versprechen_dat_V2V (ComplVV want_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))))))
+
+DetCN (DetQuant DefArt NumSg) (RelCN (UseN boy_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron i_Pron) (SlashV2V helfen_V2V (ReflVP (SlashV2a wash_V2)))))))
+
+-- Shieber's example
+
+PredVP (UsePN john_PN) (ComplVS say_VS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (ComplSlash (SlashV2V lassen_V2V (ComplSlash (SlashV2V helfen_V2V (ComplSlash (SlashV2A paint_V2A (PositA blue_A)) (DetCN (DetQuant DefArt NumSg) (UseN house_N)))) (UsePron he_Pron))) (DetCN (DetQuant DefArt NumPl) (UseN child_N)))))))
+

--- a/tests/german/object-order.README
+++ b/tests/german/object-order.README
@@ -1,4 +1,4 @@
-Implementing pronoun switch e.a. in LangGer        HL 13.6.2019 -- 20.3.2019
+Implementing pronoun switch e.a. in LangGer        HL 13.6.2019 -- 20.6.2019
 -------------------------------------------
 Ternary verbs v:V3 with two objects of category NP order them
 depending on their being (personal) pronouns or not. Basically
@@ -273,7 +273,7 @@ From Eng to Ger:
 
 examples.eng.txt could also be parsed using LangEng instead of TestLangEng|Ger.
 
-Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
+Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.tmp
 Lang> rf -file=examples.eng.txt -lines | p -lang=LangEng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
 
 Using give_V3 is confusing, as both objects are connected with noPrep. The examples are

--- a/tests/german/object-order.gfs
+++ b/tests/german/object-order.gfs
@@ -1,30 +1,30 @@
---# Use gf --run < obj-order.gfs  or  gf> eh object-order.gfs 
-? echo "loading TestLangGer.gf and TestLangEng.gf ..."
-i TestLangGer.gf TestLangEng.gf
+-- Use gf --run < obj-order.gfs  or  gf> eh object-order.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
 -- Remark: examples in examples.eng.txt need only LangEng,LangGer
-? echo "parsing from examples.eng and writing trees to examples.eng.new:"
-rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.new
-? echo "diff examples.eng.out examples.eng.new"
-? diff examples.eng.out examples.eng.new
-? echo "parsing from examples.eng and writing source and translation to examples.eng2ger.new:"
-rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.new
-? echo "diff examples.eng2ger.out examples.eng2ger.new"
-? diff examples.eng2ger.out examples.eng2ger.new
+? echo "parsing from examples.eng and writing trees to examples.eng.tmp:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" -treebank | wf -file=examples.eng.tmp
+? echo "diff examples.eng.out examples.eng.tmp"
+? diff examples.eng.out examples.eng.tmp
+? echo "parsing from examples.eng and writing source and translation to examples.eng2ger.tmp:"
+rf -file=examples.eng.txt -lines | p -lang=Eng | l -lang="Eng,Ger" | wf -file=examples.eng2ger.tmp
+? echo "diff examples.eng2ger.out examples.eng2ger.tmp"
+? diff examples.eng2ger.out examples.eng2ger.tmp
 
 ? echo "extracting positive, negative and dubious examples from examples.txt ..."
 ? grep accept examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.pos.txt
 ? grep reject examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.neg.txt
 ? grep dubious examples.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif examples.dub.txt
 
-? echo "parsing negative examples ...; storing trees in examples.neg.new ..."
-rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.new"
-? echo "diff examples.neg.out examples.neg.new:"
-? diff examples.neg.out examples.neg.new
-? echo "parsing dubious examples ...; storing trees in examples.dub.new ..."
-rf -lines -file="examples.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.dub.new"
-? echo "diff examples.dub.out examples.dub.new:"
-? diff examples.dub.out examples.dub.new
-? echo "parsing positive examples ...; storing trees in examples.pos.new ..."
-rf -lines -file="examples.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.pos.new"
-? echo "diff examples.pos.out examples.pos.new:"
-? diff examples.pos.out examples.pos.new
+? echo "parsing negative examples ...; storing trees in examples.neg.tmp ..."
+rf -lines -file="examples.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.neg.tmp"
+? echo "diff examples.neg.out examples.neg.tmp:"
+? diff examples.neg.out examples.neg.tmp
+? echo "parsing dubious examples ...; storing trees in examples.dub.tmp ..."
+rf -lines -file="examples.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.dub.tmp"
+? echo "diff examples.dub.out examples.dub.tmp:"
+? diff examples.dub.out examples.dub.tmp
+? echo "parsing positive examples ...; storing trees in examples.pos.tmp ..."
+rf -lines -file="examples.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="examples.pos.tmp"
+? echo "diff examples.pos.out examples.pos.tmp:"
+? diff examples.pos.out examples.pos.tmp

--- a/tests/german/passive.dub.out
+++ b/tests/german/passive.dub.out
@@ -1,0 +1,12 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond AAnter) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt haben bekommen wollen
+TestLangEng: we would have wanted to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (PredetNP not_Predet (UsePron youPl_Pron))))))) NoVoc
+TestLangGer: für die Bücher wird nicht euch gedankt
+TestLangEng: the books are thanked not you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+TestLangGer: für die Bücher wird nicht euch gedankt
+TestLangEng: the books aren't thanked you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist nicht mit mir debattiert worden
+TestLangEng: the book hasn't been debated with me about

--- a/tests/german/passive.gfs
+++ b/tests/german/passive.gfs
@@ -1,0 +1,23 @@
+-- Use gf --run < passive.gfs  or  gf> eh passive.gfs 
+--? echo "loading TestLangGer.gf and TestLangEng.gf ..."
+--i TestLangGer.gf TestLangEng.gf
+
+? echo "extracting positive, negative and dubious examples from passive.txt ..."
+? grep accept passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.pos.txt
+? wc -l passive.pos.txt
+? grep reject passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.neg.txt
+? wc -l passive.neg.txt
+? grep dubious passive.txt | sed s/\ --\ [\*a-zA-Z\(\)\ \.\:\,\;\<\>\\_0-4\\+\\?\\-]*// | cpif passive.dub.txt
+? wc -l passive.dub.txt
+
+? echo "parsing positive examples ...; storing trees in passive.pos.new ..."
+rf -lines -file="passive.pos.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.pos.new"
+? echo "diff passive.pos.out passive.pos.new:" ; diff passive.pos.out passive.pos.new
+
+? echo "parsing negative examples ...; storing trees in passive.neg.new ..."
+rf -lines -file="passive.neg.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.neg.new"
+? echo "diff passive.neg.out passive.neg.new:" ; diff passive.neg.out passive.neg.new
+
+? echo "parsing dubious examples ...; storing trees in passive.dub.new ..."
+rf -lines -file="passive.dub.txt" | p -lang=Ger | l -treebank -lang="Ger,Eng" | wf -file="passive.dub.new"
+? echo "diff passive.dub.out passive.dub.new:" ; diff passive.dub.out passive.dub.new

--- a/tests/german/passive.neg.out
+++ b/tests/german/passive.neg.out
@@ -1,0 +1,24 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond AAnter) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt haben bekommen wollen
+TestLangEng: we would have wanted to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))) (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N)))))) NoVoc
+TestLangGer: wir lehren die Wissenschaft unseren Freund
+TestLangEng: we teach the science our friend
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))) (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N)))))) NoVoc
+TestLangGer: wir lehren die Wissenschaft unseren Freund
+TestLangEng: we teach our friend the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (ComplVA become_VA (PastPartAP (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science becomes taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (ComplVA become_VA (PastPartAP (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science becomes taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N)))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN science_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumPl) (UseN friend_N))))))) NoVoc
+TestLangGer: die Wissenschaft wird die Freunde gelehrt
+TestLangEng: the science is taught the friends

--- a/tests/german/passive.pos.out
+++ b/tests/german/passive.pos.out
@@ -1,0 +1,195 @@
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 give_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives us the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 give_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives the cars us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives the cars us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 give_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie gibt uns den Wagen
+TestLangEng: she gives us the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 give_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wird uns gegeben
+TestLangEng: the car is given us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash2V3 give_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen wird uns gegeben
+TestLangEng: the car is given us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekommen den Wagen gegeben
+TestLangEng: we are given the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 send_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplSlash (Slash2V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie schickte uns den Wagen
+TestLangEng: she sent the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wurde uns geschickt
+TestLangEng: the car was sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen wurde uns geschickt
+TestLangEng: the car was sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekamen den Wagen geschickt
+TestLangEng: we were sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen würde uns geschickt werden
+TestLangEng: the car would be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+TestLangGer: der Wagen würde uns geschickt werden
+TestLangEng: the car would be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen würde uns nicht geschickt werden
+TestLangEng: the car wouldn't be sent to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir würden den Wagen geschickt bekommen
+TestLangEng: we would be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir würden den Wagen nicht geschickt bekommen
+TestLangEng: we wouldn't be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir würden nicht den Wagen geschickt bekommen
+TestLangEng: we would be sent not the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+TestLangGer: wir wollen den Wagen geschickt bekommen
+TestLangEng: we want to be sent the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash3V3 erklaeren_dat_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 erklaeren_dat_V3 (UsePron we_Pron)) (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain us to the cars
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron we_Pron))))) NoVoc
+TestLangGer: sie erklärten uns den Wagen nicht
+TestLangEng: they didn't explain the car to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 erklaeren_dat_V3 (UsePron we_Pron))))) NoVoc
+TestLangGer: der Wagen wurde uns nicht erklärt
+TestLangEng: the car wasn't explained to us
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+TestLangGer: wir bekamen den Wagen nicht erklärt
+TestLangEng: we weren't explained the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN gold_N)))))) NoVoc
+TestLangGer: wir danken euch nicht für das Gold
+TestLangEng: we don't thank you for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))) (UsePron youPl_Pron))))) NoVoc
+TestLangGer: wir danken euch nicht für das Gold
+TestLangEng: we don't thank you for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youPl_Pron) (PassVPSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))))))) NoVoc
+TestLangGer: euch wird nicht für das Gold gedankt
+TestLangEng: you aren't thanked for the gold
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+TestLangGer: für die Bücher wird euch gedankt
+TestLangEng: the books are thanked you for
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (ComplSlashSlash (Slash3V4 kaufen_bei_fuer_V4 (UsePron youSg_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (MassNP (UseN gold_N)))))) NoVoc
+TestLangGer: wir kaufen den Wagen bei dir für Gold
+TestLangEng: we buy for gold from you the car
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (ComplSlashSlash (Slash2V4 kaufen_bei_fuer_V4 (DetCN (DetQuant DefArt NumSg) (UseN car_N))) (UsePron youSg_Pron)) (MassNP (UseN gold_N)))))) NoVoc
+TestLangGer: wir kaufen den Wagen bei dir für Gold
+TestLangEng: we buy for gold the car from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (ComplSlash (Pass2V4 kaufen_bei_fuer_V4 (DetCN much_Det (UseN gold_N))) (UsePron youSg_Pron))))) NoVoc
+TestLangGer: der Wagen wurde für viel Gold bei dir gekauft
+TestLangEng: the car was bought for much gold from you
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: sie debattieren mit mir über das Buch
+TestLangEng: they debate with me about the book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron they_Pron) (ComplSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
+TestLangGer: sie debattieren nicht mit mir über das Buch
+TestLangEng: they don't debate with me about the book
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: mit mir wurde über das Buch debattiert
+TestLangEng: I was debated about the book with
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+TestLangGer: mit mir wurde nicht über das Buch debattiert
+TestLangEng: I wasn't debated about the book with
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist mit mir debattiert worden
+TestLangEng: the book has been debated with me about
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+TestLangGer: über das Buch ist nicht mit mir debattiert worden
+TestLangEng: the book hasn't been debated with me about
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N))) (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: wir lehren unseren Freund die Wissenschaft
+TestLangEng: we teach our friend the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (DetCN (DetQuant (PossPron we_Pron) NumSg) (UseN friend_N))) (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: wir lehren unseren Freund die Wissenschaft
+TestLangEng: we teach the science our friend
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron she_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron he_Pron)) (UsePron they_Pron))))) NoVoc
+TestLangGer: wir lehren sie ihn
+TestLangEng: we teach them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach her him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash2V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach them him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron she_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach him her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplSlash (Slash3V3 lehren_V3 (UsePron they_Pron)) (UsePron he_Pron))))) NoVoc
+TestLangGer: wir lehren ihn sie
+TestLangEng: we teach him them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: die Freunde werden die Wissenschaft gelehrt
+TestLangEng: the friends are taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+TestLangGer: er wird die Wissenschaft gelehrt
+TestLangEng: he is taught the science
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron she_Pron))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron they_Pron))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught her
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+TestLangGer: er wird sie gelehrt
+TestLangEng: he is taught them
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (Pass2V3 lehren_V3 (UsePron he_Pron))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him
+TestLang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+TestLangGer: sie wird ihn gelehrt
+TestLangEng: she is taught him

--- a/tests/german/passive.trees
+++ b/tests/german/passive.trees
@@ -1,0 +1,37 @@
+PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 give_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash2V3 give_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 give_V3 (DetCN (DetQuant DefArt NumPl) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (PassVPSlash (Slash3V3 send_V3 (UsePron we_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 send_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron we_Pron) (Pass3V3 send_V3 (PredetNP not_Predet (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron we_Pron) (ComplVV want_VV (Pass3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (Pass2V3 erklaeren_dat_V3 (UsePron we_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron we_Pron) (Pass3V3 erklaeren_dat_V3 (DetCN (DetQuant DefArt NumSg) (UseN car_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PNeg (PredVP (UsePron youPl_Pron) (PassVPSlash (Slash3V3 danken_dat_fuer_V3 (DetCN (DetQuant DefArt NumSg) (UseN gold_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN book_N)) (PassVPSlash (Slash2V3 danken_dat_fuer_V3 (UsePron youPl_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN car_N)) (ComplSlash (Pass2V4 kaufen_bei_fuer_V4 (DetCN much_Det (UseN gold_N))) (UsePron youSg_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PNeg (PredVP (UsePron i_Pron) (PassVPSlash (Slash3V3 debattieren_mit_ueber_V3 (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres AAnter) PNeg (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassVPSlash (Slash2V3 debattieren_mit_ueber_V3 (UsePron i_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumPl) (UseN friend_N)) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (DetCN (DetQuant DefArt NumSg) (UseN science_N))))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron she_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (Pass2V3 lehren_V3 (UsePron they_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron she_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron he_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron they_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (Pass2V3 lehren_V3 (UsePron he_Pron))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash2V3 lehren_V3 (UsePron he_Pron)))))) NoVoc
+ PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (PassVPSlash (Slash3V3 lehren_V3 (UsePron he_Pron)))))) NoVoc

--- a/tests/german/passive.txt
+++ b/tests/german/passive.txt
@@ -1,0 +1,110 @@
+-- Passive of V2 
+
+du wirst unterrichtet                      -- accept (dirV2)
+sie wird nicht angeschaut                  -- accept (dirV2 + prefixV)
+auf euch wird nicht gewartet               -- accept (prepV2)
+es wird auf euch gewartet                  -- accept (wrong trees: VPSlashPrep, become_VA, PrepNP)
+es wird auf euch nicht gewartet            -- accept (not recognized)
+
+ihr wurde nicht zugehört                   -- accept (V2 + dat) (PassVPSlash)
+
+-- Passive of V2A, V2S, V2Q
+
+der Wagen wurde nicht blau gemalt          -- accept (V2A) (PassVPSlash)
+wir fragen dich , ob du kommen wirst       -- accept 
+du wirst gefragt , ob du kommen wirst      -- accept (V2Q) (PassVPSlash)
+du wirst nicht gefragt , ob du nicht kommen willst -- accept 
+wir antworten dir , dass es regnet         -- accept
+dir wird geantwortet , dass es regnet      -- accept (V2S) (PassVPSlash)
+
+wir bitten dich , das Buch zu lesen        -- accept
+du wirst gebeten , das Buch zu lesen       -- accept (V2V) 
+du wirst gebeten das Buch zu lesen         -- accept (V2V) (not recognized)
+du wirst das Buch zu lesen gebeten         -- accept (V2V) (recognized)
+
+er wird gebeten , sich das Buch zu merken  -- accept (V2V) (PassVPSlash)
+ich werde gebeten , mir das Buch zu merken -- accept (not recognized) ext:Str, need ext:Agr=>Str
+
+-- Passive of VPSlash and V3
+
+sie gibt uns den Wagen                     -- accept
+
+der Wagen wird uns gegeben                 -- accept, via PassVPSlash or Pass2V3
+uns wird der Wagen gegeben                 -- accept, word order variant (not recognized)
+wir bekommen den Wagen gegeben             -- accept, via Pass3V3
+
+sie schickte uns den Wagen                 -- accept (Eng with prep)
+                                           -- uns:dat+Wagen:sg,acc | uns:acc,Wagen:pl,dat
+
+der Wagen wurde uns geschickt              -- accept, via PassVPSlash
+uns wurde der Wagen geschickt              -- accept, word order variant (not recognized)
+wir bekamen den Wagen geschickt            -- accept, via Pass3V3
+
+der Wagen würde uns geschickt werden       -- accept
+der Wagen würde uns nicht geschickt werden -- accept
+wir würden den Wagen geschickt bekommen    -- accept
+wir würden den Wagen nicht geschickt bekommen -- accept
+wir würden nicht den Wagen geschickt bekommen -- accept ?
+
+der Wagen sei uns geschickt worden         -- accept
+wir hätten den Wagen geschickt bekommen    -- accept
+
+wir wollen den Wagen geschickt bekommen    -- accept
+wir würden den Wagen geschickt bekommen wollen haben -- accept, dubiuos
+wir würden den Wagen geschickt haben bekommen wollen -- reject, dubious
+
+sie erklärten uns den Wagen nicht         -- accept
+der Wagen wurde uns nicht erklärt         -- accept
+wir bekamen den Wagen nicht erklärt       -- accept
+uns wurde den Wagen erklärt               -- reject (bug in PassVPSlash)
+
+wir danken euch nicht für das Gold        -- accept
+euch wird nicht für das Gold gedankt      -- accept
+für die Bücher wird euch gedankt          -- accept
+für die Bücher wird euch nicht gedankt    -- accept, dubious
+für die Bücher wird nicht euch gedankt    -- dubious
+
+wir kaufen den Wagen bei dir für Gold     -- accept
+der Wagen wird bei dir für Gold gekauft   -- accept (not parsed)
+der Wagen wurde für viel Gold bei dir gekauft -- accept (Obj.order: kaufen_bei_fuer)
+
+-- Passive with main verb v:V4
+
+sie debattieren mit mir über das Buch             -- accept 
+sie debattieren nicht mit mir über das Buch       -- accept 
+
+mit mir wurde über das Buch debattiert            -- accept
+mit mir wurde nicht über das Buch debattiert      -- accept
+über das Buch ist mit mir debattiert worden       -- accept 
+über das Buch ist nicht mit mir debattiert worden -- accept, dubious 
+über das Buch ist mit mir nicht debattiert worden -- accept, dubious
+
+-- Passive with main verb v:3 + acc + acc
+
+wir lehren unseren Freund die Wissenschaft        -- accept
+wir lehren die Wissenschaft unseren Freund        -- reject
+wir lehren sie ihn                                -- accept  (die Frau den Bauchtanz)
+wir lehren ihn sie                                -- accept
+
+die Freunde werden die Wissenschaft gelehrt       -- accept
+die Wissenschaft wird die Freunde gelehrt         -- reject
+er wird die Wissenschaft gelehrt                  -- accept
+er wird sie gelehrt                               -- accept
+sie wird ihn gelehrt                              -- accept
+
+-- Passive of V2Q, V2S, V2V 
+
+du wirst nicht gefragt , ob du kommen willst      -- accept (V2Q)
+uns wurde nicht geantwortet , daß ihr kommt       -- accept (V2S)
+
+du wirst gebeten , zu kommen                      -- accept (PassV2V)
+du wirst nicht gebeten , zu kommen                -- accept (PassV2V)
+du wirst nicht gebeten , nicht zu kommen          -- accept (not recognized, dubious)
+du wirst nicht gebeten , das Buch zu lesen        -- accept
+du wirst nicht gebeten , sich zu ändern           -- accept (dubious: dich/sich)
+du wirst nicht gebeten , dich zu fragen , ob du mir das Buch schicken willst -- accept
+mir wurde versprochen , das Buch zu lesen         -- accept (PassV2V)
+
+wir bitten euch euch zu fragen , ob ihr kommt     -- accept (dubious : missing comma)
+wir bitten dich dich zu ändern                    -- dubious (comma)
+


### PR DESCRIPTION
…sting/german

- NP: added field isLight in order to push negation behind light nps;
  this had been done in gf-3.9 using field isPron, but isPron is now
  used to put accusative pronoun before dative pronoun. Removed field
  adv: adverbial extensions cannot be extracted (todo: also for CN).
  Reduced isLight*isPron to w:Weight with 3 values: WPron, WLight, WHeavy.

- added param Control and field ctrl:Control to classify V2V-verbs into
  subject- and object-contol verbs, use ctrl to make reflexives agree
  with subject resp. object in VPSlash, and refine ComplSlash.

- Verb: new versions of ComplVV, SlashV2V and SlashVV to give better
  (nested) infinitives (extracting infzu and correcting object order).
  a) nested SlashVV doesn't work properly;
  b) SlashV2VNP may have to be commented out to prevent a stack overflow
     when compiling.
  Intended change of SlashV2VNP in tests/german/TestLangGer could not
  be tested due to size problems with the compiler.

- VP: changed field a1 : Polarity => Str to a1:Str to collect the adverbs
  coming before negation, using (negation : Polarity => Str) in mkClause.
  Use objCtrl:Bool instead of missingAdv to let reflexives agree with object.

- ResGer: insertObjNP reorganized, infzuVP added

- DictVerbsGer: some corrections (helft -> hilft, *sprecht -> *spricht)

- Some potential passive rules in tests/german/TestLangGer|Eng

- ExtraGer needs to be cleaned up with repect to the modified mkClause.