### PR TITLE
Small fixes to Russian RG

### DIFF
--- a/src/russian/MorphoRus.gf
+++ b/src/russian/MorphoRus.gf
@@ -1274,7 +1274,7 @@ oper verbDecl: Aspect -> Conjugation -> Str -> Str -> Str -> Str -> Str -> Verbu
 			   Dolzhen => <presentConjDolzhen,pastConjDolzhen> ;
 			   Foreign => <presentConjForeign,pastConj> } in 
        let patt = case a of {
-	            Perfective   => mkVerbImperfective;
+	            Perfective   => mkVerbPerfective;
 		    Imperfective => mkVerbImperfective } in
        patt inf imperSgP2 (conj.p1 del sgP1End) (conj.p2 sgMascPast) ;
 
@@ -1283,7 +1283,7 @@ oper verbDecl: Aspect -> Conjugation -> Str -> Str -> Str -> Str -> Str -> Verbu
 oper verbDeclMoch: Aspect -> Conjugation -> Str -> Str -> Str -> Str ->Str -> Str -> Verbum =
    \a, c, del, sgP1End, sgMascPast, imperSgP2, inf, altRoot -> 
        let patt = case a of {
-	            Perfective   => mkVerbImperfective;
+	            Perfective   => mkVerbPerfective;
 		    Imperfective => mkVerbImperfective } in
         patt inf imperSgP2 (presentConj1Moch del sgP1End altRoot) (pastConj sgMascPast);
 

--- a/src/russian/MorphoRus.gf
+++ b/src/russian/MorphoRus.gf
@@ -1290,7 +1290,7 @@ oper verbDeclMoch: Aspect -> Conjugation -> Str -> Str -> Str -> Str ->Str -> St
 oper add_sya : Voice -> Str -> Str = \v,x ->
        case v of {
 	 Act => x ;
-	 Pas => case Predef.dp 2 x of {
+	 Pas => case Predef.dp 1 x of {
                   "а" | "е" | "ё" | "и" | "о" | "у" | "ы" | "э" | "ю" | "я" => x + "сь" ;
 		  _ => x + "ся"
 	   }


### PR DESCRIPTION
Please refer to the discussion in dev list: https://groups.google.com/d/msg/gf-dev/bZA37JAm5h0/skeo087kBgAJ 

- add_sya first case never works in Unicode world
- a couple of cases are useless unless they choose right constructor (perfective / imperfective)


