### PR TITLE
Fix can (moch) in Russian RG

### DIFF
--- a/src/russian/LexiconRus.gf
+++ b/src/russian/LexiconRus.gf
@@ -21,7 +21,7 @@ lin
   bank_N = mkN "банк" ;
   bark_N = mkN "кора";
   beautiful_A = mkA "красивый";
-  become_VA = regV perfective second "станов" "лю" "стал" "стань" "стать" ;
+  become_VA = regV perfective secondA "станов" "лю" "стал" "стань" "стать" ;
   beer_N = mkIndeclinableNoun "пиво" neuter inanimate ;
   beg_V2V = dirV2 (mkV imperfective "прошу" "просишь" "просит" "просим" "просите" "просят" "просил" "проси" "просить" );
   belly_N = mkN "живот" ;

--- a/src/russian/MorphoRus.gf
+++ b/src/russian/MorphoRus.gf
@@ -1228,6 +1228,14 @@ oper presentConj1Moch: Str -> Str -> Str -> PresentVerb = \del, sgP1End, altRoot
     PRF GPl P3 => del+ sgP1End + "т"
   };
 
+oper pastConjMoch: Str -> PastVerb = \del ->
+  table {
+    PSF  (GSg Masc) => del ;
+    PSF  (GSg Fem)  => del +"ла" ;
+    PSF  (GSg Neut)  => del+"ло" ;
+    PSF  GPl => del+ "ли"
+  };
+
 -- "PastVerb" takes care of the past tense conjugation.
 
 param PastVF = PSF GenNum ;
@@ -1285,7 +1293,7 @@ oper verbDeclMoch: Aspect -> Conjugation -> Str -> Str -> Str -> Str ->Str -> St
        let patt = case a of {
 	            Perfective   => mkVerbPerfective;
 		    Imperfective => mkVerbImperfective } in
-        patt inf imperSgP2 (presentConj1Moch del sgP1End altRoot) (pastConj sgMascPast);
+        patt inf imperSgP2 (presentConj1Moch del sgP1End altRoot) (pastConjMoch sgMascPast);
 
 oper add_sya : Voice -> Str -> Str = \v,x ->
        case v of {


### PR DESCRIPTION
Fixes problem with a very important verb.

Also fixed become_VA conjugation, which caused some odd forms like "становдит"

Past tense of "мочь" are: "мог", "могла", "могло", "могли".

```
* can_VV

** UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron she_Pron) (ComplVV ∅ tired_VP))
LangRus-NEW> она могла бы быть уставшим
LangRus-OLD> она мога бы быть уставшим


** UseCl (TTAnt TCond ASimul) PPos (PredVP everybody_NP (ComplVV ∅ tired_VP))
LangRus-NEW> все могли бы быть уставшим
LangRus-OLD> все моги бы быть уставшим


** UseCl (TTAnt TCond ASimul) PPos (PredVP everything_NP (ComplVV ∅ tired_VP))
LangRus-NEW> всё могло бы быть уставшим
LangRus-OLD> всё мого бы быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVV ∅ tired_VP))
LangRus-NEW> она могла быть уставшим
LangRus-OLD> она мога быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP everybody_NP (ComplVV ∅ tired_VP))
LangRus-NEW> все могли быть уставшим
LangRus-OLD> все моги быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP everything_NP (ComplVV ∅ tired_VP))
LangRus-NEW> всё могло быть уставшим
LangRus-OLD> всё мого быть уставшим

```

Note: in some test cases above tired_VP is not having correct gender. For instance: "она могла быть уставшим" (Masc) should be "она могла быть уставшей" (Fem).