### PR TITLE
Fix must (dolzhen) in Rus RG

### DIFF
--- a/src/russian/MorphoRus.gf
+++ b/src/russian/MorphoRus.gf
@@ -1141,7 +1141,7 @@ oper verbKhotet : Verbum = verbDecl Imperfective Mixed "хо" "у" "хотел" 
 --AR oper verbKhotet : Verbum = verbDecl Imperfective Mixed "хоч" "у" "хотел" "хоти" "хотеть";
 
 -- Irregular
-oper verbDolzhen : Verbum = verbDecl Imperfective Dolzhen "долж" "ен" "долж" ["будь должен"] ["быть должным"] ;
+oper verbDolzhen : Verbum = verbDecl Imperfective Dolzhen "долж" "ен" "долж" ("будь" ++ "должен") ("быть" ++ "должным") ;
 
 
 -- further conjugation class added by Magda Gerritsen and Ulrich Real:
@@ -1159,10 +1159,10 @@ oper PresentVerb : Type = PresentVF => Str ;
 
 oper presentConjDolzhen: Str -> Str -> PresentVerb = \del, sgP1End ->
   table {
-    PRF GPl _        => del + "ны" ;
     PRF (GSg Masc) _ => del + sgP1End ;
     PRF (GSg Fem)  _ => del + "на" ;
-    PRF (GSg Neut) _ => del + "но"
+    PRF (GSg Neut) _ => del + "но" ;
+    PRF GPl _        => del + "ны"
   };
 
 -- +++ MG_UR: changed! +++
@@ -1250,10 +1250,10 @@ oper pastConj: Str -> PastVerb = \del ->
 
 oper pastConjDolzhen: Str -> PastVerb = \del ->
   table {
-    PSF  (GSg Masc) => ["был "] + del + "ен" ;
-    PSF  (GSg Fem)  => ["была "] + del + "на" ;
-    PSF  (GSg Neut)  => ["было "] + del + "но" ;
-    PSF  GPl => ["были "] + del + "ны"
+    PSF  (GSg Masc)  => "был"  ++ del + "ен" ;
+    PSF  (GSg Fem)   => "была" ++ del + "на" ;
+    PSF  (GSg Neut)  => "было" ++ del + "но" ;
+    PSF  GPl         => "были" ++ del + "ны"
   };
 
 -- further class added by Magda Gerritsen and Ulrich Real
@@ -1321,7 +1321,7 @@ oper mkVerbImperfective : Str -> Str -> PresentVerb -> PastVerb -> Verbum =
 
 	 VSUB gn => add_sya vox (past ! (PSF gn)) ++ "бы";
 
-	 VIND (GSg _) (VPresent p) => add_sya vox (presentFuture ! (PRF (GSg Masc) p));
+	 VIND (GSg g) (VPresent p) => add_sya vox (presentFuture ! (PRF (GSg g) p));
 	 VIND GPl (VPresent p)     => add_sya vox (presentFuture ! (PRF GPl p));
 	 VIND (GSg _) (VFuture P1) => "буду"   ++ add_sya vox inf ;
 	 VIND (GSg _) (VFuture P2) => "будешь" ++ add_sya vox  inf ;
@@ -1347,7 +1347,7 @@ oper mkVerbPerfective: Str -> Str -> PresentVerb -> PastVerb -> Verbum =
 
 	 VSUB gn => add_sya vox (past ! (PSF gn)) ++ "бы" ;
 
-	 VIND (GSg _) (VPresent p)  => (presentFuture ! (PRF (GSg Masc) p)); -- these are not correct,
+	 VIND (GSg g) (VPresent p)  => (presentFuture ! (PRF (GSg g) p)); -- these are not correct,
 	 VIND GPl     (VPresent p)  => (presentFuture ! (PRF GPl p)) ;       -- but used elsewhere
 	 VIND gn      (VFuture p)   => add_sya vox (presentFuture ! (PRF gn p)) ;
 	 VIND gn      VPast         => add_sya vox (past ! (PSF gn))


### PR DESCRIPTION
I've noticed, that must_VV does not work properly:
1. Is always used Masc ("она должен быть уставшим" -> "она должна быть уставшим"
2. Words clung together ("быладолжна" --> "была должна")

I am not quite sure how adjective "должен" ended up being a verb (it's an adjective with only short form), but I enabled propagation of gender and it started to work.

While overall tests show more correct results, there is still room for improvement (as for example gender does not propagate to tired_VP in the tests, something_NP is Neuter, and some subtler cases ...)





```
* must_VV

** UseCl (TTAnt TCond ASimul) PPos (PredVP (UsePron she_Pron) (ComplVV ∅ tired_VP))
LangRus-NEW> она была должна бы быть уставшим
LangRus-OLD> она быладолжна бы быть уставшим


** UseCl (TTAnt TCond ASimul) PPos (PredVP everybody_NP (ComplVV ∅ tired_VP))
LangRus-NEW> все были должны бы быть уставшим
LangRus-OLD> все былидолжны бы быть уставшим


** UseCl (TTAnt TCond ASimul) PPos (PredVP everything_NP (ComplVV ∅ tired_VP))
LangRus-NEW> всё было должно бы быть уставшим
LangRus-OLD> всё былодолжно бы быть уставшим


** UseCl (TTAnt TCond ASimul) PPos (PredVP something_NP (ComplVV ∅ tired_VP))
LangRus-NEW> что-то был должен бы быть уставшим
LangRus-OLD> что-то былдолжен бы быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP (UsePron she_Pron) (ComplVV ∅ tired_VP))
LangRus-NEW> она была должна быть уставшим
LangRus-OLD> она быладолжна быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP everybody_NP (ComplVV ∅ tired_VP))
LangRus-NEW> все были должны быть уставшим
LangRus-OLD> все былидолжны быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP everything_NP (ComplVV ∅ tired_VP))
LangRus-NEW> всё было должно быть уставшим
LangRus-OLD> всё былодолжно быть уставшим


** UseCl (TTAnt TPast ASimul) PPos (PredVP something_NP (ComplVV ∅ tired_VP))
LangRus-NEW> что-то был должен быть уставшим
LangRus-OLD> что-то былдолжен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP (ConjNP or_Conj (ConsNP (UsePron i_Pron) (BaseNP something_NP (UsePron she_Pron)))) (ComplVV ∅ tired_VP))
LangRus-NEW> что-то, она или я должна быть уставшим
LangRus-OLD> что-то, она или я должен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP (ConjNP or_Conj (ConsNP (UsePron i_Pron) (BaseNP something_NP everything_NP))) (ComplVV ∅ tired_VP))
LangRus-NEW> что-то, всё или я должно быть уставшим
LangRus-OLD> что-то, всё или я должен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP (ConjNP or_Conj (ConsNP (UsePron youSg_Pron) (BaseNP something_NP (UsePron she_Pron)))) (ComplVV ∅ tired_VP))
LangRus-NEW> что-то, она или ты должна быть уставшим
LangRus-OLD> что-то, она или ты должен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP (ConjNP or_Conj (ConsNP (UsePron youSg_Pron) (BaseNP something_NP everything_NP))) (ComplVV ∅ tired_VP))
LangRus-NEW> что-то, всё или ты должно быть уставшим
LangRus-OLD> что-то, всё или ты должен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron she_Pron) (ComplVV ∅ tired_VP))
LangRus-NEW> она должна быть уставшим
LangRus-OLD> она должен быть уставшим


** UseCl (TTAnt TPres ASimul) PPos (PredVP everything_NP (ComplVV ∅ tired_VP))
LangRus-NEW> всё должно быть уставшим
LangRus-OLD> всё должен быть уставшим


```