### PR TITLE
(unittest.py) more forgiving parser

### DIFF
--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -77,23 +77,28 @@ def numbered_np(num, noun, plural=None):
 
 def collect_testcases(testlines):
     """Parse the test file and return a list of test cases"""
-    tests = [[]]
+    tests = []
+    test = []
     for linenr, line in enumerate(testlines, 1):
+        line = line.strip()
         if line.startswith('#') or line.startswith('--'):
             # a comment line: do nothing
             pass
-        elif not line.strip():
+        elif not line:
             # an empty line: start a new test
-            if tests[-1]:
-                tests.append([])
+            if test:
+                tests.append(test)
+                test = []
         elif ':' in line:
             lang, sentence = stripstrings(line.split(':', 1))
             langfile = importfile(linenr, lang)
             is_tree = '/abstract/' in langfile
-            tests[-1].append((is_tree, linenr, lang, langfile, sentence))
+            test.append((is_tree, linenr, lang, langfile, sentence))
         else:
             error(linenr, "Ill-formatted line in test file:", line)
             exit(1)
+    if test:
+        tests.append(test)
     return tests
 
 


### PR DESCRIPTION
while implementing a test case I stumbled upon syntax errors that (although being my own fault) were a bit cryptic to decipher, like not being able to have a blank line at the end of the file. these changes make the parser less strict, accepting minor deviations from the format like having multiple blank lines between test cases.

- accepts whitespace before comment starts
- accepts blank lines after last test case, or more than one of them
  between test case

I've run tests with Hungarian and Portuguese (soon to be a PR), and it doesn't seem like I've changed the parser behavior in unintended ways, but please do review!
