### PR TITLE
Update RGL status doc + publications

### DIFF
--- a/doc/rgl-publications.txt
+++ b/doc/rgl-publications.txt
@@ -66,7 +66,16 @@ http://acl.ldc.upenn.edu/W/W07/W07-08.pdf
 //A case study with the resource grammar, focusing on the morphosyntax//
 //and agreement of constructions with numerals.//
 
+===Basque===
 
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/basque (Inari Listenmaa, Francis Tyers)
+
+- **Publications**
+
+Inari Listenmaa.
+//Formal Methods for Testing Grammars.// PhD thesis. Chalmers University of Technology and University of Gothenburg. 2019. [PDF https://gupea.ub.gu.se/bitstream/2077/59037/1/gupea_2077_59037_1.pdf]
+#BR
+//Mentioned in Chapter 5 of the thesis.//
 
 
 ===Bulgarian===
@@ -155,8 +164,13 @@ The GF Resource Grammar Library.
 
 - **Source**: http://www.grammaticalframework.org/lib/src/estonian (Kaarel Kaljurand, Inari Listenmaa)
 
-%- **Publications**
+- **Publications**
 
+Inari Listenmaa and Kaarel Kaljurand.
+Computational Estonian Grammar in Grammatical Framework.
+//Proceedings of the SALTMIL Workshop at LREC//,
+2014.
+[PDF http://ixa2.si.ehu.es/~jipsagak/SALTMIL/LREC_2014_Workshop_Proceedings_Saltmil.pdf]
 
 
 ===Finnish===
@@ -255,7 +269,9 @@ Hindi and Urdu share a grammar but not the lexicon.
 In The 3rd Workshop
 on South and Southeast Asian NLP, COLING 2012. //Reprinted in Shafqat's thesis//
 
+===Hungarian===
 
+-- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/hungarian (Inari Listenmaa, Julia Jansson)
 
 
 ===Icelandic===
@@ -281,8 +297,6 @@ Bjarki Traustason, MSc thesis, Chalmers
 %- **Publications**
 
 
-
-
 ===Japanese===
 
 - **Source**: http://www.grammaticalframework.org/lib/src/japanese (Liza Zimina)
@@ -302,7 +316,9 @@ Lecture Notes in Computer Science Volume 7614, 2012, pp 156-167.
 http://link.springer.com/chapter/10.1007%2F978-3-642-33983-7_16
 
 
+===Korean===
 
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/korean (Inari Listenmaa)
 
 ===Latin===
 
@@ -396,6 +412,14 @@ Slide presentation, TYPES 2010, Warsaw,
 2010.
 http://www.mimuw.edu.pl/~asl/publications/types2010-slides.pdf
 
+===Portuguese===
+
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/portuguese (Bruno Cuconato)
+
+- **Publications**
+
+Bruno Cuconato Claro.
+//A computational grammar for Portuguese//. MSc thesis. Rio de Janeiro, 2019.
 
 
 ===Punjabi===
@@ -485,7 +509,8 @@ http://publications.lib.chalmers.se/records/fulltext/163234.pdf
 
 ===Swahili===
 
-- **Source**: http://www.grammaticalframework.org/lib/src/swahili (Wanjiku Ng'ang'a)
+- **Source**: http://www.grammaticalframework.org/lib/src/swahili (Benson Kituku).
+- **Previous version**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/swahili/old (Wanjiku Ng'ang'a).
 
 
 - **Publications**
@@ -556,3 +581,16 @@ July 21-22, 2007, LSA 2007 Linguistic Institute, Stanford University.
 2007.
 
 See also **Hindi** above.
+
+===Zulu===
+
+- **Source:** https://github.com/LauretteM/gf-rgl-zul/tree/master/src/zulu (Laurette Marais, Laurette Pretorius)
+
+- **Publications**
+
+Laurette Marais, Johannes A. Louw, Jaco Badenhorst, Karen Calteaux, Ilana Wilken, Nina van Niekerk,and Glenn Stein.
+AwezaMed: A Multilingual, MultimodalSpeech-To-Speech Translation Application for Maternal Health Care.
+//Proceedings of the 23rd International Conference on Information Fusion//.
+July 6-9, 2020.
+#BR
+//The article presents a health care translation system, which uses the Zulu resource grammar.//

--- a/doc/rgl-publications.txt
+++ b/doc/rgl-publications.txt
@@ -66,6 +66,7 @@ http://acl.ldc.upenn.edu/W/W07/W07-08.pdf
 //A case study with the resource grammar, focusing on the morphosyntax//
 //and agreement of constructions with numerals.//
 
+
 ===Basque===
 
 - **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/basque (Inari Listenmaa, Francis Tyers)
@@ -129,6 +130,7 @@ http://www.grammaticalframework.org/gf-book/gf-chinese-appendix.pdf
 ===Czech===
 
 - **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/czech (Aarne Ranta, Michal Měchura)
+
 
 ===Danish===
 
@@ -272,9 +274,10 @@ Hindi and Urdu share a grammar but not the lexicon.
 In The 3rd Workshop
 on South and Southeast Asian NLP, COLING 2012. //Reprinted in Shafqat's thesis//
 
+
 ===Hungarian===
 
--- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/hungarian (Inari Listenmaa, Julia Jansson)
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/hungarian (Inari Listenmaa, Julia Jansson)
 
 
 ===Icelandic===
@@ -323,12 +326,27 @@ http://link.springer.com/chapter/10.1007%2F978-3-642-33983-7_16
 
 - **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/korean (Inari Listenmaa)
 
+
+
 ===Latin===
 
-- **Source**: http://www.grammaticalframework.org/lib/src/latin (Aarne Ranta)
+- **Source**: http://www.grammaticalframework.org/lib/src/latin (Herbert Lange, Aarne Ranta)
 
-%- **Publications**
+- **Publications**
 
+Herbert Lange.
+Erstellen einer Grammatik für das Lateinische im “Grammatical Framework”,
+Master’s thesis (Magiserarbeit), Ludwig-Maximilians-University Munich, 2013.
+
+Herbert Lange. Implementation of a Latin Grammar in Grammatical Framework, //DATeCH//, 2017.
+
+Herbert Lange and Peter Ljunglöf.
+MULLE: A grammar-based Latin language learning tool to supplement the classroom setting.
+//Proceedings of the 5th Workshop on Natural Language Processing Techniques for Educational Applications//,
+2018.
+[PDF https://www.aclweb.org/anthology/W18-3715.pdf]
+#BR
+//Latin RGL used in a language-learning application.//
 
 
 ===Latvian===
@@ -414,6 +432,7 @@ Some Interesting Features of the Polish Language in Grammatical Framework.
 Slide presentation, TYPES 2010, Warsaw,
 2010.
 http://www.mimuw.edu.pl/~asl/publications/types2010-slides.pdf
+
 
 ===Portuguese===
 
@@ -512,6 +531,11 @@ http://publications.lib.chalmers.se/records/fulltext/163234.pdf
 - **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/slovenian (Krasimir Angelov, Anna Ehrlemark)
 
 
+===Somali===
+
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/somali (Inari Listenmaa)
+
+
 ===Spanish===
 
 - **Source**: http://www.grammaticalframework.org/lib/src/spanish  http://www.grammaticalframework.org/lib/src/romance
@@ -557,10 +581,6 @@ P. Sojka et al (eds), TSD 2012, LNCS 7499, pp. 183-190.
 http://link.springer.com/content/pdf/10.1007%2F978-3-642-32790-2_22.pdf
 
 
-
-
-
-
 ===Thai===
 
 - **Source**: http://www.grammaticalframework.org/lib/src/thai (Aarne Ranta, Chotiros Kairoje)
@@ -594,6 +614,7 @@ July 21-22, 2007, LSA 2007 Linguistic Institute, Stanford University.
 2007.
 
 See also **Hindi** above.
+
 
 ===Zulu===
 

--- a/doc/rgl-publications.txt
+++ b/doc/rgl-publications.txt
@@ -126,6 +126,9 @@ Appendix to the GF book (A. Ranta, //Grammatical Framework//, CSLI 2011),
 http://www.grammaticalframework.org/gf-book/gf-chinese-appendix.pdf
 
 
+===Czech===
+
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/czech (Aarne Ranta, Michal Měchura)
 
 ===Danish===
 
@@ -497,6 +500,16 @@ Implementing GF Resource Grammar for Sindhi language,
 MSc Thesis, Chalmers University of Technology,
 2012.
 http://publications.lib.chalmers.se/records/fulltext/163234.pdf
+
+
+===Slovak===
+
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/slovak (Aarne Ranta, Slavomír Čéplö, Michal Měchura)
+
+
+===Slovenian===
+
+- **Source**: https://github.com/GrammaticalFramework/gf-rgl/tree/master/src/slovenian (Krasimir Angelov, Anna Ehrlemark)
 
 
 ===Spanish===

--- a/doc/rgl-publications.txt
+++ b/doc/rgl-publications.txt
@@ -465,7 +465,7 @@ LNCS 6008,
 
 ===Russian===
 
-- **Source**: http://www.grammaticalframework.org/lib/src/russian (Janna Khegai, Nikita Frolov)
+- **Source**: http://www.grammaticalframework.org/lib/src/russian (Janna Khegai, Nikita Frolov, Roman Suzi)
 
 - **Publications**
 

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -11,59 +11,62 @@ For another view, see the
 [The Resource Grammar Library coverage map http://www.postcrashgames.com/gf_world/] .
 
 Corrections and additions are welcome! Notice that only those parts of implementations
-that are currently available via http://grammaticalframework.org
+that are currently available via https://github.com/GrammaticalFramework/gf-rgl/
 are marked in the table
 
 
-|| ISO  | Language     | Git   | Mini | Parad | Lex | Lang | API | Symb | Irreg | Dict | Trans | tested | publ   | authors       ||
-| Afr   | Afrikaans    | +     | -    | ++    | +   | +    | +   | -    | -     | -    | -     | -      | -      | *LP,LM
-| Amh   | Amharic      | +     | +    | ++    | +   | +    | -   | -    | -     | -    | - | -      | +      | *MK
-| Ara   | Arabic       | +     | +    | +     | +   | +    | +   | +    | -     | -    | - | +      | +      | AD,*IL
-| Bul   | Bulgarian    | +     | +    | +     | +   | +    | +   | +    | +     | +    | + | ++     | +      | *KA
-| Cat   | Catalan      | +     | +    | ++    | +   | +    | +   | +    | +     | -    | + | ++     | -      | *JS,*IL
-| Chi   | Chinese      | +     | -    | ++    | +   | +    | +   | -    | -     | +    | + | -      | +      | ZL,*AR,*CP,QH
-| Dan   | Danish       | +     | +    | ++    | +   | +    | +   | +    | +     | -    | - | +      | -      | *AR
-| Dut   | Dutch        | +     | +    | ++    | +   | +    | +   | +    | +     | -    | + | +      | -      | *AR,FJ
-| Eng   | English      | +     | +    | ++    | +   | +    | +   | +    | +     | +    | + | ++     | +      | *AR,BB,KA
-| Est   | Estonian     | +     | -    | ++    | +   | +    | +   | -    | -     | +    | + | +      | +      | *KK,*IL
-| Eus   | Basque       | +     | -    | ++    | +   | +    | +   | -    | -     | -    | - | -      | +      | *IL
-| Fin   | Finnish      | +     | +    | ++    | +   | +    | +   | +    | -     | +    | + | ++     | +      | *AR,*IL
-| Fre   | French       | +     | +    | ++    | +   | +    | +   | +    | +     | +    | + | ++     | -      | *AR,RE
-| Ger   | German       | +     | +    | ++    | +   | +    | +   | +    | +     | +    | + | ++     | -      | *AR,HH,EG
-| Gre   | Greek(mod)   | +     | -    | ++    | +   | +    | +   | -    | -     | -    | - | -      | +      | *IP
-| Grc   | Greek(anc)   | -     | -    | -     | -   | -    | -   | -    | -     | -    | - | -      | +      | *HLe
-| Heb   | Hebrew       | +     | -    | -     | -   | -    | -   | -    | -     | -    | - | -      | +      | *DD
-| Hin   | Hindi        | +     | +    | ++    | +   | +    | +   | +    | -     | -    | + | +      | +      | *SV,*KP,MH,AR,PK
-| Ice   | Icelandic    | +     | -    | ++    | +   | +    | +   | -    | -     | -    | - | -      | +      | *BT
-| Ina   | Interlingua  | +     | +    | ++    | +   | +    | -   | -    | -     | -    | - | -      | -      | JB
-| Ita   | Italian      | +     | +    | ++    | +   | +    | +   | +    | -     | -    | + | ++     | -      | *AR,*RE,GP
-| Jpn   | Japanese     | +     | -    | ++    | +   | +    | +   | -    | -     | -    | + | +      | +      | *LZ
-| Lat   | Latin        | +     | -    | -     | -   | -    | -   | -    | -     | +    | - | -      | -      | *AR,*HLa
-| Lav   | Latvian      | +     | -    | ++    | +   | +    | +   | -    | -     | -    | - | +      | +      | *NG,*PP
-| Mlt   | Maltese      | +     | +    | ++    | +   | +    | +   | +    | -     | -    | - | -      | +      | *JC
-| Mon   | Mongolian    | +     | -    | ++    | +   | +    | +   | -    | -     | +    | - | -      | +      | *NE
-| Nep   | Nepali       | +     | +    | ++    | +   | +    | -   | -    | -     | -    | - | -      | +      | *DS
-| Nno   | Norwegian(n) | +     | +    | ++    | +   | +    | +   | +    | +     | -    | - | -      | -      | *SRE
-| Nor   | Norwegian(b) | +     | +    | ++    | +   | +    | +   | +    | +     | -    | - | +      | -      | *AR
-| Pes   | Persian      | +     | -    | +     | +   | +    | +   | -    | -     | -    | - | +      | +      | SV,EA,SM,*IL
-| Pnb   | Punjabi      | +     | +    | +     | +   | +    | +   | +    | -     | -    | - | -      | +      | *SV,MH
-| Pol   | Polish       | +     | +    | +     | +   | +    | +   | +    | -     | -    | - | +      | +      | IN,*AS
-| Por   | Portuguese   | +     | +    | ++    | +   | +    | +   | +    | +     | -    | + | +      | -      | *BC
-| Ron   | Romanian     | +     | +    | ++    | +   | +    | +   | +    | -     | -    | - | +      | +      | *RE
-| Rus   | Russian      | +     | +    | ++    | +   | +    | +   | -    | -     | +    | + | -      | +      | JK,*NF
-| Snd   | Sindhi       | +     | +    | ++    | +   | +    | +   | +    | -     | -    | - | -      | +      | *SV,*JD
-| Spa   | Spanish      | +     | +    | ++    | +   | +    | +   | +    | +     | -    | + | ++     | -      | *AR,IA,TS,*IL
-| Swa   | Swahili      | +     | -    | -     | -   | -    | -   | -    | -     | -    | - | -      | +      | *WN,JM
-| Swe   | Swedish      | +     | +    | ++    | +   | +    | +   | +    | +     | +    | + | ++     | +      | *MA,*AR,MF
-| Tha   | Thai         | +     | -    | ++    | +   | +    | +   | +    | -     | -    | + | +      | -      | *AR,CK
-| Tsn   | Tswana       | -     | -    | -     | -   | -    | -   | -    | -     | -    | - | -      | -      | *LP,AB
-| Tur   | Turkish      | +     | -    | ++    | +   | -    | -   | -    | -     | +    | - | -      | -      | *SC,KA
-| Urd   | Urdu         | +     | +    | ++    | +   | +    | +   | +    | -     | -    | - | +      | +      | *SV,MH
+|| ISO  | Language     | Parad | Lex | Lang | API | Symb | Irreg | Dict | WN | tested | publ | authors          ||
+| Afr   | Afrikaans    | ++    | +   | +    | +   | -    | -     | -    | -  | -      | -    | *LP,LM            |
+| Amh   | Amharic      | ++    | +   | +    | -   | -    | -     | -    | -  | -      | +    | *MK               |
+| Ara   | Arabic       | +     | +   | +    | +   | +    | -     | -    | -  | +      | +    | AD,*IL            |
+| Bul   | Bulgarian    | +     | +   | +    | +   | +    | +     | +    | +  | ++     | +    | *KA               |
+| Cat   | Catalan      | ++    | +   | +    | +   | +    | +     | -    | +  | ++     | -    | *JS,*IL           |
+| Chi   | Chinese      | ++    | +   | +    | +   | -    | -     | +    | +  | -      | +    | ZL,*AR,*CP,QH     |
+| Cze   | Czech        | +     | +   | +    | +   | -    | -     | -    | -  | +      | -    | *AR,*MM           |
+| Dan   | Danish       | ++    | +   | +    | +   | +    | +     | -    | -  | +      | -    | *AR               |
+| Dut   | Dutch        | ++    | +   | +    | +   | +    | +     | -    | +  | +      | -    | *AR,FJ            |
+| Eng   | English      | ++    | +   | +    | +   | +    | +     | +    | +  | ++     | +    | *AR,BB,KA         |
+| Est   | Estonian     | ++    | +   | +    | +   | -    | -     | +    | +  | +      | +    | *KK,*IL           |
+| Eus   | Basque       | ++    | +   | +    | +   | -    | -     | -    | -  | -      | +    | *IL               |
+| Fin   | Finnish      | ++    | +   | +    | +   | +    | -     | +    | +  | ++     | +    | *AR,*IL           |
+| Fre   | French       | ++    | +   | +    | +   | +    | +     | +    | -  | ++     | -    | *AR,RE            |
+| Ger   | German       | ++    | +   | +    | +   | +    | +     | +    | -  | ++     | -    | *AR,HH,EG         |
+| Gre   | Greek(mod)   | ++    | +   | +    | +   | -    | -     | -    | -  | -      | +    | *IP               |
+| Grc   | Greek(anc)   | -     | -   | -    | -   | -    | -     | -    | -  | -      | +    | *HLe              |
+| Heb   | Hebrew       | -     | -   | -    | -   | -    | -     | -    | -  | -      | +    | *DD               |
+| Hin   | Hindi        | ++    | +   | +    | +   | +    | -     | -    | -  | +      | +    | *SV,*KP,MH,AR,PK  |
+| Hun   | Hungarian    | ++    | +   | +    | +   | +    | -     | -    | -  | +      | -    | *IL,*JJ           |
+| Ice   | Icelandic    | ++    | +   | +    | +   | -    | -     | -    | -  | -      | +    | *BT               |
+| Ina   | Interlingua  | ++    | +   | +    | -   | -    | -     | -    | -  | -      | -    | JB                |
+| Ita   | Italian      | ++    | +   | +    | +   | +    | -     | -    | +  | ++     | -    | *AR,*RE,GP        |
+| Jpn   | Japanese     | ++    | +   | +    | +   | -    | -     | -    | -  | +      | +    | *LZ               |
+| Kor   | Korean       | ++    | +   | +    | +   | +    | -     | -    | -  | +      | -    | *IL               |
+| Lat   | Latin        | -     | -   | -    | -   | -    | -     | +    | -  | -      | -    | *AR,*HLa          |
+| Lav   | Latvian      | ++    | +   | +    | +   | -    | -     | -    | -  | +      | +    | *NG,*PP           |
+| Mlt   | Maltese      | ++    | +   | +    | +   | +    | -     | -    | -  | -      | +    | *JC               |
+| Mon   | Mongolian    | ++    | +   | +    | +   | -    | -     | +    | -  | -      | +    | *NE               |
+| Nep   | Nepali       | ++    | +   | +    | -   | -    | -     | -    | -  | -      | +    | *DS               |
+| Nno   | Norwegian(n) | ++    | +   | +    | +   | +    | +     | -    | -  | -      | -    | *SRE              |
+| Nor   | Norwegian(b) | ++    | +   | +    | +   | +    | +     | -    | -  | +      | -    | *AR               |
+| Pes   | Persian      | +     | +   | +    | +   | -    | -     | -    | -  | +      | +    | SV,EA,SM,*IL      |
+| Pnb   | Punjabi      | +     | +   | +    | +   | +    | -     | -    | -  | -      | +    | *SV,MH            |
+| Pol   | Polish       | +     | +   | +    | +   | +    | -     | -    | -  | +      | +    | IN,*AS            |
+| Por   | Portuguese   | ++    | +   | +    | +   | +    | +     | +    | +  | +      | +    | *BC               |
+| Ron   | Romanian     | ++    | +   | +    | +   | +    | -     | -    | -  | +      | +    | *RE               |
+| Rus   | Russian      | ++    | +   | +    | +   | -    | -     | +    | -  | -      | +    | JK,NF,*RS         |
+| Slk   | Slovak       | +     | +   | +    | +   | -    | -     | -    | -  | +      | -    | *AR,*MM,SČ        |
+| Slv   | Slovene      | ++    | +   | +    | +   | -    | -     | -    | +  | +      | -    | *KA,AE            |
+| Snd   | Sindhi       | ++    | +   | +    | +   | +    | -     | -    | -  | -      | +    | *SV,*JD           |
+| Som   | Somali       | +     | -   | -    | -   | -    | -     | -    | -  | -      | -    | *IL               |
+| Spa   | Spanish      | ++    | +   | +    | +   | +    | +     | -    | +  | ++     | -    | *AR,IA,TS,*IL     |
+| Swa   | Swahili      | +     | +   | -    | -   | -    | -     | -    | -  | -      | +    | *WN,JM,BK         |
+| Swe   | Swedish      | ++    | +   | +    | +   | +    | +     | +    | +  | ++     | +    | *MA,*AR,MF        |
+| Tha   | Thai         | ++    | +   | +    | +   | +    | -     | -    | +  | +      | -    | *AR,CK            |
+| Tur   | Turkish      | ++    | +   | -    | -   | -    | -     | +    | +  | -      | -    | *SC,KA            |
+| Urd   | Urdu         | ++    | +   | +    | +   | +    | -     | -    | -  | +      | +    | *SV,MH            |
 
 ISO = 3-letter ISO language code, used in library file names
 (mostly ISO 639-2 B (bibliographic))
-
-Git = available in the gf-rgl Git repository
 
 Parad = ``Paradigms`` file complete for major POS, ++ means with smart paradigms
 
@@ -73,13 +76,13 @@ Lang = the resource ``Syntax`` (nearly) complete
 
 API = the ``Syntax`` compiles
 
-Symb = the ``Symbolic`` API compiles
+Symb = the ``Symbolic`` API complete
 
 Irreg = the ``Irreg`` module with irregular verbs exists
 
 Dict = the ``Dict`` module, large-scale morphological lexicon, exists
 
-Trans = large-scale translation module and dictionary exists
+WN = WordNet lexicon exists
 
 tested = tested in some applications, ++ means extensively tested with no major issues
 
@@ -93,10 +96,12 @@ authors = main contributors, * means still active
 
 AB Ansu Berg,
 AD Ali El Dada,
+AE Anna Ehrlemark,
 AR Aarne Ranta,
 AS Adam Slaski,
 BB Björn Bringert,
 BC Bruno Cuconato,
+BK Benson Kituku,
 BT Bjarki Traustason,
 CK Chotiros Kairoje,
 CP Chen Peng,
@@ -116,6 +121,7 @@ IP Ioanna Papadopoulou,
 JB Jean-Philippe Bernardy,
 JC John J. Camilleri,
 JD Jherna Devi,
+JJ Julia Jansson,
 JK Janna Khegai,
 JM Juliet Mutahi,
 JS Jordi Saludes,
@@ -129,13 +135,16 @@ MA Malin Ahlberg,
 MF Markus Forsberg,
 MK Markos Kassa Gobena,
 MH Muhammad Humayoun,
+MM Michal Měchura,
 NE Nyamsuren Erdenebadrakh,
 NF Nick Frolov,
 NG Normunds Gruzitis,
 QH Qiao Haiyan,
 RE Ramona Enache,
+RS Roman Suzi,
 PP Peteris Paikens,
 SC Server Cimen,
+SČ Slavomír Čéplö,
 SM Sofy Moradi,
 SRE Stian Rødven Eide,
 SV Shafqat Virk,
@@ -147,7 +156,7 @@ ZL Zhuo Lin Qiqige
 
 ==Rules==
 
-Only components available at http://grammaticalframework.org are indicated in the table.
+Only components available at https://github.com/GrammaticalFramework/gf-rgl/ are indicated in the table.
 
 If you want to work on a language already in the table, please be kind and contact the
 active authors of it.


### PR DESCRIPTION
I updated the HTML versions manually, since it looks like they aren't generated from the txt files. Correct me if I'm wrong. 

* http://www.grammaticalframework.org/lib/doc/status.html
* http://www.grammaticalframework.org/lib/doc/rgl-publications.html

In the status document, I removed the field "in Git", because apart from Tswana, all languages were in Git. I also changed the column about (now deprecated) wide-coverage translation to indicate the WordNet status.