### PR TITLE
Add workflow for building entire RGL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
 
     - name: Build RGL
       run: |
+        mkdir -p ${DEST}
         bash Setup.sh --dest=${DEST} --gf=gf --verbose
 
     - name: Create archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         GF_VERSION: 3.10-1
       run: |
         curl -s https://www.grammaticalframework.org/download/gf_${GF_VERSION}_amd64.deb -o gf.deb
-        dpkg -i gf.deb
+        sudo dpkg -i gf.deb
 
     - name: Build RGL
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,9 @@ jobs:
         mkdir -p ${DEST}
         bash Setup.sh --dest=${DEST} --gf=gf --verbose
 
-    - name: Create archive
-      run: |
-        tar --create --gzip --verbose --file dist.tar.gz ${DEST}
-
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        path: dist.tar.gz
+        name: gf-rgl-${{ env.GITHUB_SHA }}
+        path: ${{ env.DEST }}
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: gf-rgl-${{ env.GITHUB_SHA }}
+        name: gf-rgl-${{ github.sha }}
         path: ${{ env.DEST }}
         if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install GF
+      env:
+        GF_VERSION: 3.10-1
+      run: |
+        curl -s https://www.grammaticalframework.org/download/gf_${GF_VERSION}_amd64.deb -o gf.deb
+        dpkg -i gf.deb
+
+    - name: Build RGL
+      run: |
+        bash Setup.sh --dest=dist/ --gf= --verbose
+
+    # - uses: actions/upload-artifact@v2
+    #   with:
+    #     path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,24 +5,25 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-18.04
+    env:
+      GF_VERSION: 3.10-1
+      DEST: out/
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install GF
-      env:
-        GF_VERSION: 3.10-1
       run: |
         curl -s https://www.grammaticalframework.org/download/gf_${GF_VERSION}_amd64.deb -o gf.deb
         sudo dpkg -i gf.deb
 
     - name: Build RGL
       run: |
-        bash Setup.sh --dest=dist/ --gf=gf --verbose
+        bash Setup.sh --dest=${DEST} --gf=gf --verbose
 
     - name: Create archive
       run: |
-        tar --create --gzip --verbose --file dist.tar.gz dist/
+        tar --create --gzip --verbose --file dist.tar.gz ${DEST}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,13 @@ jobs:
 
     - name: Build RGL
       run: |
-        bash Setup.sh --dest=dist/ --gf= --verbose
+        bash Setup.sh --dest=dist/ --gf=gf --verbose
 
-    # - uses: actions/upload-artifact@v2
-    #   with:
-    #     path: dist
+    - name: Create archive
+      run: |
+        tar --create --gzip --verbose --file dist.tar.gz dist/
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist.tar.gz

--- a/Setup.sh
+++ b/Setup.sh
@@ -97,4 +97,4 @@ done
 
 # Copy
 echo "Copying to ${dest}"
-cp -R -p "${dist}"/* "${dest}"
+cp -R "${dist}"/* "${dest}"


### PR DESCRIPTION
Uses the Bash build script `Setup.sh` to avoid installing Haskell in the worker.
Eventually we should have regular RGL releases with these gfo packages attached for easy downloading.