### PR TITLE
Update MorphoAra

### DIFF
--- a/src/arabic/MorphoAra.gf
+++ b/src/arabic/MorphoAra.gf
@@ -1013,7 +1013,7 @@ oper
       utAbic  = "ُ" + tAbic ;
       utAbac = mkStrong ufAcal tbc ;
       mutAbac = "م" + utAbac ;
-      mutAbacAt = mutAbac + "َاَة"
+      mutAbacAt = mutAbac + "َة"
     } in verb tAbac twbic utAbic utAbac tAbic mutAbac mutAbacAt ;
 
   ----------

--- a/unittest/README.md
+++ b/unittest/README.md
@@ -9,6 +9,8 @@ python path/to/unittest.py [-h] [-v] [--no-pmcfg] path/to/testfile.gftest (...)
 The script must be located in a sibling directory
 to the RGL `src` directory to work properly.
 
+**Note:** On Windows use WSL (Windows Subsystem for Linux) to run `unittest.py` script, also replace the commented lines for Windows inside the script.
+
 ## Test format
 
 The test file should look something like this:

--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -16,6 +16,9 @@ import argparse
 from subprocess import Popen, PIPE
 from glob import glob
 
+GF_PROCESS = 'gf -run'
+## For WSL on windows replace the GF_PROCESS with following line
+##GF_PROCESS = 'gf.exe -run'
 GRAMMARDIR = '../src'
 ENCODING = 'utf-8'
 
@@ -161,7 +164,7 @@ def runtest(testlines, args):
         print()
 
     # calling GF from a subprocess:
-    command = 'gf -run'.split()
+    command = GF_PROCESS.split()
     gfinput = '\n'.join(gfscript) + '\n'
     gf = Popen(command, stdin=PIPE, stdout=PIPE)
     stdout, _stderr = gf.communicate(gfinput.encode(ENCODING))
@@ -182,7 +185,7 @@ def runtest(testlines, args):
             linenr, lang = alltrees.pop(0).split()
             if args.verbose:
                 print('---+ line %s (%s), result from GF:' % (linenr, lang))
-                for tree in alltrees: 
+                for tree in alltrees:
                     print('   |', tree)
             if len(alltrees) == 0 or gferror("\n".join(alltrees)):
                 theerror = "\n".join(alltrees) if alltrees else "No parse trees found"
@@ -195,7 +198,7 @@ def runtest(testlines, args):
                 if besterrors > 0:
                     for oldlinenr, oldlang, oldtrees in oldresults:
                         if besttree not in oldtrees:
-                            error(linenr, 
+                            error(linenr,
                                     "The result of line %s (%s):\n    %s\n"
                                     "is not among the results of line %s (%s):\n    %s"
                                     % (linenr, lang, besttree, oldlinenr, oldlang, "\n    ".join(oldtrees)))


### PR DESCRIPTION
unit test for regular verbs form III `v3`:
```
-- مُسَافَرَاَة
AllAraAbs: GerundNP (UseV travel_V)
AllAra: مُسَافَرَة
```
running unittest.py reslut:
```
# Testing file: unittest-example.gftest

Test 1 (line 2..): 2 examples
[Error at line 3] The result of line 3 (AllAra):
    مُسَافَرَة
is not among the results of line 2 (AllAraAbs):
    مُسَافَرَاَة

Found 1 error in 1 test!
```