### PR TITLE
(Eng) Fewer fields in VP

### DIFF
--- a/src/english/ExtendEng.gf
+++ b/src/english/ExtendEng.gf
@@ -185,7 +185,7 @@ concrete ExtendEng of Extend =
     mkVPS : Temp -> Pol -> VP -> VPS = \t,p,vp -> lin VPS {
       s = \\o,a =>
         let
-          verb = vp.s ! t.t ! t.a ! p.p ! o ! a ; -- choice of Order determines aux or not
+          verb = mkVerbForms a vp ! t.t ! t.a ! p.p ! o ! a ; -- choice of Order determines aux or not
           compl = vp.s2 ! a ++ vp.ext
         in {fin = verb.aux ++ t.s ++ p.s ;
             inf = verb.adv ++ vp.ad ! a ++ verb.fin ++ verb.inf ++ vp.p ++ compl} ;
@@ -288,16 +288,12 @@ lin BaseImp = twoTable2 CPolarity ImpForm ;
     let
       be = predAux auxBe ;
       ppt = vps.ptp
-    in {
-    s = be.s ;
-    p = [] ;
-    prp = be.prp ;
-    ptp = be.ptp ;
-    inf = be.inf ;
-    ad = \\_ => [] ;
-    s2 = \\a => vps.ad ! a ++ ppt ++ vps.p  ++ vps.s2 ! a ++ ag ++ vps.c2 ; ---- place of agent
-    isSimple = False ;
-    ext = vps.ext
+    in be ** {
+        p = [] ;
+        ad = \\_ => [] ;
+        s2 = \\a => vps.ad ! a ++ ppt ++ vps.p  ++ vps.s2 ! a ++ ag ++ vps.c2 ; ---- place of agent
+        isSimple = False ;
+        ext = vps.ext
     } ;
 
   lin

--- a/src/english/ExtraEng.gf
+++ b/src/english/ExtraEng.gf
@@ -75,7 +75,7 @@ concrete ExtraEng of ExtraEngAbs = CatEng **
     MkVPS t p vp = {
       s = \\a =>
             let
-              verb = vp.s ! t.t ! t.a ! p.p ! oDir ! a ;
+              verb = mkVerbForms a vp ! t.t ! t.a ! p.p ! oDir ! a ;
               verbf = verb.aux ++ verb.adv ++ verb.fin ++ verb.inf ;
             in t.s ++ p.s ++ vp.ad ! a ++ verbf ++ vp.p ++ vp.s2 ! a ++ vp.ext
       } ;
@@ -180,17 +180,13 @@ lin
     let
       be = predAux auxBe ;
       ppt = vps.ptp
-    in {
-    s = be.s ;
-    p = [] ;
-    prp = be.prp ;
-    ptp = be.ptp ;
-    inf = be.inf ;
-    ad = \\_ => [] ;
-    s2 = \\a => vps.ad ! a ++ ppt ++ vps.p ++ vps.s2 ! a ++ ag ++ vps.c2 ; ---- place of agent
-    isSimple = False ;
-    ext = vps.ext
-    } ;
+    in be ** {
+          p = [] ;
+          ad = \\_ => [] ;
+          s2 = \\a => vps.ad ! a ++ ppt ++ vps.p ++ vps.s2 ! a ++ ag ++ vps.c2 ; ---- place of agent
+          isSimple = False ;
+          ext = vps.ext
+        } ;
 
   lin
     PassVPSlash vps = passVPSlash vps [] ;
@@ -242,7 +238,7 @@ lin
         let
           subj  = np.s ! npNom ;
           agr   = np.a ;
-          verb  = vp.s ! t ! a ! b ! o ! agr ;
+          verb  = mkVerbForms agr vp ! t ! a ! b ! o ! agr ;
           compl = vp.s2 ! agr
         in
         case o of {
@@ -256,7 +252,7 @@ lin
         let
           subj  = np.s ! npNom ;
           agr   = np.a ;
-          verb  = vp.s ! t ! a ! b ! o ! agr ;
+          verb  = mkVerbForms agr vp ! t ! a ! b ! o ! agr ;
           compl = vp.s2 ! agr
         in
         case o of {

--- a/src/english/IdiomEng.gf
+++ b/src/english/IdiomEng.gf
@@ -44,4 +44,3 @@ concrete IdiomEng of Idiom = CatEng ** open Prelude, ResEng in {
       } ;
 
 }
-

--- a/src/english/ResEng.gf
+++ b/src/english/ResEng.gf
@@ -159,12 +159,12 @@ param
                     s = table {
                           AAdj Posit c => adjCompar.s ! AAdj Posit c ;
                           AAdv         => adjCompar.s ! AAdv ;
-                          _            => nonExist } ; -- IL 06/2021. Replace with an actual string, if this causes problems.
+                          _            => nonExist } ; -- IL 2021-06. Replace with an actual string, if this causes problems.
                     isMost = True } ;
             _ => adjCompar
           } ;
 
-    -- IL 06/2021: remove "more" and "most" from A & A2's inflection table
+    -- IL 2021-06: remove "more" and "most" from A & A2's inflection table
     getCompar : Case -> Adjective -> Str = \c,a -> case a.isMost of {
       True => "more" ++ a.s ! AAdj Posit c ;
       False => a.s ! AAdj Compar c
@@ -395,7 +395,7 @@ param
       False => {aux = x ; adv = "not" ; fin = [] ; inf = z}
       } ;
 
-{- IL 24/04/2018 To fix scope of reflexives:
+{- IL 2018-04 To fix scope of reflexives:
   a) ComplSlash ( … ReflVP … ) X:    reflexive should agree with X
     LangEng> l PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a like_V2))) (UsePron he_Pron))
     I beg him to like /himself/
@@ -421,42 +421,22 @@ param
     insertExtra obj vp ** {c2 = vp.c2 ; gapInMiddle = vp.gapInMiddle ; missingAdv = vp.missingAdv } ;
 
 --- AR 7/3/2013 move the particle after the object
-  insertObjPartLast : (Agr => Str) -> VP -> VP = \obj,vp -> {
-    s = vp.s ;
+  insertObjPartLast : (Agr => Str) -> VP -> VP = \obj,vp -> vp ** {
     p = [] ;  -- remove particle from here
-    prp = vp.prp ;
-    ptp = vp.ptp ;
-    inf = vp.inf ;
-    ad = vp.ad ;
     s2 = \\a => obj ! a ++ vp.s2 ! a ++ vp.p ; -- and put it here ; corresponds to insertObjPre
     isSimple = False ;
-    ext = vp.ext
     } ;
 
 --- The adverb should be before the finite verb.
 
   insertAdV : Str -> VP -> VP = \ad -> insertAdVAgr (\\_ => ad) ;
 
-  insertAdVAgr : (Agr => Str) -> VP -> VP = \ad,vp -> {
-    s = vp.s ;
-    p = vp.p ;
-    prp = vp.prp ;
-    ptp = vp.ptp ;
-    inf = vp.inf ;
+  insertAdVAgr : (Agr => Str) -> VP -> VP = \ad,vp -> vp ** {
     ad  = \\a => vp.ad ! a ++ ad ! a ;
-    s2 = \\a => vp.s2 ! a  ;
     isSimple = False ;
-    ext = vp.ext
     } ;
 
-  insertExtra : Str -> VP -> VP = \e,vp -> {
-    s = vp.s ;
-    p = vp.p ;
-    prp = vp.prp ;
-    ptp = vp.ptp ;
-    inf = vp.inf ;
-    ad  = vp.ad ;
-    s2 =  vp.s2  ;
+  insertExtra : Str -> VP -> VP = \e,vp -> vp ** {
     isSimple = False ;
     ext = vp.ext ++ e  --- there should be at most one, one might think; but: I would say that it will be raining if I saw clouds
     } ;
@@ -523,7 +503,7 @@ param
   haveContr   = agrVerb (cBind "s")     (cBind "ve") ;
   haventContr = agrVerb (cBind "s not")  (cBind "ve not") ;
 
-  Aux = {
+  Aux : Type = {
     pres  : Polarity => Agr => Str ;
     contr : Polarity => Agr => Str ;  -- contracted forms
     past  : Polarity => Agr => Str ;  --# notpresent


### PR DESCRIPTION
This PR changes the lincat of VP in the English resource grammar. 
I have tested the grammar in development with gftest to confirm that the linearisations haven't changed.

## The changes
It reduces the fields in VP by two orders of magnitude, and makes the grammar better suited for morphological analysis. All verbs except auxiliaries only need 4 forms inside VP, and all other forms can be built in PredVP. The same for auxiliaries, but just more forms inside VP.
So I put two fields inside a VP, `auxForms : Aux` and `nonAuxForms : Str*4`, and add a parameter `isAux` that tells which field to use when building a Cl.

Why both fields?
* If we treat auxiliaries as normal verbs, we get "you don't be __" for "you aren't __", and that's obviously wrong.
* If we didn't care about morphological lexicon, we could just fill the Aux fields for all verbs: morphologically distinct forms like "can't" for auxiliaries, and periphrastic constructions like "doesn't sing/eat/play" for other verbs. This would still reduce the number of fields inside VP, but not gain anything for improving morphological analysis.

So we use two sets of fields and a parameter for which strategy to choose in PredVP. This results in significantly fewer fields than previously, and is better for morphological analysis. For example:

```haskell
--Old grammar: "does" appears in 46 functions
Lang> ma "does" | ? sort -u | wc -l
      46

--New grammar: "does" appears in 7 functions
Lang> ma "does"
do_V2 : s VPres
SlashVS : s Pres Simul CPos OQuest
SlashVP : s Pres Simul CPos OQuest
PredVP : s Pres Simul CPos OQuest
PredSCVP : s Pres Simul CPos OQuest
ImpersCl : s Pres Simul CPos OQuest
GenericCl : s Pres Simul CPos OQuest
```

But there is still a lot of room for improvement, as seen with *have*:

```haskell
-- Old grammar
Lang> ma "have" | ? sort -u | wc -l
    2672  

-- New grammar
Lang> ma "have" | ? sort -u | wc -l
     248 
```

## Future improvements

Probably not worth the effort, but listing them here for completeness' sake.

### Reduce fields further
If we cared more about the number of fields, it's easy to streamline the `auxForms`—even the worst case of Aux only has 9 distinct forms (*am, are, aren't, is, isn't, was, wasn't, were, weren't*). Also there are many places we really don't need the full Agr—only two forms are enough, *sing/sings*.

If I work on this more, I could also fix potentially #368. But that is a minor error, fixable by postprocessing in any application.
Also we don't really need to care about the number of fields that much, English is not among the slower languages. 

### Postpone inflection table further

We reduced the number of hits for `ma`, but an ideal morphological analyser would get one hit per word, not 7 or 248. I could work on this further, eliminating the inflection table from Cl and RCl, and only introducing the concrete strings like "didn't" or "have" at the S level, like I do in the Basque RG.

The downsides of this approach are:
* So much of the current implementation builds on determining word order in Cl, would need major restructuring of all Cl-producing funs
* The amount of words that get many hits from `ma` is limited—only the handful of auxiliaries, so an application that relies on `ma` can probably deal with them separately.