### PR TITLE
(Ger) reimplementation of infinitives to improve compilation

### DIFF
--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -50,11 +50,13 @@ concrete CatGer of Cat =
 
 -- Noun
 
-    CN = {s : Adjf => Number => Case => Str ;
-		  rc : Number => Str ; -- Frage , [rc die ich gestellt habe]
-		  ext : Str ; -- Frage , [sc wo sie schläft])
-		  adv : Str ; -- Frage [a von Max]
-		  g : Gender} ;
+    CN = {
+      s : Adjf => Number => Case => Str ;
+      rc : Number => Str ; -- Frage , [rc die ich gestellt habe]
+      ext : Str ;          -- Frage , [sc wo sie schläft]
+      adv : Str ;          -- Haus    [adv auf dem Hügel]
+      g : Gender
+      } ;
     NP = ResGer.NP ; 
     Pron = {s : NPForm => Str ; a : Agr} ;
     Det, DAP = {s,sp : Gender => PCase => Str ; n : Number ; a : Adjf ; isDef : Bool} ;
@@ -86,10 +88,10 @@ concrete CatGer of Cat =
 
 -- Open lexical classes, e.g. Lexicon
 
-    V, VS, VQ = ResGer.Verb ; -- = {s : VForm => Str} ;
+    V, VA, VS, VQ = ResGer.Verb ; -- = {s : VForm => Str} ;
     VV = Verb ** {isAux : Bool} ;
-    V2, VA, V2A, V2S, V2Q = Verb ** {c2 : Preposition} ;
-    V2V = Verb ** {c2 : Preposition ; isAux : Bool ; ctrl : Control} ;
+    V2, V2A, V2S, V2Q = Verb ** {c2 : Preposition} ;
+    V2V = Verb ** {c2 : Preposition ; isAux : Bool ; objCtrl : Bool} ;
     V3 = Verb ** {c2, c3 : Preposition} ;
 
     A  = {s : Degree => AForm => Str} ;
@@ -113,7 +115,7 @@ concrete CatGer of Cat =
     ClSlash = \cls -> cls.s ! MIndic ! Pres ! Simul ! Pos ! Main ++ cls.c2.s ;
 
     VP = \vp -> useInfVP False vp ;
-    VPSlash = \vps -> useInfVP False vps ++ vps.c2.s ;
+    VPSlash = \vps -> useInfVP False vps ++ vps.c2.s ++ vps.ext;
 
 	AP = \ap -> ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ++ ap.ext ;
         A2 = \a2 -> a2.s ! Posit ! APred ++ a2.c2.s ;

--- a/src/german/ConstructionGer.gf
+++ b/src/german/ConstructionGer.gf
@@ -42,13 +42,13 @@ lin
   where_go_QCl np = mkQCl (lin IAdv (ss "wohin")) (mkCl np (mkVP L.go_V)) ;
   where_come_from_QCl np =  mkQCl (lin IAdv (ss "woher")) (mkCl np (mkVP L.come_V)) ;
   
-  go_here_VP = mkVP (mkVP L.go_V) (mkAdv "her") ;
-  come_here_VP = mkVP (mkVP L.come_V) (mkAdv "her") ;
-  come_from_here_VP = mkVP (mkVP L.come_V) (mkAdv "von hier") ;
+  go_here_VP = mkVP (mkVP L.go_V) (ParadigmsGer.mkAdv "her") ;
+  come_here_VP = mkVP (mkVP L.come_V) (ParadigmsGer.mkAdv "her") ;
+  come_from_here_VP = mkVP (mkVP L.come_V) (ParadigmsGer.mkAdv "von hier") ;
 
-  go_there_VP = mkVP (mkVP L.go_V) (mkAdv "hin") ;
-  come_there_VP = mkVP (mkVP L.come_V) (mkAdv "hin") ;
-  come_from_there_VP = mkVP (mkVP L.come_V) (mkAdv "von dort") ;
+  go_there_VP = mkVP (mkVP L.go_V) (ParadigmsGer.mkAdv "hin") ;
+  come_there_VP = mkVP (mkVP L.come_V) (ParadigmsGer.mkAdv "hin") ;
+  come_from_there_VP = mkVP (mkVP L.come_V) (ParadigmsGer.mkAdv "von dort") ;
 
 lincat
   Weekday = N ;

--- a/src/german/DocumentationGerFunctor.gf
+++ b/src/german/DocumentationGerFunctor.gf
@@ -147,8 +147,8 @@ lin
 
 lin
   NoDefinition   t     = {s=t.s};
-  MkDefinition   t d   = {s="<p><b>Definierung:</b>"++t.s++d.s++"</p>"};
-  MkDefinitionEx t d e = {s="<p><b>Definierung:</b>"++t.s++d.s++"</p><p><b>Beispiel:</b>"++e.s++"</p>"};
+  MkDefinition   t d   = {s="<p><b>Definition:</b>"++t.s++d.s++"</p>"};
+  MkDefinitionEx t d e = {s="<p><b>Definition:</b>"++t.s++d.s++"</p><p><b>Beispiel:</b>"++e.s++"</p>"};
 
   MkDocument d i e = ss (i.s1 ++ d.s ++ i.s2 ++ paragraph e.s) ;  -- explanation appended in a new paragraph
   MkTag i = ss i.t ;

--- a/src/german/ExtendGer.gf
+++ b/src/german/ExtendGer.gf
@@ -35,9 +35,8 @@ lin
     ConjVPI = conjunctDistrTable Bool ;
 
     ComplVPIVV v vpi = 
---        insertInf (vpi.s ! v.isAux) (
-      insertInf {s=(vpi.s ! v.isAux);isAux=v.isAux;ctrl=SubjC} ( -- HL ??
-            predVGen v.isAux v) ; ----
+      insertInf {inpl = <\\_ => [], (vpi.s ! v.isAux)> ; extr = \\_ => []}  -- HL 3/22
+        (predVGen v.isAux v) ;
 
     BaseVPS = twoTable2 Order Agr ;
     ConsVPS = consrTable2 Order Agr comma ;
@@ -70,37 +69,45 @@ lin
           m = tm.m ;
           subj  = [] ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
+          haben = verb.inf2 ;
           neg   = tm.s ++ p.s ++ vp.a1 ++ negation ! b ; -- HL 8/19 ++ vp.a1 ! b ;
           -- obj1  = (vp.nn ! agr).p1 ;
           -- obj   = (vp.nn ! agr).p2 ; 
           -- compl = obj1 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
-          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ nonpronouns
-          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
+          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ light nps
+          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects and heavy nps
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          inf   = vp.inf.s ++ verb.inf ++ verb.inf2 ;
-          extra = vp.ext ;
-          infE : Str =                              -- HL 30/6/2019
-            case <t,a,vp.isAux> of {
-              <Fut|Cond,Simul,True> => inf ;                           --# notpresent
-              <Fut|Cond,Anter,True> -- Duden 318: kommen wollen haben => haben kommen wollen --# notpresent
-                => verb.inf2 ++ vp.inf.s ++ verb.inf ;                   --# notpresent
-              <_,Anter,True> => inf ;                                  --# notpresent
-              _ => verb.inf ++ verb.inf2 ++ vp.inf.s } ;
-          inffin : Str =
-            case <t,a,vp.isAux> of {
-	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => verb.fin ++ verb.inf2 ++ vp.inf.s ++ verb.inf ;  --# notpresent
-	           <_,Anter,True>                                      --# notpresent
-                     => verb.fin ++ inf ;            -- double inf     --# notpresent
-                   _ => inf ++ verb.fin              --- or just auxiliary vp
-            } ;
+          infObjs = (vp.inf.inpl.p1)!agr ;               -- adapted to new VP.inf, HL 3/2022
+          infPred = vp.inf.inpl.p2 ;
+          infCompl : Str = case <t,a,vp.isAux> of {
+                 <Fut|Cond,Anter,True> => [] ; _ => infObjs ++ infPred } ;
+          pred : {inf, infComplfin : Str} = case <t,a,vp.isAux> of {
+             <Fut|Cond,Anter,True>  =>                                    --# notpresent
+               {inf    = infObjs ++ haben ++ infPred ++ verb.inf ;        --# notpresent Duden 318
+                infComplfin = -- es ++ wird ++ haben ++ tun ++ wollen     --# notpresent
+                   infObjs ++ verb.fin ++ haben ++ infPred ++ verb.inf} ; --# notpresent
+             <_,Anter,True> =>                                            --# notpresent
+               {inf    = verb.inf ++ haben ;                              --# notpresent
+                infComplfin = -- es ++ wird/hat/hatte ++ tun ++ wollen    --# notpresent
+                   infObjs ++ verb.fin ++ infPred ++ verb.inf ++ haben} ; --# notpresent
+              <Pres,_,_> =>
+               {inf    = verb.inf ++ haben ;
+                infComplfin = -- es zu tun ++ [] ++ [] ++ versucht
+                   infCompl ++ verb.inf ++ haben ++ verb.fin}
+                                                                         ; --# notpresent
+              _ =>                                                         --# notpresent
+               {inf    = verb.inf ++ haben ;                               --# notpresent
+                infComplfin = -- es zu tun ++ versucht ++ [] ++ hat        --# notpresent
+                              infCompl ++ verb.inf ++ haben ++ verb.fin}   --# notpresent
+              } ;
+           extra = vp.inf.extr!agr ++ vp.ext ;
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ infE ++ extra ;
-	    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ infE ++ extra ;
-	    Sub  => subj ++ compl ++ vp.infExt ++ inffin ++ extra
-          }
+	  Main => subj ++ verb.fin ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Inv  => verb.fin ++ subj ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Subj =>             subj ++ compl ++   pred.infComplfin   ++ extra
+        }
     } ;
 
     ConjVPS = conjunctDistrTable2 Order Agr ;

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -12,16 +12,9 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     MkVPI vp = {s = \\b => useInfVP b vp} ;
     ConjVPI = conjunctDistrTable Bool ;
 
-    ComplVPIVV v vpi = 
---        insertInf (vpi.s ! v.isAux) (
-      insertInf {s=(vpi.s ! v.isAux);isAux=v.isAux;ctrl=SubjC} ( -- HL ??
-            predVGen v.isAux v) ; ----
-{-
-      insertExtrapos vpi.p3 (
-        insertInf vpi.p2 (
-          insertObj vpi.p1 (
-            predVGen v.isAux v))) ;
--}
+    ComplVPIVV v vpi =
+      insertInf {inpl = <\\_ => [], (vpi.s ! v.isAux)> ; extr = \\_ => []}  -- HL 3/22
+        (predVGen v.isAux v) ;
 
     PPzuAdv cn = {s = case cn.g of {
       Masc | Neutr => "zum" ;
@@ -33,8 +26,8 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
     moegen_VV = auxVV mögen_V ;
 
-    ICompAP ap = {s = \\_ => "wie" ++ ap.s ! APred ; 
-				  ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext} ; 
+    ICompAP ap = {s = \\_ => "wie" ++ ap.s ! APred ;
+                  ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext} ;
 
     CompIQuant iq = {s = table {Ag g n p => iq.s ! n ! g ! Nom} ; ext = ""} ;
 
@@ -43,8 +36,6 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     DetNPMasc det = {
       s = \\c => det.sp ! Masc ! c ; ---- genders
       a = agrP3 det.n ;
-      -- isPron = False ;
-      -- isLight = True ; 
       w = WLight ;
       ext, rc = []
       } ;
@@ -52,8 +43,6 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     DetNPFem det = {
       s = \\c => det.sp ! Fem ! c ; ---- genders
       a = agrP3 det.n ;
-      -- isPron = False ;
-      -- isLight = True ; 
       w = WLight ;
       ext, rc = []
       } ;
@@ -66,37 +55,40 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       } ;
 
     PassVPSlash vp = 
-		let c = case <vp.c2.c,vp.c2.isPrep> of {
-               <NPC Acc,False> => NPC Nom ;
-               _ => vp.c2.c}
-			in insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
-				{subjc = vp.c2 ** {c= c}} ;
-		-- regulates passivised object: accusative objects -> nom; all others: same case
-		-- this also gives "mit dir wird gerechnet" ;
-		-- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
+      let c = case <vp.c2.c,vp.c2.isPrep> of {
+            <NPC Acc,False> => NPC Nom ;
+            _ => vp.c2.c}
+      in insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
+          { c1 = vp.c2 ** {c = c}} ;
+    -- regulates passivised object: accusative objects -> nom; all others: same case
+    -- this also gives "mit dir wird gerechnet" ;
+    -- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
 
     PassAgentVPSlash vp np = ---- "von" here, "durch" in StructuralGer
       insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
 
     Pass3V3 v = -- HL 7/19
       let bekommenPass : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") 
-      in insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommenPass) ** { subjc = PrepNom ; c2 = v.c2 } ;      
+      in insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommenPass) **
+           { c1 = PrepNom ; c2 = v.c2 ; objCtrl = False } ;
 
-    PastPartAP vp = {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ vp.inf.s ++ 
-                  vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
-      isPre = True ;
-      c = <[],[]> ;
-      ext = [] 
+    PastPartAP vp =
+      let a = agrP3 Sg in {
+        s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3 ++ vp.a2
+                    ++ vp.inf.inpl.p2 ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+        isPre = True ;
+        c = <[],[]> ;
+        ext = vp.ext
       } ;
 
-    PastPartAgentAP vp np = 
-    let agent = appPrepNP P.von_Prep np
-    in {
-      s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ (vp.nn ! agrP3 Sg).p3 ++ vp.a2 ++ agent ++ 
-                   vp.inf.s ++ 
-                   vp.c2.s ++ --- junk if not TV
-                   vp.ext ++ vp.infExt ++ vp.s.s ! VPastPart af ;
+    PastPartAgentAP vp np =
+      let a = agrP3 Sg ;
+          agent = appPrepNP P.von_Prep np
+      in {
+      s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3
+                  ++ vp.a2 ++ agent ++ vp.inf.inpl.p2
+                  ++ vp.c2.s                         -- junk if not TV
+                  ++ vp.ext ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
       ext = [] 
@@ -138,37 +130,45 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           m = tm.m ;
           subj  = [] ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
+          haben = verb.inf2 ;
           neg   = tm.s ++ p.s ++ vp.a1 ++ negation ! b ; -- HL 8/19 ++ vp.a1 ! b ;
           -- obj1  = (vp.nn ! agr).p1 ;
           -- obj   = (vp.nn ! agr).p2 ; 
           -- compl = obj1 ++ neg ++ obj ++ vp.a2 ; -- from EG 15/5
-          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ nonpronouns
-          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects
+          obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ light nps
+          obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects and heavy nps
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          inf   = vp.inf.s ++ verb.inf ++ verb.inf2 ;
-          extra = vp.ext ;
-          infE : Str =                              -- HL 30/6/2019
-            case <t,a,vp.isAux> of {
-              <Fut|Cond,Simul,True> => inf ;                           --# notpresent
-              <Fut|Cond,Anter,True> -- Duden 318: kommen wollen haben => haben kommen wollen --# notpresent
-                => verb.inf2 ++ vp.inf.s ++ verb.inf ;                   --# notpresent
-              <_,Anter,True> => inf ;                                  --# notpresent
-              _ => verb.inf ++ verb.inf2 ++ vp.inf.s } ;
-          inffin : Str =
-            case <t,a,vp.isAux> of {
-	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => verb.fin ++ verb.inf2 ++ vp.inf.s ++ verb.inf ;  --# notpresent
-	           <_,Anter,True>                                      --# notpresent
-                     => verb.fin ++ inf ;            -- double inf     --# notpresent
-                   _ => inf ++ verb.fin              --- or just auxiliary vp
-            } ;
+          infObjs = (vp.inf.inpl.p1)!agr ;               -- adapted to new VP.inf, HL 3/2022
+          infPred = vp.inf.inpl.p2 ;
+          infCompl : Str = case <t,a,vp.isAux> of {
+                 <Fut|Cond,Anter,True> => [] ; _ => infObjs ++ infPred } ;
+          pred : {inf, infComplfin : Str} = case <t,a,vp.isAux> of {
+             <Fut|Cond,Anter,True>  =>                                    --# notpresent
+               {inf    = infObjs ++ haben ++ infPred ++ verb.inf ;        --# notpresent Duden 318
+                infComplfin = -- es ++ wird ++ haben ++ tun ++ wollen     --# notpresent
+                   infObjs ++ verb.fin ++ haben ++ infPred ++ verb.inf} ; --# notpresent
+             <_,Anter,True> =>                                            --# notpresent
+               {inf    = verb.inf ++ haben ;                              --# notpresent
+                infComplfin = -- es ++ wird/hat/hatte ++ tun ++ wollen    --# notpresent
+                   infObjs ++ verb.fin ++ infPred ++ verb.inf ++ haben} ; --# notpresent
+              <Pres,_,_> =>
+               {inf    = verb.inf ++ haben ;
+                infComplfin = -- es zu tun ++ [] ++ [] ++ versucht
+                   infCompl ++ verb.inf ++ haben ++ verb.fin}
+                                                                         ; --# notpresent
+              _ =>                                                         --# notpresent
+               {inf    = verb.inf ++ haben ;                               --# notpresent
+                infComplfin = -- es zu tun ++ versucht ++ [] ++ hat        --# notpresent
+                              infCompl ++ verb.inf ++ haben ++ verb.fin}   --# notpresent
+              } ;
+           extra = vp.inf.extr!agr ++ vp.ext ;
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ infE ++ extra ;
-	    Inv  => verb.fin ++ subj ++ compl ++ vp.infExt ++ infE ++ extra ;
-	    Sub  => subj ++ compl ++ vp.infExt ++ inffin ++ extra
-          }
+	  Main => subj ++ verb.fin ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Inv  => verb.fin ++ subj ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Subj =>             subj ++ compl ++   pred.infComplfin   ++ extra
+        }
     } ;
 
     ConjVPS = conjunctDistrTable2 Order Agr ;
@@ -182,67 +182,78 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
     ReflPoss num cn = {s = \\a,c => num.s ! cn.g ! c ++ possPron a num.n cn.g c ++ cn.s ! adjfCase Strong c ! num.n ! c} ;
 
+    ReflPron = { s = reflPron } ;  -- reflexively used personal pronoun, with special forms in P3 Sg
+
+    -- In P1,P2 we might use "selbst" to define a (stronger) reflexive pronoun instead: -- HL 3/2022
+    --   du kennst mich vs. ich kenne mich selbst
+    --   er kennt ihn   vs. er kennt sich (selbst)
+    --   sie kennen sich (selbst) =/= sie kennen einander
+    -- Likewise, instead of ReflPoss we might define a reflexive possessive pronoun:
+    --   du kennst meine Fehler vs. ich kenne meine eigenen Fehler
+    --   er|sie|es kennt seine Fehler  vs. er|sie|es kennt seine|ihre|seine eigenen Fehler
+  oper
+    reflPronSelf : Agr => Case => Str = \\a => \\c => reflPron ! a ! c ++ "selbst" ;
+
+    reflPossPron : Agr -> Number -> Gender -> Case -> Str =
+      let eigen = adjForms "eigen" "eigen" in
+         \a,n,g,c -> possPron a n g c ++ (eigen ! (AMod (gennum g n) c)) ;
+
 -- implementation of some of the relevant Foc rules from Extra
 
   lincat 
-	Foc = {s : Mood => ResGer.Tense => Anteriority => Polarity => Str} ;
+    Foc = {s : Mood => ResGer.Tense => Anteriority => Polarity => Str} ;
 	
   lin 
     FocObj np cl =
-		let n = appPrepNP cl.c2 np
-		in mkFoc n cl ; 
+      let n = appPrepNP cl.c2 np in mkFoc n cl ;
 
-	FocAdv adv cl = mkFoc adv.s cl ;
+    FocAdv adv cl = mkFoc adv.s cl ;
 
-	FocAP ap np =
-		let adj = ap.s ! APred ;
-		    vp = predV sein_V ** {ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext}; 
-				-- potentially not correct analysis for all examples
-				-- works for:
-				-- "treu ist sie ihm"
-				-- "froh ist sie dass er da ist"
-				-- "stolz ist sie auf ihn"
-		    subj = mkSubj np vp.subjc ;
-			cl = mkClause subj.p1 subj.p2 vp
-		in mkFoc adj cl ;
+    FocAP ap np =
+      let adj = ap.s ! APred ;
+          vp = predV ResGer.sein_V ** {ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext};
+               -- potentially not correct analysis for all examples
+               -- works for:
+               -- "treu ist sie ihm"
+               -- "froh ist sie dass er da ist"
+               -- "stolz ist sie auf ihn"
+          subj = mkSubj np vp.c1 ;
+          cl = mkClause subj.p1 subj.p2 vp
+      in mkFoc adj cl ;
 
-	UseFoc t p f = {s = t.s ++ p.s ++ f.s ! t.m ! t.t ! t.a ! p.p} ;
+    UseFoc t p f = {s = t.s ++ p.s ++ f.s ! t.m ! t.t ! t.a ! p.p} ;
 
 
 -- extra rules to get some of the "es" alternative linearisations
 
   lin
-	EsVV vv vp = predV vv ** {
-		nn = \\a => let n = vp.nn ! a in <"es" ++ n.p1, n.p2, n.p3, n.p4, n.p5, n.p6> ;
-		inf = vp.inf ** {s = vp.s.s ! (VInf True) ++ vp.inf.s} ;  -- ich genieße es zu versuchen zu gehen; alternative word order could be produced by vp.inf ++ vp.s.s... (zu gehen zu versuchen)
-		a1 = vp.a1 ;
-		a2 = vp.a2 ;
-		ext = vp.ext ;
-		infExt = vp.infExt ;
-		adj = vp.adj } ;
-		
-	EsV2A v2a ap s = predV v2a ** {
-		nn = \\_ => <"es",[],[],[],[],[]> ; 
-		adj = ap.s ! APred ; 
-		ext = "," ++ "dass" ++ s.s ! Sub} ;
+    EsVV vv vp =                             -- HL 3/2022
+      let inf = mkInf False Simul Pos vp ;   -- False = force extraction
+          objs : Agr => Str * Str * Str * Str = \\a => <"es",[],[],[]> ;
+          vps = predV vv ** { nn = objs }
+      in insertExtrapos vp.ext (
+           insertInf inf vps) ;
+
+    EsV2A v2a ap s = predV v2a ** {
+      nn = \\_ => <"es",[],[],[]> ;
+      adj = ap.s ! APred ;
+      ext = "," ++ conjThat ++ s.s ! Sub} ;
 
 -- "es wird gelacht"; generating formal sentences
 
   lincat
-	FClause = ResGer.VP ** {subj : ResGer.NP} ;
-
+    FClause = ResGer.VP ** {subj : ResGer.NP} ;
 
   lin
-	VPass v = 
-  		let vp = predV werdenPass ;
-		in vp ** {
-			subj = esSubj ; 
-			inf = vp.inf ** {s = v.s ! VPastPart APred } } ; -- construct the formal clause
+    VPass v =
+      let vp = predV werdenPass
+      in vp ** {subj = esSubj ;
+		inf = vp.inf ** {s = v.s ! VPastPart APred } } ; -- construct the formal clause
 
-	AdvFor adv fcl = fcl ** {a2 = adv.s} ;
+    AdvFor adv fcl = fcl ** {a2 = adv.s} ;
 	
 	FtoCl cl = 
-		let subj = mkSubj cl.subj cl.subjc 
+		let subj = mkSubj cl.subj cl.c1
 		in DisToCl subj.p1 subj.p2 cl ;
 
 
@@ -251,16 +262,14 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     mkFoc : Str -> Cl -> Foc = \focus, cl ->
 		lin Foc {s = \\m,t,a,p => focus ++ cl.s ! m ! t ! a ! p ! Inv} ;
 
-	esSubj : NP = lin NP {
-		s = \\_ => "es" ; 
-		rc, ext = [] ;
-		a = Ag Neutr Sg P3 ;
-                -- isLight = True ; 
-		-- isPron = True
-                w = WPron
-          } ;
+    esSubj : CatGer.NP = lin NP {
+      s = \\_ => "es" ;
+      rc, ext = [] ;
+      a = Ag Neutr Sg P3 ;
+      w = WPron
+    } ;
 
-	DisToCl : Str -> Agr -> FClause -> Clause = \subj,agr,vp ->  
+    DisToCl : Str -> Agr -> FClause -> Clause = \subj,agr,vp ->
 	  let vps = useVP vp in {
       s = \\m,t,a,b,o =>
         let
@@ -273,18 +282,19 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
           obj1  = (vp.nn ! agr).p1 ;
           obj2  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ;
           compl = obj1 ++ neg  ++ vp.adj ++ obj2 ++ vp.a2 ; -- adj added
-          inf   = vp.inf.s ++ verb.inf ; -- not used for linearisation of Main/Inv
+          inf = vp.inf.inpl.p2 ++ verb.inf ;  -- not used for linearisation of Main/Inv
+          infExt = vp.inf.extr ! agr ;
           extra = vp.ext ;
-          inffin : Str = 
+          inffin : Str =
             case <a,vp.isAux> of {                       
 	           <Anter,True> => verb.fin ++ inf ; -- double inf   --# notpresent
-             _            => inf ++ verb.fin              --- or just auxiliary vp
+                   _            => inf ++ verb.fin   --- or just auxiliary vp
             }                                            
         in
         case o of {
-	    Main => subj ++ verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
-	    Inv  => verb.fin ++ compl ++ vp.infExt ++ verb.inf ++ extra ++ vp.inf.s ;
-	    Sub  => compl ++ vp.infExt ++ inffin ++ extra }
+	    Main => subj ++ verb.fin ++ compl ++ infExt ++ verb.inf ++ extra ++ vp.inf.inpl.p2 ;
+	    Inv  => verb.fin ++ compl ++ infExt ++ verb.inf ++ extra ++ vp.inf.inpl.p2 ; -- vp.inf.s ;
+	    Sub  => compl ++ infExt ++ inffin ++ extra }
     		} ; 
 		
 		-- this function is not entirely satisfactory as largely 

--- a/src/german/IdiomGer.gf
+++ b/src/german/IdiomGer.gf
@@ -59,7 +59,7 @@ concrete IdiomGer of Idiom = CatGer **
       } ;
 
     ImpP3 np vp = {
-      s = (mkClause ((mkSubj np vp.subjc).p1) np.a vp).s ! 
+      s = (mkClause ((mkSubj np vp.c1).p1) np.a vp).s !
                            MConjunct ! Pres ! Simul ! Pos ! Inv 
       } ;
 

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -607,17 +607,17 @@ mkV2 : overload {
 
   mkV2V = overload { -- default: object-control
     mkV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = False ; objCtrl = True ; lock_V2V = <>} ;  -- ermahne jmdn, sich zu waschen
     mkV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = False ; ctrl = ObjC ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = False ; objCtrl = True ; lock_V2V = <>} ;
     } ;
   auxV2V = overload {
     auxV2V : V -> V2V 
-      = \v -> dirV2 v ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
+      = \v -> dirV2 v ** {isAux = True ; objCtrl = True ; lock_V2V = <>} ;  -- lasse jmdn sich waschen
     auxV2V : V -> Prep -> V2V 
-      = \v,p -> prepV2 v p ** {isAux = True ; ctrl = ObjC ; lock_V2V = <>} ;
+      = \v,p -> prepV2 v p ** {isAux = True ; objCtrl = True ; lock_V2V = <>} ;
     } ;
-  subjV2V v = v ** {ctrl = SubjC} ;
+  subjV2V v = v ** {objCtrl = False} ;
 
   mkV2A = overload {
     mkV2A : V -> V2A 

--- a/src/german/QuestionGer.gf
+++ b/src/german/QuestionGer.gf
@@ -50,7 +50,7 @@ concrete QuestionGer of Question = CatGer ** open ResGer in {
       s = \\m,t,a,p => 
             let 
               vp  = predV sein_V ** {ext = icomp.ext};
-	      subj = mkSubj np vp.subjc ;
+	      subj = mkSubj np vp.c1 ;
               cls = (mkClause subj.p1 subj.p2 vp).s ! m ! t ! a ! p ;
               why = icomp.s ! np.a
             in table {

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -101,14 +101,14 @@ resource ResGer = ParamX ** open Prelude in {
 
 --2 For $Verb$
 
-  param VForm = 
+  param VForm =
      VInf Bool           -- True = with the particle "zu"
    | VFin Bool VFormFin  -- True = prefix glued to verb
    | VImper    Number    -- prefix never glued
    | VPresPart AForm     -- prefix always glued
    | VPastPart AForm ;
 
-  param VFormFin = 
+  param VFormFin =
      VPresInd  Number Person
    | VPresSubj Number Person
    | VImpfInd  Number Person --# notpresent
@@ -123,10 +123,6 @@ resource ResGer = ParamX ** open Prelude in {
   param VAux = VHaben | VSein ;
 
   param VType = VAct | VRefl Case ;
-
--- Implicit subject of embedded vp equals subject resp. object of matrix verb v:V2V:
-
-  param Control = SubjC | ObjC | NoC ; -- NoC : verb without infinite vp-complement
 
 -- The order of a sentence depends on whether it is used as a main
 -- clause, inverted, or subordinate.
@@ -546,22 +542,23 @@ resource ResGer = ParamX ** open Prelude in {
       } ;
 
    VP : Type = {
-      s  : Verb ;                         -- HL 6/2019: <refl|pron,NP,PP,AP|CN|Adv,ObjInf,EmbedInfs>
-      nn : Agr => Str * Str * Str * Str   --            <sich|ihr,deine Frau,an sie,gut,
-                      * Str * Str ;       -- splitInfExt: (rate) dir, dich zu bemühen mir zu helfen> 
-      a1 : Str ;              -- adv before negation, adV
-      a2 : Str ;              -- heute = adv
-      adj : Str ;             -- adjectival complement ("ich finde dich schön")
-      isAux : Bool ;          -- is a double infinitive
-      inf : {s:Str ; isAux:Bool ; ctrl:Control} ; -- infinitival complement of VV or V2V
-      ext : Str ;             -- dass sie kommt
-      infExt : Str ;	      -- infinitival complements of inf 
-                              -- e.g. ich hoffe [ihr zu helfen] zu versuchen 
-      subjc : Preposition     -- case of subject
+      s  : Verb ;                         -- HL 6/2019: <refl|pron,NP,PP,AP|CN|Adv>
+      nn : Agr => Str * Str * Str * Str ; --            <sich|ihr,deine Frau,an sie,gut>
+      a1 : Str ;              -- was: adV inserted before negation, unused?
+      a2 : Str ;              -- adverb
+      adj : Str ;             -- adjectival complement of V(2)A, e.g. ich finde dich schön
+      isAux : Bool ;          -- is a double infinitive?, e.g. müssen:VV, lassen:V2V
+      ext : Str ;             -- sentential complement of V(2)S, V(2)Q, e.g. dass|ob sie kommt
+      inf : {inpl: (Agr => Str)*Str ; -- infinitival complement of V(2)V       HL 3/2022
+             extr: (Agr => Str)} ;    -- e.g. ihn [] versuchen (lasse) [, ihr zu helfen]
+      c1 : Preposition        -- case of subject
      } ;
 
-  VPSlash = VP ** {c2 : Preposition ; 
-                   objCtrl : Bool } ; -- True = embedded reflexives agree with object 
+  VPSlash = VP ** {c2 : Preposition ; objCtrl : Bool} ;  -- HL 3/2019 objCtr added
+
+  -- objCtrl distinguishes object-control from subject-control verb v:V2V in VP.s:
+  -- if True, reflexives in vp.inf and vp.nn have to agree with c2-object (added
+  -- by ComplSlash), else with subject (added by mkClause).
 
   useVP : VP -> VPC = \vp ->
     let
@@ -604,10 +601,11 @@ resource ResGer = ParamX ** open Prelude in {
         Cond => vf True (wuerde a) vinf [] ;   --# notpresent
         Pres => vf b (vfin b m t a) [] []
         } ;
-      VPFinite m t Anter => case t of {                  --# notpresent
-        Pres | Past => vf True (hat m t a) vpart [] ;    --# notpresent
+      VPFinite m t Anter => case t of {
+        Past => vf True (hat m t a) vpart [] ;           --# notpresent
         Fut  => vf True (wird m a) vpart haben ;         --# notpresent
-        Cond => vf True (wuerde a) vpart haben           --# notpresent 
+        Cond => vf True (wuerde a) vpart haben ;         --# notpresent
+        Pres => vf True (hat m t a) vpart []
         } ;                                              --# notpresent
       VPImperat False => vf False (verb.s ! VImper (numberAgr a)) [] [] ;
       VPImperat True  => vf False (verb.s ! VFin False (VPresSubj Pl P3)) [] [] ;
@@ -616,31 +614,23 @@ resource ResGer = ParamX ** open Prelude in {
       }
     } ;
 
-  predV : Verb -> VPSlash = predVGen False ;
+  predV : Verb -> VP = predVGen False ;
 
   predVc : Verb ** {c2 : Preposition} -> VPSlash = \v -> 
     predV v ** {c2 = v.c2 ; objCtrl = False} ;
 
-  predVGen : Bool -> Verb -> VPSlash = \isAux, verb -> {
-    s = {
-     s = verb.s ;
-     prefix = verb.prefix ;
-     particle = verb.particle ;
-     aux = verb.aux ;
-     vtype = verb.vtype
-     } ;
+  predVGen : Bool -> Verb -> VP = \isAux, verb -> {
+    s = verb ;
     a1,a2  : Str = [] ;
-    nn  : Agr => Str * Str * Str * Str * Str * Str = case verb.vtype of {
-      VAct => \\_ => <[],[],[],[],[],[]> ;
-      VRefl c => \\a => <reflPron ! a ! c,[],[],[],[],[]>
+    nn  : Agr => Str * Str * Str * Str = case verb.vtype of {
+      VAct => \\_ => <[],[],[],[]> ;
+      VRefl c => \\a => <reflPron ! a ! c,[],[],[]>
       } ;
     isAux = isAux ; ----
-    inf = {s=[]; isAux=True; ctrl=NoC} ; -- default infinitive complement 
-    ext,infExt,adj : Str = [] ;          -- (isAux=True => no endcomma)
-    subjc = PrepNom ;
-    -- Dummy values for subtyping.
-    c2 = PrepNom ; 
-    objCtrl = False 
+    -- default infinitival complement:
+    inf = {inpl = <\\_ => [], []>; extr = \\_ => []} ;
+    ext,adj : Str = [] ;
+    c1 = PrepNom
     } ;
 
   auxPerfect : Verb -> VForm => Str = \verb ->
@@ -702,100 +692,109 @@ resource ResGer = ParamX ** open Prelude in {
 
   -- IL 24/04/2018 Fixing the scope of reflexives
   objAgr : { a : Agr } -> VP -> VP = \obj,vp -> vp ** {
-    nn = \\a => vp.nn ! obj.a } ;  
-  -- HL: if reflexive only: <vp.nn.p1 ! np.a, vp.nn.p1 ! a, ..>
+    nn = \\a => vp.nn ! obj.a ;
+    inf = {inpl = <\\a => vp.inf.inpl.p1 ! obj.a, vp.inf.inpl.p2> ;  -- HL 3/2022
+           extr = \\a => vp.inf.extr ! obj.a} } ;                    -- HL 3/2022
 
 -- Extending a verb phrase with new constituents.
 
-  insertObj : (Agr => Str) -> VPSlash -> VPSlash = \obj,vp ->  -- obj:Comp A|Adv|CN
-    vp ** { nn = \\a => let vpnn = vp.nn ! a 
-              in  <vpnn.p1, vpnn.p2, vpnn.p3, obj ! a ++ vpnn.p4, vpnn.p5, vpnn.p6> } ;
+  insertObj : (Agr => Str) -> VP -> VP = \obj,vp ->  -- obj:Comp A|Adv|CN
+    vp ** { nn = \\a => let vpnn = vp.nn ! a in
+                        <vpnn.p1, vpnn.p2, vpnn.p3, obj ! a ++ vpnn.p4> } ;
 
   insertObjc : (Agr => Str) -> VPSlash -> VPSlash = \obj,vp ->
     insertObj obj vp ** {c2 = vp.c2 ; objCtrl = vp.objCtrl } ;
 
   insertObjNP : NP -> Preposition -> VPSlash -> VPSlash = \np,prep,vp ->
     let c = case prep.c of { NPC cc => cc ; _ => Nom } ;
-        obj : Agr => Str = \\_ => appPrepNP prep np ;
+        obj = appPrepNP prep np ;
     in vp ** {
-      nn = \\a =>                  -- HL 11/6/19: rough objNP order:                (p5,p6 = splitInfExt)
-        let vpnn = vp.nn ! a in    -- vfin < accPron < refl < (gen|dat)Pron < nonPronNP < neg < prepNP < vinf|comp
-{- less expensive if isLight is removed from NPs:
-       case <np.isPron,prep.isPrep,c> of {
-          -- (assuming v.c2=acc) nonPron: dat < acc|gen  (acc < gen not enforced)
-          <True, False,Acc> => -- <es|ihn sich,  np, pp, comp, _,_>
-            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
-          <True, False,_  > => -- <sich ihm,     np, pp, comp>
-            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
-          <False,False,Dat> => -- <prons, dat ++ np, pp, comp>
-            <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
-          <False,False,_  > => -- <prons, np ++ gen|acc, pp, comp>
-            <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
-          <_,    True,_   > => -- <prons, np, pp++pp, compl>
-            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6>
-        }
--}
--- expensive:  -- vfin < accPron < refl < (gen|dat)Pron < lightNP < neg < heavyNP|PP < vinf|comp
-        case <prep.isPrep, np.w, c> of { 
-          <True, _,_> =>       -- <prons, light, heavy++pp, compl,_,_>
-            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> ;
-          <False,WPron, Acc> => -- <ihn ++ sich, light, heavy, comp, _,_>
-            <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
+      nn = \\a =>
+        let vpnn = vp.nn ! a in
+        -- HL 11/6/19: rough object NP order (expensive):
+        -- vfin < accPron < refl < (gen|dat)Pron < lightNP < neg < heavyNP|PP < vinf|comp
+        case <prep.isPrep, np.w, c> of { -- 2 * 3 * 4 = 24 cases
+          <True, _,_> =>       -- <prons, light, heavy++pp, compl>
+            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj, vpnn.p4> ;
+          <False,WPron, Acc> => -- <ihn ++ sich, light, heavy, comp>
+            <obj ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ;
           <False,WPron, _  > => -- <sich ++ ihm|seiner, light, heavy, comp>
-            <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
-          <False,WLight,Dat> => -- (assuming v.c2=acc) nonPron: dat < acc|gen  
+            <vpnn.p1 ++ obj, vpnn.p2, vpnn.p3, vpnn.p4> ;
+          <False,WLight,Dat> => -- (assuming v.c2=acc) nonPron: dat < acc|gen
                                 -- <prons, dat ++ np, heavy, comp>
-            <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
+            <vpnn.p1, obj ++ vpnn.p2, vpnn.p3, vpnn.p4> ;
           <False,WHeavy,Dat> => -- <prons, light, dat ++ np, comp>
-            <vpnn.p1, vpnn.p2, obj ! a ++ vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+            <vpnn.p1, vpnn.p2, obj ++ vpnn.p3, vpnn.p4> ;
           <False,WLight,_  > => -- <prons, np ++ gen|acc, heavy, comp>
-            <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ; 
+            <vpnn.p1, vpnn.p2 ++ obj, vpnn.p3, vpnn.p4> ;
           <False,WHeavy,_  > => -- <prons, light, dat ++ np, comp>
-            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4, vpnn.p5, vpnn.p6> } 
+            <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj, vpnn.p4> }
     } ; -- the ordering of objects of v:V3 (and v:V4) is also determined by Slash?V3 (and Slash?V4)
 
   insertObjRefl : VPSlash -> VPSlash = \vp -> -- HL 6/2019, to order reflPron < neg < prep+reflPron
     let prep = vp.c2 ;
-        b = notB prep.isPrep ;
         c = case prep.c of { NPC cc => cc ; _ => Acc } ;
-        obj : Agr => Str = \\a => prep.s ++ reflPron ! a ! c ;
+        obj : Agr => Str = \\a => prep.s ++ reflPron ! a ! c ;  -- HL: to test ReflVP: reflPronSelf
     in vp ** {
       nn = \\a =>
         let vpnn = vp.nn ! a in
-        case b of {
-          True  => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;
-          False => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> }
+        case prep.isPrep of {
+          False => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ;
+          True  => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4> }
     } ;
 
-  insertAdV : Str -> VP -> VP = \adv,vp -> vp ** { -- not used in RGL, so VP.a1 can be skipped
+  insertAdV : Str -> VP -> VP = \adv,vp -> vp ** { -- not used in Ger, so VP.a1 can be skipped
     a1 = adv ++ vp.a1 } ;                          -- cf. AdvVP(Slash),AdVVP(Slash)
 
   insertAdv : Str -> VP -> VP = \adv,vp -> vp ** {
     a2 = vp.a2 ++ adv } ;
 
-  insertExtrapos : Str -> VPSlash -> VPSlash = \ext,vp -> vp ** {
+  insertExtrapos : Str -> VP -> VP = \ext,vp -> vp ** {
     ext = vp.ext ++ ext } ;
 
-  insertInfExt : Str -> VPSlash -> VPSlash = \infExt,vp -> vp ** {
-	infExt = vp.infExt ++ infExt } ;
+  -- HL 3/2022: to do nested infinitival objects in ComplVV, SlashVV, SlashV2V
+  -- embed <sich, helfen> into <ihn, lassen> = <ihn sich, helfen lassen>
+  embedInf : (Agr => Str) * Str -> (Agr => Str) * Str -> (Agr => Str) * Str =
+     \f,g -> <\\a => g.p1!a ++ f.p1!a, f.p2 ++ g.p2> ;
 
-  -- HL: to handle infExt in ComplVV and SlashVV, SlashV2V
-  insertInfExtraObj : (Agr => Str) -> VPSlash -> VPSlash = \objs,vp -> vp ** { 
-    nn = \\a => let vpnn = vp.nn ! a in
-      <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, objs ! a ++ vpnn.p5, vpnn.p6> 
-    } ;
-  insertInfExtraInf : (Agr => Str) -> VPSlash -> VPSlash = \inf,vp -> vp ** { 
-    nn = \\a => let vpnn = vp.nn ! a in
-      <vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6 ++ inf ! a>   
-    } ;
+  -- Futur-II:  (ich werde) ihn dir ++ haben ++ helfen lassen
+  insertInf : {inpl:(Agr => Str)*Str ; extr:(Agr => Str)} -> VP -> VP =
+  \inf,vp -> vp ** {inf = {inpl = embedInf inf.inpl vp.inf.inpl ;
+                           extr = \\agr => vp.inf.extr!agr ++ inf.extr!agr}} ;
 
-  insertInf : {s:Str;isAux:Bool;ctrl:Control} -> VPSlash -> VPSlash = \inf,vp -> vp ** {
-    inf = {s = inf.s ++ vp.inf.s ; isAux = inf.isAux ; ctrl=inf.ctrl} } ;
+  glueInpl : (Agr => Str)*Str -> (Agr => Str) =
+      \inplace -> \\agr => (inplace.p1!agr ++ inplace.p2) ;
 
-  insertAdj : Str -> Str * Str -> Str -> VPSlash -> VPSlash = \adj,c,ext,vp -> vp ** {
+  -- HL 3/22: extract infzu-complement, leave inf-complement in-place
+  mkInf : Bool -> Anteriority -> Polarity -> VP ->
+                {inpl : (Agr => Str) * Str ; extr : (Agr => Str)} =
+     \isAux,ant,pol,vp ->
+        let
+            vpi = infVP isAux ant pol vp ;
+            topInpl = <vpi.objs, vpi.pred> ;
+            emptyInpl : (Agr => Str) * Str = <\\_ => [], []> ;
+            comma = bindComma
+        in
+          case <isAux,vp.isAux> of {
+            <True,True> -- 1: {s=will, inpl=<(sich, waschen) können>, extr = []}
+                => {inpl = embedInf vpi.inpl topInpl ;
+                    extr = \\agr => vpi.extr!agr} ;
+            <True,False> -- 2: {s=will; inpl=<[], versuchen>, extr = sich zu waschen}
+                => {inpl = topInpl ;
+                    extr = \\agr => (glueInpl vpi.inpl)!agr ++ vpi.extr!agr} ;
+            <False,True> -- 3: {s=wagt; inpl=<[], []>, extr = (sich, waschen) zu wollen}
+                => {inpl = emptyInpl ;
+                    extr = let moved = embedInf vpi.inpl topInpl
+                           in \\agr => comma ++ (glueInpl moved)!agr ++ vpi.extr!agr} ;
+            <False,False> -- 4: {s=wagt, inpl=<[], []>, extr = zu versuchen, (sich zu waschen)}
+                => {inpl = emptyInpl ;
+                    extr = \\agr => comma ++ (glueInpl topInpl)!agr ++ vpi.extr!agr}
+        } ;
+
+  insertAdj : Str -> Str * Str -> Str -> VP -> VP = \adj,c,ext,vp -> vp ** {
     nn = \\a => 
       let vpnn = vp.nn ! a in <vpnn.p1, vpnn.p2 ++ c.p1, -- der Frau treu
-                               vpnn.p3, vpnn.p4, vpnn.p5, vpnn.p6> ;  
+                               vpnn.p3, vpnn.p4> ;
     adj = vp.adj ++ adj ++ c.p2 ;                        -- neugierig auf das Buch
     ext = vp.ext ++ ext} ;           
 
@@ -809,7 +808,8 @@ resource ResGer = ParamX ** open Prelude in {
     s : Mood => Tense => Anteriority => Polarity => Order => Str
     } ;
 
-  mkClause : Str -> Agr -> VP -> Clause = \subj,agr,vp ->  let vps = useVP vp in {
+  mkClause : Str -> Agr -> VP -> Clause = \subj,agr,vp ->
+    let vps = useVP vp in {
       s = \\m,t,a,b,o =>
         let
           ord   = case o of {
@@ -817,55 +817,43 @@ resource ResGer = ParamX ** open Prelude in {
             _ => False
             } ;
           verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
+          haben = verb.inf2 ;
           neg = negation ! b ;
           obj1  = (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ; -- refl ++ pronouns ++ light nps
           obj2  = (vp.nn ! agr).p3 ;                     -- pp-objects and heavy nps
           obj3  = (vp.nn ! agr).p4 ++ vp.adj ++ vp.a2 ;  -- pred.AP|CN|Adv, via useComp HL 6/2019
           compl = obj1 ++ neg ++ obj2 ++ obj3 ;
-          -- leave inf-complement of +auxV(2)V in place, 
+          infObjs = (vp.inf.inpl.p1)!agr ;
+          infPred = vp.inf.inpl.p2 ;
+          -- leave inf-complement of +auxV(2)V in place,
           -- extract infzu-complement of -auxV(2)V: (ComplVV, SlashV2V)
-          infExt : Str * Str = case vp.inf.isAux of 
-            { True => <(vp.nn!agr).p6,[]> ; _ => <[],(vp.nn!agr).p6> } ;
-          extra = infExt.p2 ++ vp.ext ;
-          infCompls = -- () tun | ihn (es tun) lassen | ihm [es zu tun] versprechen 
-            (vp.nn ! agr).p5 ++ infExt.p1 ++ vp.inf.s ; 
-          comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {
-            True => [] ; _ => bindComma} ;
-          inf : Str =
-            case <t,a,vp.isAux> of {
-              <Fut|Cond,Anter,True>  =>                 --# notpresent   
-                --     haben () tun wollen | 
-                -- ihn haben (es tun) lassen wollen () |
-                -- ihm haben () versprechen wollen (, es zu tun)  
-                (vp.nn ! agr).p5 ++ verb.inf2 ++ infExt.p1 ++ vp.inf.s ++ verb.inf ; --# notpresent
-              <_,       Anter,True>  =>                 --# notpresent
-                -- tun wollen [] | ihn (es tun) lassen wollen [] | 
-                -- ihm () versprechen wollen [] (, es zu tun)
-                infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent
-              <Fut|Cond,Simul,True>  =>                 --# notpresent
-                infCompls ++ verb.inf ++ verb.inf2 ;    --# notpresent
-              <Fut|Cond,Anter,False> =>                 --# notpresent
-              -- gebeten haben , es zu tun () | gebeten haben , ihn (es tun) zu lassen
-                verb.inf ++ verb.inf2 ++ comma ++ infCompls ; --# notpresent 
-              _                      => verb.inf2 ++ verb.inf ++ comma ++ infCompls } ;
-          inffin : Str =
-            case <t,a,vp.isAux> of {
-	           <Fut|Cond,Anter,True>  -- ... wird|würde haben kommen wollen --# notpresent
-                     => (vp.nn ! agr).p5 ++ verb.fin                      --# notpresent
-                     ++ verb.inf2 ++ infExt.p1 ++ vp.inf.s ++ verb.inf ;  --# notpresent
-	           <Pres|Past,Anter,True>                                 --# notpresent
-                     => (vp.nn ! agr).p5 ++ infExt.p1 ++ verb.fin         --# notpresent
-                     ++ vp.inf.s ++ verb.inf ++ verb.inf2 ; -- double inf --# notpresent
-                   <_, _          ,True> 
-                     => infCompls ++ verb.inf ++ verb.inf2 ++ verb.fin ;  -- or just auxiliary vp
-                   <_, _          ,False>
-                     => verb.inf ++ verb.inf2 ++ verb.fin ++ comma ++ infCompls
-            } ;
+          infCompl : Str = case <t,a,vp.isAux> of {
+                 <Fut|Cond,Anter,True> => [] ;  _ => infObjs ++ infPred } ;
+          pred : {inf, infComplfin : Str} = case <t,a,vp.isAux> of {
+             <Fut|Cond,Anter,True>  =>                                    --# notpresent
+               {inf    = infObjs ++ haben ++ infPred ++ verb.inf ;        --# notpresent Duden 318
+                infComplfin = -- es ++ wird ++ haben ++ tun ++ wollen     --# notpresent
+                   infObjs ++ verb.fin ++ haben ++ infPred ++ verb.inf} ; --# notpresent
+             <_,Anter,True> =>                                            --# notpresent
+               {inf    = verb.inf ++ haben ;                              --# notpresent
+                infComplfin = -- es ++ wird/hat/hatte ++ tun ++ wollen    --# notpresent
+                   infObjs ++ verb.fin ++ infPred ++ verb.inf ++ haben} ; --# notpresent
+              <Pres,_,_> =>
+               {inf    = verb.inf ++ haben ;
+                infComplfin = -- es zu tun ++ [] ++ [] ++ versucht
+                   infCompl ++ verb.inf ++ haben ++ verb.fin}
+                                                                         ; --# notpresent
+              _ =>                                                         --# notpresent
+               {inf    = verb.inf ++ haben ;                               --# notpresent
+                infComplfin = -- es zu tun ++ versucht ++ [] ++ hat        --# notpresent
+                              infCompl ++ verb.inf ++ haben ++ verb.fin}   --# notpresent
+              } ;
+          extra = vp.inf.extr!agr ++ vp.ext ;
         in
-        case o of { 
-	  Main => subj ++ verb.fin ++ compl ++ inf ++ extra ;
-	  Inv  => verb.fin ++ subj ++ compl ++ inf ++ extra ;
-	  Sub  =>             subj ++ compl ++ inffin ++ extra
+        case o of {
+	  Main => subj ++ verb.fin ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Inv  => verb.fin ++ subj ++ compl ++ infCompl ++ pred.inf ++ extra ;
+	  Subj =>             subj ++ compl ++   pred.infComplfin   ++ extra
         }
     } ;
 
@@ -886,34 +874,60 @@ resource ResGer = ParamX ** open Prelude in {
   es wird nicht besser
 -}
 
-  infVP : Bool -> VP -> ((Agr => Str) * Str * Str * Str) = 
-    \isAux, vp -> let vps = useVP vp in
+  infVP = overload {
+     infVP : Bool -> VP -> ((Agr => Str) * Str * Str * Str)
+     = infVP_orig ; -- from gf-3.9,
+     infVP : Bool -> Anteriority -> Polarity -> VP
+           -> { objs:(Agr => Str) ; pred:Str; inpl:(Agr=>Str)*Str ; extr:(Agr=>Str) }
+     = infVP_ant ; -- admit infinitive in Anter anteriority and Neg polarity
+  } ;
+
+  infVP_orig : Bool -> VP -> ((Agr => Str) * Str * Str * Str) =
+    \isAux, vp -> let vps = useVP vp ;
+                      infExt = vp.inf.extr ! agrP3 Sg   -- HL 3/22
+    in
     <
      \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4 ++ vp.a2,
      vp.a1 ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit Simul).inf,  -- vp.a1 ! Pos
-     vp.inf.s,
-     vp.infExt ++ vp.ext
+     vp.inf.inpl.p2, -- ! HL
+     infExt ++ vp.ext
     > ;
 
-  useInfVP : Bool -> VP -> Str = \isAux,vp ->
-    let vpi = infVP isAux vp in
-    vpi.p1 ! agrP3 Sg ++ vpi.p3 ++ vpi.p2 ++ vpi.p4 ;
+  infVP_ant : Bool -> Anteriority -> Polarity -> VP  -- HL 3/22
+    -> { objs:(Agr => Str) ; pred:Str ; inpl:(Agr=>Str)*Str ; extr:(Agr=>Str) } =
+      \isAux, ant, pol, vp -> let vps = useVP vp in
+      {
+        objs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ negation ! pol ++ (vp.nn ! agr).p3
+          ++ vp.a2 ++ (vp.nn ! agr).p4 ;  -- objects + predicative A|CN|NP
+        pred = vp.a1 ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit ant).inf ;
+        -- inplace and extracted parts of vp.inf:
+        inpl = vp.inf.inpl ;
+        extr = vp.inf.extr
+      } ;
 
-  infzuVP : Bool -> Control -> Anteriority -> Polarity -> VP  -- HL 
-    -> { objs:(Agr => Str) ; pred:{s:Str;isAux:Bool;ctrl:Control} ; inf:Str ; ext:Str } =
-      \isAux, ctrl, ant, pol, vp -> let vps = useVP vp in
+  infVPSlash : Bool -> Anteriority -> Polarity -> VPSlash  -- HL 3/22
+    -> { objs:(Agr => Str) ; pred:Str; inpl:(Agr=>Str)*Str ; extr:(Agr=>Str) } =
+      \isAux, ant, pol, vp -> let vps = useVP vp in
       { objs = \\agr => (vp.nn ! agr).p1 ++ (vp.nn ! agr).p2 ++ negation ! pol ++ (vp.nn ! agr).p3
           ++ vp.a2 ++ (vp.nn ! agr).p4 ;  -- objects + predicative A|CN|NP
-        pred = { s = vp.a1 ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit ant).inf ;
-                 isAux = vp.isAux ; ctrl = ctrl } ;
-        inf = vp.inf.s ;
-        ext = vp.ext
-      } ;
+        pred = vp.inf.inpl.p2 ++ vp.a1 ++ vp.adj ++ (vps.s ! (notB isAux) ! agrP3 Sg ! VPInfinit ant).inf ;
+        -- inplace and extracted parts of vp.inf:
+        inpl = <vp.inf.inpl.p1, []> ; -- move the predicate part to pred
+        extr = vp.inf.extr
+      } ** {c2 = vp.c2 ; objCtrl = vp.objCtrl} ;
+
+  -- for CatGer.linref VP and Verb.embedVP:
+  useInfVP : Bool -> VP -> Str = \isAux,vp ->
+    -- let vpi = infVP isAux vp in
+    -- vpi.p1 ! agrP3 Sg ++ vpi.p3 ++ vpi.p2 ++ vpi.p4 ;
+    let vpi = infVP isAux Simul Pos vp ; -- HL 3/2022
+        agr : Agr = (Ag Masc Sg P3) ;
+        glue : (Agr => Str)*Str -> Str =  \i -> i.p1!agr ++ i.p2
+    in
+       glue (embedInf vpi.inpl <vpi.objs, vpi.pred>) ++ vpi.extr!agr ++ vp.ext ;
 
 -- The nominative case is not used as reflexive, but defined here
 -- so that we can reuse this in personal pronouns. 
--- The missing Sg "ihrer" shows that a dependence on gender would
--- be needed.
 
   reflPron : Agr => Case => Str = table {
     Ag _ Sg P1 => caselist "ich" "mich" "mir"  "meiner" ;
@@ -984,11 +998,10 @@ resource ResGer = ParamX ** open Prelude in {
     } ;
 
 -- Function that allows the construction of non-nominative subjects.
-  mkSubj : NP -> Preposition -> Str * Agr = \np, subjc -> 
+  mkSubj : NP -> Preposition -> Str * Agr = \np, prep ->
     let 
-      sub = subjc ;
-      agr = case sub.c of { NPC Nom => np.a ; _ => Ag Masc Sg P3 } ;
-      subj = appPrepNP sub np
+      agr = case prep.c of { NPC Nom => np.a ; _ => Ag Masc Sg P3 } ;
+      subj = appPrepNP prep np
     in <subj , agr> ;
 
 }

--- a/src/german/SentenceGer.gf
+++ b/src/german/SentenceGer.gf
@@ -4,9 +4,9 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
 
   lin
 
-	PredVP np vp = 
-		let subj = mkSubj np vp.subjc 
-		in mkClause subj.p1 subj.p2 vp ;
+    PredVP np vp =
+      let subj = mkSubj np vp.c1
+      in mkClause subj.p1 subj.p2 vp ;
 
 	{- applies verb's subject case to subject ;
 	   forces 3rd person sg agreement for any non-nom subjects -->
@@ -26,16 +26,16 @@ concrete SentenceGer of Sentence = CatGer ** open ResGer, Prelude in {
             } ;
           agr  = Ag Fem (numImp n) ps.p1 ; --- g does not matter
           verb = vps.s ! False ! agr ! VPImperat ps.p3 ;
-          inf  = vp.inf.s ++ verb.inf ;  -- HL .nn
+          inf  = vp.inf.inpl.p2 ++ verb.inf ;  -- HL .s/.inpl.p2
           obj  = (vp.nn ! agr).p2 ++ (vp.nn ! agr).p3 ++ (vp.nn ! agr).p4
         in
 --        verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
         verb.fin ++ ps.p2 ++ (vp.nn ! agr).p1 ++ vp.a1 ++ negation ! pol ++ obj ++ vp.a2 ++ inf ++ vp.ext
     } ; 
 
-    SlashVP np vp = 
-		let subj = mkSubj np vp.subjc 
-		in mkClause subj.p1 subj.p2 vp ** {c2 = vp.c2} ;
+    SlashVP np vp =
+      let subj = mkSubj np vp.c1 ;                       -- HL 3/2022: need a mkClSlash to prevent
+      in mkClause subj.p1 subj.p2 vp ** { c2 = vp.c2 } ; -- reflexives in vp instantiated to np.a
 
     AdvSlash slash adv = {
       s  = \\m,t,a,b,o => slash.s ! m ! t ! a ! b ! o ++ adv.s ;

--- a/src/malay/AllMayAbs.gf
+++ b/src/malay/AllMayAbs.gf
@@ -3,4 +3,6 @@
 abstract AllMayAbs =
   Lang,
   Extend
-  ** {} ;
+  ** {
+    fun sing_V2: V2;
+  } ;

--- a/tests/german/TestLang.gf
+++ b/tests/german/TestLang.gf
@@ -1,7 +1,7 @@
 abstract TestLang = 
   Grammar, 
   TestLexiconGerAbs
---  , Construction
+  , Construction
   ** {    
   flags startcat=Phr ;
 

--- a/tests/german/TestLangEng.gf
+++ b/tests/german/TestLangEng.gf
@@ -4,7 +4,7 @@
 concrete TestLangEng of TestLang = 
   GrammarEng
   , TestLexiconEng
---  , ConstructionEng
+  , ConstructionEng
   ** open (R=ResEng), (P=ParadigmsEng), Prelude, (E=ExtendEng)
   in {
 

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -2,9 +2,9 @@
 -- use the modified files in gf-rgl/src/german
 
 concrete TestLangGer of TestLang = 
-  GrammarGer - [PassV2] -- to improve these ,ComplVV,SlashVV,SlashV2V,SlashV2VNP
-  , TestLexiconGer - [helfen_V2V, warnen_V2V, versprechen_dat_V2V, lassen_V2V]
---  , ConstructionGer -- needs SlashV2VNP of VerbGer
+  GrammarGer
+  , TestLexiconGer
+  , ConstructionGer
   ** open ResGer,Prelude,(P=ParadigmsGer) in {
 
   flags startcat = Phr ; unlexer = text ; lexer = text ;
@@ -27,147 +27,128 @@ concrete TestLangGer of TestLang =
     ReflVPSlash v3 = -- reflexive use of v:V3, untested
       (insertObjRefl (predVc v3) ** {c2 = v3.c3}); 
 
-    PassV2 v = -- insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ;
-      let c = case <v.c2.c, v.c2.isPrep> of {
-            <NPC Acc, False> => NPC Nom ; _ => v.c2.c} -- acc object -> nom; all others: same PCase
-      in insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) ** { subjc = v.c2 ** {c = c} } ;
-
-    PassV2Q v q = 
+    PassV2Q v q =
       let c = case <v.c2.c, v.c2.isPrep> of {
             <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
-          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
-            ** { subjc = v.c2 ** {c = c} } 
+          vp = insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass)
+            ** { c1 = v.c2 ** {c = c} }
       in insertExtrapos (bindComma ++ q.s ! QIndir) vp ;
 
-    PassV2S v s = 
+    PassV2S v s =
       let c = case <v.c2.c, v.c2.isPrep> of {
             <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
-          vp = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
-            ** { subjc = v.c2 ** {c = c} } 
+          vp = insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass)
+            ** { c1 = v.c2 ** {c = c} }
       in insertExtrapos (bindComma ++ conjThat ++ s.s ! Sub) vp ;
 
     PassV2V v vp = 
-      let c = case <v.c2.c, v.c2.isPrep> of {
+      let
+          inf = mkInf v.isAux Simul Pos vp ;             -- ok for v.isAux=False, v.c2.c=Acc
+          c = case <v.c2.c, v.c2.isPrep> of {            --        v.objCtrl=True   HL 3/22
             <NPC Acc, False> => NPC Nom ; _ => v.c2.c} ; -- acc;pcase object -> nom;pcase subject
-          vp2 = insertObjc (\\_ => v.s ! VPastPart APred) (predV werdenPass) 
-            ** { subjc = v.c2 ** {c = c} } 
-      in insertExtrapos (bindComma ++ (useInfVP False vp)) vp2 ; -- misses subject agr for vp = ReflVP vps
-{-
+          vp2 = insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass)
+            ** { c1 = v.c2 ** {c = c} } ;
+        in insertInf inf vp2 ;                           -- v=lassen needs in-place inf instead
+
     PassVPSlash vp = 
       let c = case <vp.c2.c,vp.c2.isPrep> of {
-            <NPC Acc, False> => NPC Nom ; _ => vp.c2.c}
-      in insertObjc (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) 
-      ** {ext = vp.ext ; subjc = vp.c2 ** {c = c}} ;
-                -- regulates passivised object: accusative objects -> nom; all others: same case
-		-- this also gives "mit dir wird gerechnet" ;
-		-- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
-       -- HL: does not work for vp = (Slash2V3 v np): uns wird den Beweis erklärt
-       --                       vp = (SlashV2V v2v reflVP): wir werden gebeten, uns zu fragen , ob S
+            <NPC Acc, False> => NPC Nom ; _ => vp.c2.c} ;
+          ctrl = case vp.objCtrl of { True => False ; _ => True }  -- always False?
+      in -- insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass ** {c1 = vp.c2 ** {c = c}})
+          insertObj (\\_ => vp.s.s ! (VPastPart APred))
+                      (predV werdenPass ** {nn = vp.nn ; c1 = vp.c2 ** {c = c}})
+           ** {ext = vp.ext ; inf = vp.inf ; c2 =vp.c2 ; objCtrl = ctrl } ;  -- c2 ?
+       -- Scharolta: passivised object: acc object -> nom subject; all others: same case/prep
+       -- HL: does not work for vp = (Slash2V3 v np): uns wird *den Beweis erklärt
+       -- 3/22 works for        vp = (SlashV2V v2v reflVP): wir werden gebeten, uns zu waschen
+
     PastPartAP vp = {
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++ 
         (vp.nn ! agrP3 Sg).p3 ++ (vp.nn ! agrP3 Sg).p4 ++ vp.adj ++ vp.a2 
-        ++ vp.inf.s ++ vp.infExt ++ vp.s.s ! VPastPart af ;
+        ++ vp.inf.inpl.p2 ++ vp.s.s ! VPastPart af ;
       isPre = True ;
       c = <[],[]> ;
       adj = [] ;
-      ext = vp.ext 
+      ext = (vp.inf.extr ! agrP3 Sg) ++ vp.ext  -- HL 5/4/2022
       } ;
--}
+
     Pass2V3 v np = -- HL 7/19: making the (active) direct object to the (passive) subject
-      let vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
-            ** { subjc = PrepNom ; c2 = v.c3 }
-      in insertObjNP np vps.c2 vps ;
+      let vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
+            ** { c1 = PrepNom ; c2 = v.c3 }
+      in insertObjNP np vps.c2 (vps ** {objCtrl = False});
 
     Pass3V3 v np = -- HL 7/19: making the (active) indirect object to the (passive) subject
       let bekommen : Verb = P.habenV (P.irregV "bekommen" "bekommt" "bekam" "bekäme" "bekommen") ;
-          vps = insertObjc (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
-            ** { subjc = PrepNom ; c2 = v.c2 } 
-      in insertObjNP np vps.c2 vps ;
+          vps = insertObj (\\_ => (v.s ! VPastPart APred)) (predV bekommen)
+            ** { c1 = PrepNom ; c2 = v.c2 }
+      in insertObjNP np vps.c2 (vps ** {objCtrl = False});
 {-      
     Pass2V4 v np = 
       let vps = -- : VPSlashSlash = 
             insertObj (\\_ => (v.s ! VPastPart APred)) (predV werdenPass)
-            ** { subjc = PrepNom ; c2 = v.c3 ; c3 = v.c4 } 
+            ** { c1 = PrepNom ; c2 = v.c3 ; c3 = v.c4 }
       in (insertObjNP np vps.c3 vps) ;
 
     -- Todo: Pass?V2S, Pass?V2Q, PassVS, PassVQ Pass?V2V
 -}
 
-    SlashV2Vneg v vp =   -- versprechen, (\agr => sich!agr es nicht zu merken) 
+    SlashV2Vneg v vp = -- HL 3/22
       let 
-        vps = (predVGen v.isAux v) ** { c2 = v.c2 } ; --; ctrl = v.ctrl } ;
-        vpi = infzuVP v.isAux v.ctrl Simul Neg vp ;
-        comma = case orB vp.isAux (case vp.inf.ctrl of { NoC => True ; _ => False }) of {True => [] ; _ => bindComma} ;
-        embeddedInf : Agr => Str = case vp.inf.isAux of {
-          True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
-          False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
-      in 
-      insertExtrapos vpi.ext (
-        insertInf vpi.pred (   
-          insertInfExtraObj vpi.objs (
-            insertInfExtraInf embeddedInf vps))) ;
+        vps = (predVGen v.isAux v) ;
+        inf = mkInf v.isAux Simul Neg vp
+       in
+        insertExtrapos vp.ext (
+          insertInf inf vps) ** {c2 = v.c2 ; objCtrl = v.objCtrl} ;
 
-    lin -- with param Control in ../../src/german/ParadigmsGer.gf
-      helfen_V2V = P.mkV2V (P.irregV "helfen" "hilft" "half" "hälfe" "geholfen") P.datPrep ; 
-      warnen_V2V = P.mkV2V (P.regV "warnen") P.accPrep ;
-      versprechen_dat_V2V = 
-        P.subjV2V (P.mkV2V (P.irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") P.datPrep) ;
-      lassen_V2V = P.auxV2V (P.irregV "lassen" "lasst" "ließ" "ließe" "gelassen") P.accPrep ;  -- lasse dich (*zu) arbeiten
+}
 
 -- SlashV2VNP : V2V -> NP -> VPSlash -> VPSlash ; -- beg me to buy
 -- -- (the book) that (she (begged:V2V me:NP (to buy ()):VPSlash):VPSlash):ClSlash
 
--- very expensive:
--- + SlashV2V 2332800 (6480,40)
--- + SlashV2VNP 2267481600 (4320,270) vs. (1080,90) in VerbGer, 305460 msec
--- Languages: TestLangGer
--- 623657 msec
-{- 
-    SlashV2VNP v np vp =  
-      let
-        vps = (predVGen v.isAux v) ** { c2 = vp.c2 } ; -- objCtrl = 
-        vpi = infzuVP v.isAux v.ctrl Simul Pos vp ;
-        -- comma = case <vp.isAux,vp.inf.ctrl> of { <True,_> => [] ; <_,NoC> => [] ; _ => bindComma} ;
-        embeddedInf : Agr => Str = 
-          \\agr => "[" ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ++ "]";  
-        -- embeddedInf : Agr => Str = case vp.inf.isAux of {
-        --   True  => \\agr => comma ++ (vp.nn!agr).p5 ++ (vp.nn!agr).p6 ++ vpi.inf ;  -- ihn es lesen (zu) lassen
-        --   False => \\agr => comma ++ (vp.nn!agr).p5 ++ vpi.inf ++ (vp.nn!agr).p6 }  -- ihn (zu) bitten , es zu lesen
-      in
-      insertExtrapos vpi.ext (           -- vps.ext   <- vp's object-sentence ++ extractedInfzu?
-        insertInf vpi.pred (             -- vps.inf   <- vp's infinite main verb
-          insertInfExtraObj vpi.objs (   -- vps.nn.p5 <- vp's object nps
-            insertInfExtraInf embeddedInf (
-              insertObjNP np v.c2 vps )))) ;
--}
+-- 3/22 expensive:
+-- i -v -src TestLangGer.gf
+-- + ComplSlash     699840 (355680,532)
+-- + SlashV2V       259200   (1440,20)
+-- + SlashV2VNP  503884800  (77760,540)
+-- 243273 msec
+
 {-
 TestLang> p "the book that we beg her to promise him to read" | l
 the book that we beg her to promise him to read
-das Buch , das wir sie bitten , ihn zu versprechen [ [ ] zu lesen ]
+das Buch , das wir sie bitten , ihm zu versprechen , zu lesen
 
 TestLang> p "the book that we beg her to beg him to read" | l
 the book that we beg her to beg him to read
-das Buch , das wir sie bitten , ihn zu bitten [ [ ] zu lesen ]
+das Buch , das wir sie bitten , ihn zu bitten , zu lesen
 
 TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPres ASimul) PPos (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron she_Pron) (SlashV2a read_V2))))))
 TestLangEng: the book that we promise her to read
-TestLangGer: das Buch , dem wir ihr versprechen , zu lesen   Bug: dem => das
+TestLangGer: das Buch , das wir ihr versprechen , zu lesen
 
 TestLang> p "the book that we beg her to sell to him" | l
 the book that we beg her to sell to him
-das Buch , das wir ihm sie bitten , zu verkaufen
-=> das Buch , das wir sie bitten , ihm zu verkaufen
+das Buch , das wir sie bitten , ihm zu verkaufen
+
+p -lang=Ger "das Kind , auf das wir ihn bitten , zu warten ," | l
+the child that we beg him to wait for
+das Kind , auf das wir ihn bitten , zu warten
+
+pied piping:
 ~~> das Buch , das ihm zu verkaufen wir sie bitten
- ~~ das Buch , an das zu glauben wir sie bitten
+~~> das Kind , auf das zu warten wir ihn bitten
 
 Wrong in gf-3.9 as well:
 Lang> p "the woman that we beg him to listen to" | l
 the woman that we beg him to listen to
-die Frau , die wir ihn zuzuhören bitten  (Bug: die => der)
+die Frau , der wir ihn bitten , zuzuhören
 
 Lang> p "the book that we beg her to sell to him" | l
 the book that we beg her to sell to him
-das Buch , das wir ihn sie zu verkaufen bitten (Bug: ihn sie => sie ihm)
-=> das Buch, das wir sie bitten, ihm zu verkaufen
+das Buch, das wir sie bitten, ihm zu verkaufen
+
+Test reflexive resolution:
+
+gr -tr (PredVP (UsePron ?) (ComplSlash (SlashV2V lassen_V2V (ReflVP (SlashV2a wash_V2))) (UsePron ?))) | l
+
 -}
-}
+

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -23,8 +23,8 @@ oper
          \v,p2,p3,p4 -> lin V4 (v ** { c2=p2 ; c3=p3 ; c4=p4 }) ;
   dirV4 : V -> Prep -> Prep -> V4 = \v,c,d -> mkV4 v accPrep c d ;
   -- control verbs
-  dirV2V : V -> V2V = \v -> mkV2V v ; 
-
+  dirV2V : V -> V2V = \v -> mkV2V v ; -- object control verb;
+                                      -- subjV2V v2v = subject-control verb
 lin
   aendern_rV = reflV (regV "ändern") accusative ;
   anstrengen_rV = reflV (prefixV "an" (regV "strengen")) accusative ;
@@ -37,29 +37,37 @@ lin
 
   erklaeren_dat_V3 = mkV3 (irregV "erklären" "erklärt" "erklärte" "erklärte" "erklärt") ;
   anklagen_gen_V3 = dirV3 (prefixV "an" (regV "klagen")) genPrep ;
-  erinnern_an_V3 = dirV3 (irregV "erinnern" "erinnert" "erinnerte" "erinnerte" "erinnert") (mkPrep "an" accusative) ; 
+  erinnern_an_V3 = dirV3 (irregV "erinnern" "erinnert" "erinnerte"
+                                 "erinnerte" "erinnert") (mkPrep "an" accusative) ;
   danken_dat_fuer_V3 = mkV3 (regV "danken") datPrep (mkPrep "für" accusative) ;
-  debattieren_mit_ueber_V3 = mkV3 (irregV "debattieren" "debattiert" "debattierte" "debattierte" "debattiert") mit_Prep (mkPrep "über" accusative) ;
+  debattieren_mit_ueber_V3 = mkV3 (irregV "debattieren" "debattiert" "debattierte"
+                                          "debattierte" "debattiert") mit_Prep (mkPrep "über" accusative) ;
   lehren_V3 = dirV3 (regV "lehren") accPrep ;
 
-  abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut" "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;
+  abschauen_bei_rV3 = reflV3 (prefixV "ab" (irregV "schauen" "schaut"
+                                                   "schaute" "schaute" "geschaut")) dative accPrep bei_Prep ;
   leihen_von_rV3 = reflV3 (irregV "leihen" "leiht" "lieh" "liehe" "geliehen") dative accPrep von_Prep ;
 
-  entschuldigen_bei_fuer_rV3 = 
-    reflV3 (irregV "entschuldigen" "entschuldigt" "entschuldigte" "entschuldigte" "entschuldigt") accusative bei_Prep fuer_Prep ;
+  entschuldigen_bei_fuer_rV3 = reflV3 (irregV "entschuldigen" "entschuldigt" "entschuldigte"
+                                              "entschuldigte" "entschuldigt") accusative bei_Prep fuer_Prep ;
   raechen_am_fuer_rV3 = reflV3 (regV "rächen") accusative (mkPrep "an" dative) fuer_Prep ;
 
   kaufen_bei_fuer_V4 = dirV4 (regV "kaufen") bei_Prep fuer_Prep ;
   mieten_von_fuer_V4 = dirV4 (regV "mieten") von_Prep fuer_Prep ;
 
   neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
-
+  
+  -- verbs with infinitival object (non-modal):
   wagen_VV = mkVV (regV "wagen")  ;
   versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
 
+  -- object control verbs:
   helfen_V2V = mkV2V (irregV "helfen" "hilft" "half" "hälfe" "geholfen") datPrep ; 
   warnen_V2V = dirV2V (regV "warnen")  ;
---  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "verspricht" "versprach" "verspräche" "versprochen") datPrep) ;
-  lassen_V2V = auxV2V (irregV "lassen" "lasst" "ließ" "ließe" "gelassen") accPrep ;  -- lasse dich (*zu) arbeiten
+  lassen_V2V = auxV2V (irregV "lassen" "läßt" "ließ" "ließe" "gelassen") accPrep ;
+                                            -- lasse dich (*zu) arbeiten
+  -- subject control verb:
+  versprechen_dat_V2V = subjV2V (mkV2V (irregV "versprechen" "verspricht"
+                                               "versprach" "verspräche" "versprochen") datPrep) ;
 
 }

--- a/tests/german/infinitives.lin.out
+++ b/tests/german/infinitives.lin.out
@@ -53,7 +53,7 @@ TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashV2a read_V2
 TestLangGer: ich will das Buch lesen
 TestLangEng: I want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich wage das Buch , zu lesen -- wrong
+TestLangGer: ich wage das Buch zu lesen
 TestLangEng: I dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 TestLangGer: ich muss das Buch lesen
@@ -68,22 +68,22 @@ TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV 
 TestLangGer: ich muss das Buch lesen wollen
 TestLangEng: I must want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich muss das Buch wagen , zu lesen -- wrong
+TestLangGer: ich muss das Buch zu lesen wagen
 TestLangEng: I must dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich will das Buch wagen , zu lesen -- wrong
+TestLangGer: ich will das Buch zu lesen wagen
 TestLangEng: I want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich wage das Buch , lesen zu wollen -- wrong
+TestLangGer: ich wage das Buch lesen zu wollen
 TestLangEng: I dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 TestLangGer: ich muss das Buch lesen wollen
 TestLangEng: I must want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: ich muss das Buch wagen , zu lesen -- wrong
+TestLangGer: ich muss das Buch wagen zu lesen -- wrong
 TestLangEng: I must dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: ich will das Buch wagen , zu lesen -- wrong
+TestLangGer: ich will das Buch wagen zu lesen -- wrong
 TestLangEng: I want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
 TestLangGer: ich wage , das Buch lesen zu wollen
@@ -101,22 +101,22 @@ TestLang: PredVP (UsePron i_Pron) (ComplVV wagen_VV (ComplVV want_VV (ComplSlash
 TestLangGer: ich wage , das Buch lesen zu wollen
 TestLangEng: I dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: ich muss das Buch wagen wollen , zu lesen -- wrong
+TestLangGer: ich muss das Buch zu lesen wagen wollen
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplSlash (SlashVV wagen_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
-TestLangGer: ich muss das Buch wagen wollen , zu lesen -- wrong
+TestLangGer: ich muss das Buch wagen wollen zu lesen -- wrong
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV want_VV (ComplVV wagen_VV (ComplSlash (SlashV2a read_V2) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))))
 TestLangGer: ich muss wagen wollen , das Buch zu lesen
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich muss das Buch wagen , lesen zu wollen -- wrong
+TestLangGer: ich muss das Buch wagen lesen zu wollen -- wrong
 TestLangEng: I must dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashVV must_VV (SlashVV want_VV (SlashVV wagen_VV (SlashV2a read_V2)))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich muss das Buch wagen , zu lesen wollen -- wrong
+TestLangGer: ich muss das Buch zu lesen wagen wollen
 TestLangEng: I must want to dare to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplSlash (SlashVV wagen_VV (SlashVV want_VV (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N))))
-TestLangGer: ich muss das Buch wagen , lesen zu wollen -- wrong
+TestLangGer: ich muss das Buch wagen lesen zu wollen -- wrong
 TestLangEng: I must dare to want to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplVV must_VV (ComplVV wagen_VV (ComplSlash (SlashVV want_VV (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))
 TestLangGer: ich muss wagen , das Buch lesen zu wollen
@@ -149,43 +149,43 @@ TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (Sla
 TestLangGer: ich bitte ihn , ihm zu versprechen , das Buch zu lesen
 TestLangEng: I beg him to promise him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich lasse das Buch ihn lesen -- wrong object order (3.9 SlashV2VNP)
+TestLangGer: ich lasse ihn das Buch lesen
 TestLangEng: I let him read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich bitte das Buch ihn , zu lesen -- wrong (SlashV2VNP)
+TestLangGer: ich bitte ihn das Buch , zu lesen -- wrong (SlashV2VNP)
 TestLangEng: I beg him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich verspreche das Buch ihm , zu lesen -- wrong (SlashV2VNP)
+TestLangGer: ich verspreche ihm das Buch , zu lesen -- wrong (SlashV2VNP)
 TestLangEng: I promise him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich bitte das Buch ihn die , zu lassen lesen -- wrong (SlahV2VNP) bitte die, ihn es lesen zu lassen
+TestLangGer: ich bitte die das Buch , ihn lesen zu lassen -- wrong (SlahV2VNP) 
 TestLangEng: I beg them to let him read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron they_Pron) (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich bitte das Buch ihn sie , zu lassen lesen -- wrong (SlashV2VNP)
+TestLangGer: ich bitte sie das Buch , ihn lesen zu lassen -- wrong (SlashV2VNP)
 TestLangEng: I beg them to let him read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
-TestLangGer: ich bitte die , das Buch ihn lesen zu lassen -- wrong obj order
+TestLangGer: ich bitte die , ihn das Buch lesen zu lassen
 TestLangEng: I beg them to let him read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP lassen_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
-TestLangGer: ich bitte sie , das Buch ihn lesen zu lassen -- wrong obj order
+TestLangGer: ich bitte sie , ihn das Buch lesen zu lassen
 TestLangEng: I beg them to let him read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (DetNP (DetQuant DefArt NumPl)) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich verspreche das Buch ihn denen , zu bitten zu lesen -- wrong (SlashV2VNP gf-3.9))
+TestLangGer: ich verspreche denen das Buch , ihn zu bitten , zu lesen -- wrong (SlashV2VNP))
 TestLangEng: I promise them to beg him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron they_Pron) (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich verspreche das Buch ihn ihnen , zu bitten zu lesen -- wrong (SlashV2VNP)
+TestLangGer: ich verspreche ihnen das Buch , ihn zu bitten , zu lesen -- wrong (SlashV2VNP)
 TestLangEng: I promise them to beg him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (DetNP (DetQuant DefArt NumPl)))
-TestLangGer: ich verspreche denen , das Buch ihn zu bitten , zu lesen -- wrong obj order
+TestLangGer: ich verspreche denen , ihn das Buch zu bitten , zu lesen
 TestLangEng: I promise them to beg him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron they_Pron))
-TestLangGer: ich verspreche ihnen , das Buch ihn zu bitten , zu lesen -- wrong obj order
+TestLangGer: ich verspreche ihnen , ihn das Buch zu bitten , zu lesen -- wrong
 TestLangEng: I promise them to beg him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2VNP beg_V2V (UsePron he_Pron) (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))
-TestLangGer: ich bitte das Buch ihm ihn , zu versprechen zu lesen -- wrong (SlashV2VNP)
+TestLangGer: ich bitte ihn das Buch , ihm zu versprechen , zu lesen -- wrong (SlashV2VNP)
 TestLangEng: I beg him to promise him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2VNP versprechen_dat_V2V (UsePron he_Pron) (SlashV2a read_V2)) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))) (UsePron he_Pron))
-TestLangGer: ich bitte ihn , das Buch ihm zu versprechen , zu lesen -- wrong (SlashV2VNP)
+TestLangGer: ich bitte ihn , ihm das Buch zu versprechen , zu lesen -- wrong (SlashV2VNP)
 TestLangEng: I beg him to promise him to read the book
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ReflVP (SlashV2a love_V2))) (UsePron youSg_Pron))
 TestLangGer: ich bitte dich , dich zu lieben
@@ -200,7 +200,7 @@ TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (Com
 TestLangGer: ich verspreche ihr , mich lieben zu wollen
 TestLangEng: I promise her to want to love herself -- wrong: myself
 TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V beg_V2V (ComplSlash (SlashV2Vneg versprechen_dat_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
-TestLangGer: ich will sie bitten , dir zu versprechen , sich nicht zu hassen
+TestLangGer: ich will sie bitten , dir zu versprechen , sich nicht zu hassen   (uses SlashV2Vneg)
 TestLangEng: I want to beg her to promise you not to hate yourself -- wrong: herself
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron she_Pron))
 TestLangGer: ich verspreche ihr , mich bei mir für es zu entschuldigen
@@ -209,7 +209,7 @@ TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V versprechen_dat_V2V (Com
 TestLangGer: ich verspreche uns , es mir zu geben
 TestLangEng: I promise us to give it itself -- wrong: myself
 TestLang: PredVP (UsePron i_Pron) (ComplVV want_VV (ComplSlash (SlashV2V versprechen_dat_V2V (ComplSlash (SlashV2Vneg beg_V2V (ReflVP (SlashV2a hate_V2))) (UsePron youSg_Pron))) (UsePron she_Pron)))
-TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu hassen
+TestLangGer: ich will ihr versprechen , dich zu bitten , dich nicht zu hassen  -- SlashV2Vneg
 TestLangEng: I want to promise her to beg you to not hate yourself
 TestLang: PredVP (UsePron i_Pron) (ComplSlash (SlashV2V beg_V2V (ComplSlash (ReflVPSlash entschuldigen_bei_fuer_rV3) (UsePron it_Pron))) (UsePron youSg_Pron))
 TestLangGer: ich bitte dich , dich bei dir für es zu entschuldigen
@@ -227,7 +227,7 @@ TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPas
 TestLangGer: das Buch , das wir nicht lesen mussten
 TestLangEng: the book that we hadn't to read
 TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (SlashV2a read_V2))))))
-TestLangGer: das Buch , das wir nicht wagten , zu lesen
+TestLangGer: das Buch , das wir nicht zu lesen wagten
 TestLangEng: the book that we didn't dare to read
 TestLang: DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast ASimul) PNeg (RelSlash IdRP (SlashVP (UsePron we_Pron) (SlashVV wagen_VV (Slash3V3 erklaeren_dat_V3 (UsePron she_Pron)))))))
 TestLangGer: das Buch , das wir nicht wagten , ihr zu erklären

--- a/tests/german/vp-paradigm.gfs
+++ b/tests/german/vp-paradigm.gfs
@@ -1,7 +1,7 @@
 -- To create vp-paradigm.out, I used changes of 30/6/2019 (in git branch vp-paradigm):
--- i ../../src/german/LangGer.gf  
+i ../../src/german/LangGer.gf
 -- Use gf --run < vp-paradigm.gfs > vp-paradigm.tmp to compare with gf-rgl.  HL 3/7/2019
-i alltenses/LangGer.gfo
+-- i alltenses/LangGer.gfo
   
 -- verb phrases with modal verb
 l -lang=Ger -table (PredVP (UsePron he_Pron) (ComplVV want_VV (UseV sleep_V)))
@@ -19,3 +19,7 @@ l -table (PredVP (DetCN (DetQuant DefArt NumSg) (UseN book_N)) (PassV2 read_V2))
 l PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (DetCN (DetQuant DefArt NumSg) (UseN woman_N))) (DetCN (DetQuant DefArt NumSg) (UseN book_N)))))) NoVoc
 
 l PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (UsePron i_Pron) (ComplSlash (Slash3V3 send_V3 (UsePron she_Pron)) (UsePron it_Pron))))) NoVoc
+
+-- relative clause from object np is not extracted behind vpart:
+l UseCl (TTAnt TPast AAnter) PNeg (PredVP (UsePron i_Pron) (ComplSlash (SlashV2a know_V2) (DetCN (DetQuant DefArt NumSg) (RelCN (UseN book_N) (UseRCl (TTAnt TPast AAnter) PPos (RelSlash IdRP (SlashVP (UsePron youPl_Pron) (SlashV2VNP beg_V2V (UsePron we_Pron) (AdvVPSlash (SlashV2a read_V2) today_Adv)))))))))
+


### PR DESCRIPTION
- removed Control and treat control verbs with VPSlash.objCtrl:Bool

- combined VP.inf and VP.infExt to VP.inf with inplace/extracted parts
  depending on Agr, to subj/obj-control reflexives in infinitival complements

- AllGer compiles from src in 250s (SlashV2VNP!), .gfo loads in 15s on x86_64