### PR TITLE
Fix most_Predet in Finnish

### DIFF
--- a/src/finnish/StructuralFin.gf
+++ b/src/finnish/StructuralFin.gf
@@ -62,7 +62,7 @@ concrete StructuralFin of Structural = CatFin **
   less_CAdv = X.mkCAdv "vähemmän" "kuin" ;
   many_Det = MorphoFin.mkDet Sg (snoun2nounBind (mkN "moni" "monia")) ;
   more_CAdv = X.mkCAdv "enemmän" "kuin" ;
-  most_Predet = {s = \\n,c => (nForms2N (dSuurin "useinta")).s ! NCase n (npform2case n c)} ;
+  most_Predet = {s = \\n,c => (nForms2N (dSuurin "usein")).s ! NCase n (npform2case n c)} ;
   much_Det = MorphoFin.mkDet Sg (snoun2nounBind (exceptNomN (mkN "paljo") "paljon")) ** {isNum = True} ; --Harmony not relevant, it's just a CommonNoun
   must_VV = mkVV (caseV genitive (mkV "täytyä")) ;
   no_Utt = ssp "INTERJ" "ei" ;


### PR DESCRIPTION
I have the following construct in my grammar:

Most what = PredetNP most_Predet (mkNP aPl_Det what) ;

Can be seen here https://github.com/rnd0101/gf-miniprojects/blob/master/crud/CrudI.gf as commented out, but also https://github.com/rnd0101/gf-miniprojects/blob/master/crud/Crud.gf#L40 as commented.

However, when I do


> i CrudEng.gf CrudFin.gf
Crud> gt Command (Do Get (Most Message)) | l
get most messages .
saa useintmmat viestit .

One can notice "useintmmat", where "useimmat" should be.
in StructuralFin.gf:

most_Predet = {s = \\n,c => (nForms2N (dSuurin "useinta")).s ! NCase n (npform2case n c)} ;

Should it be:

most_Predet = {s = \\n,c => (nForms2N (dSuurin "usein")).s ! NCase n (npform2case n c)} ;

at least my grammar produces the correct result then:

Crud> gt Command (Do Get (Most Message)) | l
get most messages .
saa useimmat viestit .
