### PR TITLE
Fix plgen of 3*a nouns, eg stroika

### DIFF
--- a/src/russian/InflectionRus.gf
+++ b/src/russian/InflectionRus.gf
@@ -179,7 +179,8 @@ oper
         <6, Stressed, _>  => stem1 + "е" + end;
         <6, _, _>         => stem1 + "и" + end;
         <5, _, _ + ("ь"|"й") + #consonant> => stem2 + "е" + end;
-        <3, _, _ + ("й" |"ж"|"ц"|"ч"|"ш"|"щ") + #consonant> => stem1 + "е" + stemEnd1 + end;  -- бабушка
+        <3, _, _ + "й" + #consonant> => stem2 + "е" + stemEnd1 + end;  -- стройка
+        <3, _, _ + ("ж"|"ц"|"ч"|"ш"|"щ") + #consonant> => stem1 + "е" + stemEnd1 + end;  -- бабушка
         <3, _, _ + #consonant> => stem1 + "о" + stemEnd1 + end ;  -- ^жшчщц - голубка
         <1, Stressed, _ + ("ь"|"й") + #consonant> => stem2 + "ё" + stemEnd1 + end ;
         <1, _, _ + ("ь"|"й") + #consonant> => stem2 + "е" + stemEnd1 + end ;


### PR DESCRIPTION
While dealing with my own grammar I discovered, that йка-ending Russian nouns have wrong ending in plural genitive:

Crud> l Doc (ActorDoes3 ActorTask Copy3 (Every Message) (Nof (IDig D_9) Setting))
task copies every message to 9 settings .
задание копирует каждое сообщение в 9 настройек .

The й should not be there in "настройек".

After this fix:

Crud> l Doc (ActorDoes3 ActorTask Copy3 (Every Message) (Nof (IDig D_9) Setting))
task copies every message to 9 settings .
задание копирует каждое сообщение в 9 настроек .

which is correct.