### PR TITLE
Minor fixes/cleanup in Estonian

### DIFF
--- a/src/estonian/CatEst.gf
+++ b/src/estonian/CatEst.gf
@@ -13,7 +13,7 @@ concrete CatEst of Cat = CommonX ** open HjkEst, ResEst, Prelude in {
 
 -- Sentence
 
-    Cl    = {s : ResEst.Tense => Anteriority => Polarity => SType => Str} ;
+    Cl    = {s : ResEst.Tense => Anteriority => Polarity => Str} ;
     ClSlash = {s : ResEst.Tense => Anteriority => Polarity => Str ; c2 : Compl} ;
     Imp   = {s : Polarity => Agr => Str} ;
 

--- a/src/estonian/ConjunctionEst.gf
+++ b/src/estonian/ConjunctionEst.gf
@@ -7,7 +7,9 @@ concrete ConjunctionEst of Conjunction =
 
     ConjS = conjunctDistrSS ;
 
-    ConjAdv = conjunctDistrSS ;
+    ConjAdv,
+    ConjAdV,
+    ConjIAdv = conjunctDistrSS ;
 
     ConjCN conj ss = conjunctDistrTable NForm conj ss ** ss ;
 
@@ -27,8 +29,8 @@ concrete ConjunctionEst of Conjunction =
 
     BaseS = twoSS ;
     ConsS = consrSS comma ;
-    BaseAdv = twoSS ;
-    ConsAdv = consrSS comma ;
+    BaseAdv, BaseAdV, BaseIAdv = twoSS ;
+    ConsAdv, ConsAdV, ConsIAdv = consrSS comma ;
     BaseCN x y = twoTable NForm (mergeCN x) y ** {postmod = y.postmod} ;
     ConsCN x xs = consrTable NForm comma (mergeCN x) xs ** xs ;
     BaseNP x y = twoTable NPForm (mergeNP x) y ** {a = conjAgr x.a y.a ; postmod = y.postmod} ;
@@ -41,26 +43,29 @@ concrete ConjunctionEst of Conjunction =
   lincat
     [S] = {s1,s2 : Str} ;
     [Adv] = {s1,s2 : Str} ;
+    [AdV] = {s1,s2 : Str} ;
+    [IAdv] = {s1,s2 : Str} ;
     [CN] = {s1,s2 : NForm => Str ; postmod : Str} ;
     [NP] = {s1,s2 : NPForm => Str ; a : Agr ; postmod : Str} ;
-    [AP] = {s1,s2 : {s : Bool => NForm => Str ; infl : Infl }} ;
+    [AP] = LinListAP ;
     [RS] = {s1,s2 : Agr => Str ; c : NPForm} ;
 
   oper
+
+    LinListAP : Type = {s1,s2 : {s : Bool => NForm => Str ; infl : Infl}} ;
+
     --Modified from prelude/Coordination.gf generic functions
-    twoTableAdj : (_,_ : AP) -> [AP] = \x,y ->
-    lin ListAP {
+    twoTableAdj : (_,_ : ResEst.APhrase) -> LinListAP = \x,y -> {
       s1 = x ;
       s2 = y
     } ;
 
-    consrTableAdj : Str -> APhrase -> [AP] -> [AP] = \c,x,xs ->
+    consrTableAdj : Str -> ResEst.APhrase -> LinListAP -> LinListAP = \c,x,xs ->
       let
         ap1 = xs.s1 ;
         ap2 = xs.s2
-      in
-       lin ListAP {s1 =
-             {s = \\isMod,nf =>
+      in {
+        s1 = {s = \\isMod,nf =>
                 case isMod of {
                   True => case <ap1.infl, ap2.infl> of {
                             <(Participle|Invariable),(Participle|Invariable)> =>
@@ -74,16 +79,15 @@ concrete ConjunctionEst of Conjunction =
                   False => ap1.s ! isMod ! nf ++ c ++ ap2.s ! isMod ! nf --kassid on valmid ja suured
                   } ;
               infl = Regular } ;
-       s2 = x ;
+        s2 = x ;
       } ;
 
 
-    conjunctDistrTableAdj : ConjunctionDistr -> [AP] -> AP =  \or,xs ->
+    conjunctDistrTableAdj : ConjunctionDistr -> LinListAP -> APhrase =  \or,xs ->
       let
         ap1 = xs.s1 ;
         ap2 = xs.s2 ;
-      in
-      lin AP {s = \\isMod,nf =>
+      in {s = \\isMod,nf =>
                 case isMod of {
                   True => case <ap1.infl, ap2.infl> of {
                             <(Participle|Invariable),(Participle|Invariable)> =>

--- a/src/estonian/ConstructionEst.gf
+++ b/src/estonian/ConstructionEst.gf
@@ -16,12 +16,12 @@ lin
     let n_years_AdA : AdA = lin AdA (mkUtt (lin NP (mkNP <lin Card card : Card> L.year_N)))
     in  mkVP (mkAP n_years_AdA L.old_A) ;
 
-  have_name_Cl x y = mkCl (mkNP (E.GenNP x) L.name_N) (lin NP y) ;
-  married_Cl x y = mkCl (mkNP and_Conj (lin NP x) (lin NP y)) (ParadigmsEst.mkAdv "abielus") ;
+  have_name_Cl x y = mkCl (mkNP (E.GenNP x) L.name_N) <lin NP y : NP> ;
+  married_Cl x y = mkCl (mkNP and_Conj <lin NP x : NP> <lin NP y : NP>) (ParadigmsEst.mkAdv "abielus") ;
 
   what_name_QCl x = mkQCl (mkIComp whatSg_IP) (mkNP (E.GenNP x) L.name_N) ;
-  how_old_QCl x = mkQCl (E.ICompAP (mkAP L.old_A)) (lin NP x) ;
-  how_far_QCl x = mkQCl (E.IAdvAdv L.far_Adv) (lin NP x) ;
+  how_old_QCl x = mkQCl (E.ICompAP (mkAP L.old_A)) <lin NP x : NP> ;
+  how_far_QCl x = mkQCl (E.IAdvAdv L.far_Adv) <lin NP x : NP> ;
 
 -- some more things
   weather_adjCl ap = mkCl (mkVP (lin AP ap)) ;
@@ -29,7 +29,10 @@ lin
   is_right_VP = mkVP have_V2 (lin NP (mkNP (ParadigmsEst.mkN "õigus"))) ;
   is_wrong_VP = mkVP (ParadigmsEst.mkV "eksima") ;
 
-  n_units_AP card cn a = mkAP (lin AdA (mkUtt (lin NP (mkNP <lin Card card : Card> (lin CN cn))))) (lin A a) ;
+  n_units_AP card cn a =
+    let x_inches_NP : NP = mkNP <lin Card card : Card> <lin CN cn : CN> ;
+        x_inches_AdA : AdA = lin AdA (mkUtt x_inches_NP) ;
+     in mkAP x_inches_AdA <lin A a : A> ;
 
 {-
   glass_of_CN  np =  mkCN (lin N2 (mkN2 (mkN "klaas") (casePrep partitive))) (lin NP np) | mkCN (lin N2 (mkN2 (mkN "klaasitäis") (casePrep partitive))) (lin NP np) ;

--- a/src/estonian/DocumentationEstFunctor.gf
+++ b/src/estonian/DocumentationEstFunctor.gf
@@ -23,7 +23,7 @@ lincat
 oper
   heading : N -> Str = \n -> (nounHeading n).s ;
 
-  caseplus2nf : N -> ResEst.Number -> CasePlus -> Str = \noun,num,cas ->
+  caseplus2nf : ResEst.Noun -> ResEst.Number -> CasePlus -> Str = \noun,num,cas ->
     noun.s ! NCase num cas.c ++ cas.suf ;
 
   caseplus2af : (AForm => Str) -> ResEst.Number -> CasePlus -> Str = \adj,num,cas ->
@@ -65,77 +65,77 @@ lin
   InflectionV v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v)) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V v : V>)) ;
     s2 = inflVerb v
     } ;
 
   InflectionV2 v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.something_NP)) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V2 v : V2> S.something_NP)) ;
     s2 = inflVerb v
     } ;
 
   InflectionV3 v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.something_NP S.something_NP)) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V3 v : V3> S.something_NP S.something_NP)) ;
     s2 = inflVerb v
     } ;
 
   InflectionV2V v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.we_NP (S.mkVP (L.sleep_V)))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V2V v : V2V> S.we_NP (S.mkVP (L.sleep_V)))) ;
     s2 = inflVerb v
     } ;
 
   InflectionV2S v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.we_NP (lin S (ss "...")))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V2S v : V2S> S.we_NP (lin S (ss "...")))) ;
     s2 = inflVerb v
     } ;
 
   InflectionV2Q v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.we_NP (lin QS (ss "...")))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V2Q v : V2Q> S.we_NP (lin QS (ss "...")))) ;
     s2 = inflVerb v
     } ;
 
   InflectionV2A v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v S.we_NP L.beautiful_A)) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin V2A v : V2A> S.we_NP L.beautiful_A)) ;
     s2 = inflVerb v
     } ;
 
   InflectionVV v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v (S.mkVP (L.sleep_V)))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin VV v : VV> (S.mkVP (L.sleep_V)))) ;
     s2 = inflVerb v
     } ;
 
   InflectionVS v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v (lin S (ss "...")))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin VS v : VS> (lin S (ss "...")))) ;
     s2 = inflVerb v
     } ;
 
   InflectionVQ v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v (lin QS (ss "...")))) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin VQ v : VQ> (lin QS (ss "...")))) ;
     s2 = inflVerb v
     } ;
 
   InflectionVA v = {
     t  = "v" ;
     s1 = heading1 (heading verb_Category) ++
-         paragraph (verbExample (S.mkCl S.she_NP v L.beautiful_A)) ;
+         paragraph (verbExample (S.mkCl S.she_NP <lin VA v : VA> L.beautiful_A)) ;
     s2 = inflVerb v
     } ;
 
@@ -143,16 +143,15 @@ oper
   verbExample : CatEst.Cl -> Str = \cl -> (S.mkUtt cl).s ;
 {-
 -} --# notpresent
-  inflVerb : CatEst.V -> Str = \verb ->
+  inflVerb : ResEst.Verb -> Str = \verb ->
      let
-       --verb = sverb2verbSep verb0 ;
        vfin : ResEst.VForm -> Str = \f ->
          verb.s ! f ;
        vinf : ResEst.InfForms -> Str = \if ->
          applyInfFormsV if verb.s ;
 
        nounNounHeading : Parameter -> Parameter -> Str = \n1,n2 ->
-         (S.mkUtt (G.PossNP (S.mkCN n1) (S.mkNP n2))).s ;
+         (S.mkUtt (G.PossNP (S.mkCN <lin N n1 : N>) (S.mkNP <lin N n2 : N>))).s ;
      in
        heading3 (nounNounHeading present_Parameter indicative_Parameter) ++
        frameTable (
@@ -254,7 +253,7 @@ oper
              td (vfin (PastPart Pass )))
           ) ; --}
 
-  inflNoun : (Number -> CasePlus -> Str) -> Str = \nouns ->
+  inflNoun : (ResEst.Number -> CasePlus -> Str) -> Str = \nouns ->
     frameTable (
           tr (th ""          ++ th (heading singular_Parameter)               ++ th (heading plural_Parameter)) ++
           tr (th (heading nominative_Parameter)  ++ td (nouns Sg Nominative)  ++ td (nouns Pl Nominative)) ++

--- a/src/estonian/ExtendEst.gf
+++ b/src/estonian/ExtendEst.gf
@@ -260,12 +260,12 @@ concrete ExtendEst of Extend =
     -- : NP -> VS -> Utt -> Cl ;      -- "I am here", she said
     FrontComplDirectVS np vs utt =
       let cl : Cl = PredVP np (UseV vs) ;
-       in cl ** {s = \\t,a,p,o => utt.s ++ bindComma ++ cl.s ! t ! a ! p ! o} ;
+       in cl ** {s = \\t,a,p => utt.s ++ bindComma ++ cl.s ! t ! a ! p} ;
 
     -- : NP -> VQ -> Utt -> Cl ;      -- "where", she asked
     FrontComplDirectVQ np vq utt =
       let cl : Cl = PredVP np (UseV vq) ;
-       in cl ** {s = \\t,a,p,o => utt.s ++ bindComma ++ cl.s ! t ! a ! p ! o} ;
+       in cl ** {s = \\t,a,p => utt.s ++ bindComma ++ cl.s ! t ! a ! p} ;
 
 
 ---------------------------------

--- a/src/estonian/ExtraEst.gf
+++ b/src/estonian/ExtraEst.gf
@@ -135,7 +135,7 @@ concrete ExtraEst of ExtraEstAbs = CatEst **
             (\\_,b,_ => linNP (NPCase Nom) np)
             (predV (verbOlema ** {sc = NPCase Nom}))) ;
       in
-      cl.s ! t ! ant ! bo ! SDecl ;
+        cl.s ! t ! ant ! bo ;
       c = NPCase Nom
       } ;
 
@@ -144,18 +144,20 @@ concrete ExtraEst of ExtraEstAbs = CatEst **
         (\\_,b,_ => linNP (NPCase Nom) np) (predV v)) ;
 
     ICompExistNP adv np =
-      let cl = mkClause (\_ -> adv.s ! np.a) np.a (insertObj
-        (\\_,b,_ => linNP (NPCase Nom) np) (predV (verbOlema ** {sc = NPCase Nom}))) ;
-      in  {
-        s = \\t,a,p => cl.s ! t ! a ! p ! SDecl
-      } ;
+      let subj : Polarity -> Str = \_ -> adv.s ! np.a ;
+          pred : VP = insertObj
+                        (\\_,b,_ => linNP (NPCase Nom) np)
+                        (predV (verbOlema ** {sc = NPCase Nom})) ;
+       in mkClause subj np.a pred ;
+
 
     IAdvPredNP iadv v np =
-      let cl = mkClause (\_ -> iadv.s) np.a (insertObj
-                 (\\_,b,_ => linNP v.sc np) (predV v)) ;
-      in  {
-        s = \\t,a,p => cl.s ! t ! a ! p ! SDecl
-      } ;
+      let subj : Polarity -> Str = \_ -> iadv.s ;
+          pred : VP = insertObj
+                        (\\_,b,_ => linNP v.sc np)
+                        (predV v) ;
+       in mkClause subj np.a pred ;
+
 
 --    i_implicPron = mkPronoun [] "minun" "minua" "minuna" "minuun" Sg P1 ;
     whatPart_IP = emptyIP ** {

--- a/src/estonian/ExtraEst.gf
+++ b/src/estonian/ExtraEst.gf
@@ -23,7 +23,7 @@ concrete ExtraEst of ExtraEstAbs = CatEst **
 ---      a = RAg (agrP3 num.n)
       } ;
   oper
-    caseCN : CasePlus -> NP -> CN -> CN = \c,np,cn -> cn ** {
+    caseCN : CasePlus -> NPhrase -> CNoun -> CNoun = \c,np,cn -> cn ** {
       s = \\nf => appCompl True Pos (P.casePrep c) np ++ cn.s ! nf
       } ;
 
@@ -38,7 +38,7 @@ concrete ExtraEst of ExtraEstAbs = CatEst **
     linVPI : InfForms -> LinVPI -> Str = \inf,vpi -> vpi.s ! inf.stem ;
 
     -- Version that uses InfStem
-    infVPIF : NPForm -> Polarity -> Agr -> VP -> InfStem -> Str = \sc,pol,agr,vp,if ->
+    infVPIF : NPForm -> Polarity -> Agr -> ResEst.VP -> InfStem -> Str = \sc,pol,agr,vp,if ->
       infVPAnt Simul sc pol agr vp {stem=if ; suf="a"} ;
 
   lin
@@ -145,17 +145,17 @@ concrete ExtraEst of ExtraEstAbs = CatEst **
 
     ICompExistNP adv np =
       let subj : Polarity -> Str = \_ -> adv.s ! np.a ;
-          pred : VP = insertObj
-                        (\\_,b,_ => linNP (NPCase Nom) np)
-                        (predV (verbOlema ** {sc = NPCase Nom})) ;
+          pred : ResEst.VP = insertObj
+                               (\\_,b,_ => linNP (NPCase Nom) np)
+                               (predV (verbOlema ** {sc = NPCase Nom})) ;
        in mkClause subj np.a pred ;
 
 
     IAdvPredNP iadv v np =
       let subj : Polarity -> Str = \_ -> iadv.s ;
-          pred : VP = insertObj
-                        (\\_,b,_ => linNP v.sc np)
-                        (predV v) ;
+          pred : ResEst.VP = insertObj
+                               (\\_,b,_ => linNP v.sc np)
+                               (predV v) ;
        in mkClause subj np.a pred ;
 
 

--- a/src/estonian/ExtraEstAbs.gf
+++ b/src/estonian/ExtraEstAbs.gf
@@ -1,6 +1,6 @@
 abstract ExtraEstAbs = Extra [
-  GenNP,GenIP,GenRP,
-  PassVPSlash, PassAgentVPSlash,
+  GenNP,GenIP,GenRP,IP,IQuant,Num,CN,RP,
+  PassVPSlash, PassAgentVPSlash, VPSlash,
   VPI,ListVPI,BaseVPI,ConsVPI,MkVPI,ComplVPIVV,ConjVPI,
   VPS,ListVPS,BaseVPS,ConsVPS,ConjVPS,MkVPS,PredVPS,ConjVPS,Tense,Temp,Pol,S,
   VV,VP,Conj,NP,Quant,IAdv,IComp,ICompAP,IAdvAdv,Adv,AP, Pron, ProDrop] ** {

--- a/src/estonian/IdiomEst.gf
+++ b/src/estonian/IdiomEst.gf
@@ -13,8 +13,8 @@ concrete IdiomEst of Idiom = CatEst **
 
     ExistIP ip =
       let cas : NPForm = NPCase Nom ; ---- also partitive in Extra
-          vp : VP = insertObj (\\_,b,_ => "olemas") (predV olla) ;
-          subj : NP = ip ** {isPron = False ; a = agrP3 ip.n} ;
+          vp : MorphoEst.VP = insertObj (\\_,b,_ => "olemas") (predV olla) ;
+          subj : MorphoEst.NPhrase = ip ** {isPron = False ; a = agrP3 ip.n} ;
        in existClause (subjForm subj cas) (agrP3 Sg) vp ;
 
 -- Notice the nominative in the cleft $NP$: "se on Matti josta Liisa pitÃ¤Ã¤"

--- a/src/estonian/IdiomEst.gf
+++ b/src/estonian/IdiomEst.gf
@@ -5,23 +5,17 @@ concrete IdiomEst of Idiom = CatEst **
 
   lin
     ExistNP np =
-      let
-        cas : Polarity -> NPForm = \p -> case p of {
-          Pos => NPCase Nom ; -- on olemas lammas
-          Neg => NPCase Part  -- ei ole olemas lammast
-          } ;
-        vp = insertObj (\\_,b,_ => "olemas" ++ linNP (cas b) np) (predV olla)
-      in
-      existClause noSubj (agrP3 Sg) vp ;
+      let cas : Polarity -> NPForm = \p -> case p of {
+            Pos => NPCase Nom ;    -- on olemas lammas
+            Neg => NPCase Part } ; -- ei ole olemas lammast
+          vp = insertObj (\\_,b,_ => "olemas" ++ linNP (cas b) np) (predV olla)
+       in existClause noSubj (agrP3 Sg) vp ;
 
     ExistIP ip =
-      let
-        cas : NPForm = NPCase Nom ; ---- also partitive in Extra
-        vp = insertObj (\\_,b,_ => "olemas") (predV olla) ;
-        cl = existClause (subjForm (ip ** {isPron = False ; a = agrP3 ip.n}) cas) (agrP3 Sg) vp
-      in {
-        s = \\t,a,p => cl.s ! t ! a ! p ! SDecl
-        } ;
+      let cas : NPForm = NPCase Nom ; ---- also partitive in Extra
+          vp : VP = insertObj (\\_,b,_ => "olemas") (predV olla) ;
+          subj : NP = ip ** {isPron = False ; a = agrP3 ip.n} ;
+       in existClause (subjForm subj cas) (agrP3 Sg) vp ;
 
 -- Notice the nominative in the cleft $NP$: "se on Matti josta Liisa pitÃ¤Ã¤"
 -- Est: "see on Mati, kellest Liis lugu peab"

--- a/src/estonian/NounEst.gf
+++ b/src/estonian/NounEst.gf
@@ -216,8 +216,7 @@ concrete NounEst of Noun = CatEst ** open ResEst, HjkEst, MorphoEst, Prelude in 
 
   oper
     numN : NForm -> Number = \nf -> case nf of {
-      NCase n _ => n ;
-      _ => Sg ---
+      NCase n _ => n
       } ;
 
 

--- a/src/estonian/NumeralEst.gf
+++ b/src/estonian/NumeralEst.gf
@@ -73,7 +73,7 @@ oper
       }
     } ;
 
-  nBIND : Number -> Str = \n -> case n of {Sg => [] ; _ => BIND} ; -- no BIND after silent 1
+  nBIND : MorphoEst.Number -> Str = \n -> case n of {Sg => [] ; _ => BIND} ; -- no BIND after silent 1
 
 param
   NumPlace = NumIndep | NumAttr  ;

--- a/src/estonian/ParadigmsEst.gf
+++ b/src/estonian/ParadigmsEst.gf
@@ -617,9 +617,10 @@ oper
     mkA : N -> A = \n -> noun2adjDeg n ** {infl = Regular} ;
     mkA : N -> (parem,parim : Str) -> A = regAdjective ;
     mkA : N -> (infl : Infl) -> A = \n,infl -> noun2adjDeg n ** {infl = infl} ;
-    -- TODO: temporary usage of regAdjective1
     mkA : N -> (valmim,valmeim : Str) -> (infl : Infl) -> A =
-		\n,c,s,infl -> (regAdjective1 n c s) ** {infl = infl} ;
+		\n,c,s,infl ->
+      let regA : A = regAdjective n c s
+       in regA ** {infl = infl} ;
   } ;
 
   invA balti = lin A {s = \\_,_ => balti ; infl = Invariable} ;
@@ -643,11 +644,6 @@ oper
       (noun2adj posit)
       (noun2adjComp False (nForms2N (hjk_type_IVb_audit compar "a")))
       (noun2adjComp False (nForms2N (hjk_type_IVb_audit superl "a"))) ;
-
-  -- TODO: this is a temporary hack that converts A ~> Adjective.
-  -- The caller needs this otherwise ** fails.
-  -- This should be cleaned up but I don't know how (K).
-  regAdjective1 : Noun -> Str -> Str -> Adjective = regAdjective ;
 
   -- Adjectives whose comparison forms can be derived from the sg gen.
   -- In case of comparative this fails only for 70 adjectives.

--- a/src/estonian/QuestionEst.gf
+++ b/src/estonian/QuestionEst.gf
@@ -5,15 +5,10 @@ concrete QuestionEst of Question = CatEst ** open ResEst, Prelude in {
   lin
 
     QuestCl cl = {
-      s = \\t,a,p => cl.s ! t ! a ! p ! SQuest
+      s = \\t,a,p => "kas" ++ cl.s ! t ! a ! p
       } ;
 
-    QuestVP ip vp =
-      let
-        cl = mkClause (subjForm (ip ** {isPron = False ; a = agrP3 ip.n}) vp.sc) (agrP3 ip.n) vp
-      in {
-        s = \\t,a,p => cl.s ! t ! a ! p ! SDecl
-        } ;
+    QuestVP ip vp = mkClause (subjForm (ip ** {isPron = False ; a = agrP3 ip.n}) vp.sc) (agrP3 ip.n) vp ;
 
     QuestSlash ip slash = {
       s = \\t,a,p =>
@@ -25,7 +20,7 @@ concrete QuestionEst of Question = CatEst ** open ResEst, Prelude in {
       } ;
 
     QuestIAdv iadv cl = {
-      s = \\t,a,p => iadv.s ++ cl.s ! t ! a ! p ! SDecl
+      s = \\t,a,p => iadv.s ++ cl.s ! t ! a ! p
       } ;
 
     QuestIComp icomp np = {
@@ -34,7 +29,7 @@ concrete QuestionEst of Question = CatEst ** open ResEst, Prelude in {
           vp = predV (verbOlema ** {sc = NPCase Nom}) ;
           cl = mkClause (subjForm np vp.sc) np.a vp ;
         in
-        icomp.s ! np.a ++ cl.s ! t ! a ! p ! SDecl
+        icomp.s ! np.a ++ cl.s ! t ! a ! p
       } ;
 
     PrepIP p ip = {s =

--- a/src/estonian/RelativeEst.gf
+++ b/src/estonian/RelativeEst.gf
@@ -5,7 +5,7 @@ concrete RelativeEst of Relative = CatEst ** open Prelude, ResEst, MorphoEst in 
   lin
 
     RelCl cl = {
-      s = \\t,a,p,_ => "nii" ++ "et" ++ cl.s ! t ! a ! p ! SDecl ;
+      s = \\t,a,p,_ => "nii" ++ "et" ++ cl.s ! t ! a ! p ;
       ---- sellainen
       c = NPCase Nom
       } ;
@@ -23,7 +23,7 @@ concrete RelativeEst of Relative = CatEst ** open Prelude, ResEst, MorphoEst in 
                         vp.sc)
                       agr vp
         in
-        cl.s ! t ! ant ! b ! SDecl ;
+        cl.s ! t ! ant ! b ;
       c = NPCase Nom
       } ;
 

--- a/src/estonian/ResEst.gf
+++ b/src/estonian/ResEst.gf
@@ -180,8 +180,6 @@ oper
     glue (vf  ! Inf   if.stem) if.suf ;
 
 param
-  SType = SDecl | SQuest | SInv ;
-
 --2 For $Relative$
 
     RAgr = RNoAg | RAg Agr ;
@@ -365,51 +363,34 @@ oper
 -- For $Sentence$.
 
   Clause : Type = {
-    s : Tense => Anteriority => Polarity => SType => Str
+    s : Tense => Anteriority => Polarity => Str
     } ;
 
   ClausePlus : Type = {
     s : Tense => Anteriority => Polarity => {subj,fin,inf,compl,adv,p,ext : Str}
     } ;
 
-  -- The Finnish version of SQuest featured a word order change and
-  -- the question particle "ko". The Estonian version just prefixes the
-  -- declarative sentence with the yes/no-queryword "kas".
-  -- SQuest: "kas" + SDecl
-  -- It would be also correct to use the Finnish structure, just without the ko-particle.
-  -- Inari: added a third SType, SInv.
-  -- Not sure if SInv is needed, but keeping it for possible future use.
-  -- There's need for an inverted word order with auxiliary verbs; infVP handles that. ComplVV calls infVP, which inverts the word order for the complement VP, and puts it into the resulting VP's `compl' field.
-  -- SInv made by mkClause would be for cases where you just need to construct an inverted word order, and then call it from some other place; application grammar (TODO: api oper for SType) or ExtraEst.
   mkClause : (Polarity -> Str) -> Agr -> VP -> Clause = \sub,agr,vp ->
    { s = \\t,a,b =>
       let
         c = (mkClausePlus sub agr vp).s ! t ! a ! b ;
-        --                 saan              sinust     aru    0
-        --       ma        olen     täna     sinust     aru    saanud
-        declCl = c.subj ++ c.fin ++ c.adv ++ c.compl ++ c.p ++ c.inf ++ c.ext ;
-        --                                [sind näha]  0      tahtnud
-        --      täna     olen     ma        sinust     aru    saanud
-        invCl = c.adv ++ c.fin ++ c.subj ++ c.compl ++ c.p ++ c.inf ++ c.ext
       in
-         table {
-           SDecl  => declCl ;
-           SQuest => "kas" ++ declCl ;
-           SInv   => invCl
-         }
-      } ;
+        --        saan              sinust     aru
+        -- ma     olen     täna     sinust     aru    saanud
+        c.subj ++ c.fin ++ c.adv ++ c.compl ++ c.p ++ c.inf ++ c.ext ;
+   } ;
 
   existClause : (Polarity -> Str) -> Agr -> VP -> Clause = \sub,agr,vp ->
    { s = \\t,a,b =>
       let
         c = (mkClausePlus sub agr vp).s ! t ! a ! b ;
-        --       (mis)     on       olnud    olemas (lammas)
-        declCl = c.subj ++ c.fin ++ c.inf ++ c.compl ;
       in
-         table {
-           SQuest => "kas" ++ declCl ;
-           _      => declCl
-         }
+        -- c.subj ++ c.fin ++ c.inf ++ c.compl ;
+        --        saan              sinust     aru
+        -- ma     olen     täna     sinust     aru    saanud
+        -- (mis)  on       olnud    täna            olemas …
+        c.subj ++ c.fin ++ c.inf ++ c.adv ++ c.p ++ c.compl ++ c.ext ;
+
     } ;
 
   mkClausePlus : (Polarity -> Str) -> Agr -> VP -> ClausePlus =

--- a/src/estonian/SentenceEst.gf
+++ b/src/estonian/SentenceEst.gf
@@ -19,8 +19,7 @@ concrete SentenceEst of Sentence = CatEst ** open Prelude, ResEst in {
 
 -- The object case is formed at the use site of $c2$, in $Relative$ and $Question$.
 
-    SlashVP np vp = {
-      s = \\t,a,p => (mkClause (subjForm np vp.sc) np.a vp).s ! t ! a ! p ! SDecl ;
+    SlashVP np vp =  mkClause (subjForm np vp.sc) np.a vp ** {
       c2 = vp.c2
       } ;
 
@@ -29,26 +28,23 @@ concrete SentenceEst of Sentence = CatEst ** open Prelude, ResEst in {
       c2 = slash.c2
       } ;
 
-    SlashPrep cl prep = {
-      s = \\t,a,p => cl.s ! t ! a ! p ! SDecl ;
+    SlashPrep cl prep = cl ** {
       c2 = prep
       } ;
 
-    SlashVS np vs slash = {
-      s = \\t,a,p =>
-        (mkClause (subjForm np vs.sc) np.a
-          (insertExtrapos (etta_Conj ++ slash.s)
-             (predV vs))
-        ).s ! t ! a ! p ! SDecl ;
-      c2 = slash.c2
-      } ;
+    SlashVS np vs slash =
+      let cl : Clause =
+            mkClause
+              (subjForm np vs.sc) np.a
+              (insertExtrapos (etta_Conj ++ slash.s) (predV vs))
+       in cl ** {c2 = slash.c2} ;
 
 
     EmbedS  s  = {s = etta_Conj ++ s.s} ;
     EmbedQS qs = {s = qs.s} ;
     EmbedVP vp = {s = infVP (NPCase Nom) Pos (agrP3 Sg) vp InfDa} ; --- case,pol,agr,infform
 
-    UseCl  t p cl = {s = t.s ++ p.s ++ cl.s ! t.t ! t.a ! p.p ! SDecl} ;
+    UseCl  t p cl = {s = t.s ++ p.s ++ cl.s ! t.t ! t.a ! p.p} ;
     UseQCl t p cl = {s = t.s ++ p.s ++ cl.s ! t.t ! t.a ! p.p} ;
     UseRCl t p cl = {
       s = \\r => t.s ++ p.s ++ cl.s ! t.t ! t.a ! p.p ! r ;

--- a/src/estonian/TerminologyEst.gf
+++ b/src/estonian/TerminologyEst.gf
@@ -91,7 +91,7 @@ lin
   nounHeading n = ss (n.s ! NCase Sg Nom) ;
   nounPluralHeading n = ss (n.s ! NCase Pl Nom) ;
 
-  formGF_N = mkN "vorm" ;
+  formGr_N = mkN "vorm" ;
   exampleGr_N = mkN "näide" ;
 
 }

--- a/src/estonian/VerbEst.gf
+++ b/src/estonian/VerbEst.gf
@@ -83,7 +83,7 @@ concrete VerbEst of Verb = CatEst ** open Prelude, ResEst in {
 
     ReflVP v = insertObjPre (\\fin,b,agr => appCompl fin b v.c2 (reflPron agr)) v ;
 
-    PassV2 v = let vp : VP = passiveVP (predV v) in vp ** {
+    PassV2 v = let vp : ResEst.VP = passiveVP (predV v) in vp ** {
       sc = compl2subjcase v.c2  -- koer valitakse ; koerale räägitakse
       } ;
 


### PR DESCRIPTION
Mostly just removing dead code and lock field warnings. The only nontrivial change is to the internal oper existClause, which so far has been used only from certain functions, and it dropped a bunch of fields from the argument, because those fields were empty anyway. I added those fields back to the output, with the idea that an application grammar might use that internal oper, and the argument may have any fields. (It was anyway bad behaviour in the first place to drop those fields.)