### PR TITLE
(Fin) New forms to 2-argument mkN opers in ParadigmsFin

### DIFF
--- a/src/finnish/ParadigmsFin.gf
+++ b/src/finnish/ParadigmsFin.gf
@@ -499,8 +499,15 @@ mkVS = overload {
 ----  mkNA : N -> A = snoun2sadj ;
 
   mk1N : (talo : Str) -> N = \s -> lin N (nforms2snoun (nForms1 s)) ;
-  mk2N : (talo,taloja : Str) -> N = \s,t -> lin N (nforms2snoun (nForms2 s t)) ;
-  mk2NsgGen : (talo,talon : Str) -> N = \sgnom,sggen -> lin N (nforms2snoun (nForms2sgGen sgnom sggen)) ; -- When we have access to the singular genitive but not plural partitive, e.g. from some dump of lemmatised nouns
+  -- When we have access to the some other form than plural partitive, e.g. from some dump of lemmatised nouns
+  mk2NsgGen : (talo,talon : Str) -> N =
+    \sgnom,sggen -> lin N (nforms2snoun (nForms2sgGen sgnom sggen)) ;
+  mk2NsgPar : (talo,taloa : Str) -> N =
+    \sgnom,sgpar -> lin N (nforms2snoun (nForms2sgPar sgnom sgpar)) ;
+  mk2NsgIll : (talo,taloon : Str) -> N =
+    \sgnom,sgill -> lin N (nforms2snoun (nForms2sgIll sgnom sgill)) ;
+
+
   mk3N : (talo,talon,taloja : Str) -> N = \s,t,u -> lin N (nforms2snoun (nForms3 s t u)) ;
   mk4N : (talo,talon,taloa,taloja : Str) -> N = \s,t,u,v ->
       lin N (nforms2snoun (nForms4 s t u v)) ;
@@ -671,6 +678,7 @@ mkVS = overload {
       _  => case <sydan,sydamen> of {
               <_ + "s",         _ + "ksen"> => dJalas sydan ;
               <_ + "s",         _ + "den"> => dLujuus sydan ;
+              <_ + "s",         _ + "hen"> => d42 sydan ;
               <_ + ("as"|"äs"), _ + ("aan"|"ään")> => dRae sydan sydamen ;
               <_ + "n",         _ + "men"> => dLiitin sydan sydamen ;
               <_ + "in",        _ + ("imman"|"immän")> => dSuurin sydan ;
@@ -679,11 +687,76 @@ mkVS = overload {
               <_ + "mpi",       _ + ("emman" | "emmän")> => dSuurempi sydan ;
               <_ + "e",         _ + "een"> => dRae sydan sydamen ;
               <_ + "e",         _ + "en"> => dNukke sydan sydamen ;
+              <_ + "ut",        _ + "een"> => dOttanut sydan ;  -- kuollut, kuolleen
+              <_ + "ut",        _ + "en"> => dRae sydan sydamen ; -- olut, oluen
               _ => regSydan  -- TODO: see what cases still fail and if SgGen helps
            }
       } ;
 
---- this is a paradigm hidden from the API. It should not be used without caution
+  -- like nForms2, but 2nd argument is Sg Partitive
+  nForms2sgPar : (sydan,sydanta : Str) -> NForms = \sydan,sydanta ->
+    table {
+      2 => sydanta ; -- insert the given Sg Par form in the table
+      n => guessedSydan ! n} -- otherwise, use the guessed forms
+    where {
+      -- a couple of guesses for genitive
+      oven : Str = init sydan + "en" ;            --  ov|i|  -> |en|
+      kynnen : Str = init (init sydan) + "nen" ;  -- kyn|si| -> |nen|
+      r : Str = case last sydan of {"n" => "m" ; x => x} ; -- gen stem consonant for piennar, liitin
+      pientaren : Str = strongGrade (init sydan) + r + "en" ;
+
+      -- then we form a full paradigm with a genitive guessed from the SgNom+SgPar
+      guessedSydan : NForms = case <sydan,sydanta> of {
+        <_ + "i", _ + ("ea"|"eä")> => dArpi sydan oven ;
+        <_ + "nsi", _ + "ntt" + ("a"|"ä")> => dArpi sydan kynnen ;
+        <_ + ("psi"|"tsi"), _ + ("sta"|"stä")> => dArpi sydan oven ; -- laps|i|->|en|,  veits|i|->|en|
+        <_ + "i", _ + ("nta"|"ntä")> => dArpi sydan oven ;
+        <_ + "r", _ + ("rta"|"rtä")> => dPiennar sydan pientaren ;
+        <_ + ("on"|"ön"), _ + ("nta"|"ntä")> => dOnneton sydan ;
+        <_ + "in", _ + ("nta"|"ntä")> => dLiitin sydan pientaren ; -- can't distinguish between dLämmin or dLiitin from Sg Par only
+        <_ + "s", ("sta"|"stä")> => dJalas sydan ;
+        <_ + ("us"|"ys"), ("tta"|"ttä")> => dLujuus sydan ; -- can't distinguish between dLujuus and dKaunis from Sg Par only
+        <_ + "s"        , ("tta"|"ttä")> => dKaunis sydan ;
+        <_ + "t"        , ("tta"|"ttä")> => dRae sydan oven ; -- olu|t| -> |en| — can't distinguish between kuollut and olut
+        _ => nForms1 sydan }
+      } ;
+
+  -- like nForms2, but 2nd argument is Sg Illative
+  nForms2sgIll : (sydan,sydameen : Str) -> NForms = \sydan,sydameen ->
+    table {
+      4 => sydameen ; -- insert the given Sg Ill form in the table
+      n => guessedSydan ! n} -- otherwise, use the guessed forms
+    where {
+      -- a couple of guesses for genitive
+      oven : Str = init (init sydameen) + "n" ; -- keep grade from Ill: ove|en| -> ove|n| ; liittime|en| -> liittime|n|
+      käden : Str = weakGrade (init (init sydameen)) + "n" ; -- weaken grade from Ill: kä|tee|n  -> kä|de|n
+      rakeen : Str = strongGrade sydan + "en" ;              -- strong grade from Nom: ra||e -> ra|k|e+en
+
+      guessedSydan : NForms = case <sydan,sydameen> of {
+        <_ + ("aa"|"ää"|"uu"|"yy"|"oo"|"öö"),
+                   _ + "seen"> => dPaluu sydan ;
+        <_ + "si", _ + "teen"> => dArpi sydan käden ; -- käsi, kynsi
+        <_ + "i",  _ + "een"> => dArpi sydan oven ; -- ovi, lapsi, virsi
+        <_ + "e",  _ + "eeseen"> => dRae sydan rakeen ; -- hame, rae
+        <_ + "e",  _ + "een"> => dNukke sydan käden ; -- nukke
+        <_ + "t",  _ + "eeseen"> => dOttanut sydan ; -- kuollut
+        <_ + "t",  _ + "een"> => dRae sydan oven ; -- olut
+        <_ + "n",  _ + "meen"> => dLiitin sydan oven ;
+        <_ + "n",  _ + ("maan"|"mään")> => dOnneton sydan ;
+        <_ + "s",  _ + "kseen"> => dJalas sydan ; -- Sg Ill can distinguish between jalas, lujuus, kahdeksas, kaunis and mies
+        <_ + "s",  _ + "nteen"> => d45 sydan ;
+        <_ + "s",  _ + "teen"> => dLujuus sydan ;
+        <_ + "s",  _ + "seen"> => dKaunis sydan ;
+        <_ + "s",  _ + "heen"> => d42 sydan ;
+        _ => nForms1 sydan }
+    } ;
+
+
+
+
+
+
+  --- this is a paradigm hidden from the API. It should not be used without caution
   invarN : Str -> N = \s -> <lin N {s = \\_ => s ; h = Back} : N> ;
 
   mkN2 = overload {

--- a/src/finnish/ParadigmsFin.gf
+++ b/src/finnish/ParadigmsFin.gf
@@ -499,6 +499,16 @@ mkVS = overload {
 ----  mkNA : N -> A = snoun2sadj ;
 
   mk1N : (talo : Str) -> N = \s -> lin N (nforms2snoun (nForms1 s)) ;
+
+  -- Best results for 2-argument smart paradigm come with Pl Part as second argument.
+  -- But we allow Sg Gen + Pl Nom as well, since they could be common mistakes.
+  -- For other numbers and cases as the 2nd argument, see mk2Nsg{Gen,Par,Ill} (hidden from API).
+  mk2N : (talo,taloja : Str) -> N = \s,t -> case t of {
+    sydame + "n" => mk2NsgGen s t ;            -- Sg Gen
+    sydame + "t" => mk2NsgGen s (sydame+"n") ; -- Pl Nom
+    _ => lin N (nforms2snoun (nForms2 s t))    -- Default: Pl Par
+  } ;
+
   -- When we have access to the some other form than plural partitive, e.g. from some dump of lemmatised nouns
   mk2NsgGen : (talo,talon : Str) -> N =
     \sgnom,sggen -> lin N (nforms2snoun (nForms2sgGen sgnom sggen)) ;
@@ -750,10 +760,6 @@ mkVS = overload {
         <_ + "s",  _ + "heen"> => d42 sydan ;
         _ => nForms1 sydan }
     } ;
-
-
-
-
 
 
   --- this is a paradigm hidden from the API. It should not be used without caution


### PR DESCRIPTION
Now featuring

- 3 explicit functions hidden from the API:
  - mk2NsgGen, mk2NsgPar, mk2NsgIll
- Default 2-argument mkN also accepts singular genitive and plural nominative—best results still with plural partitive.  