### PR TITLE
Small fixes in Finnish noun paradigms

### DIFF
--- a/src/finnish/MorphoFin.gf
+++ b/src/finnish/MorphoFin.gf
@@ -288,34 +288,40 @@ resource MorphoFin = ResFin ** open Prelude in {
       (jalaksi + "n" + a) (jalaksi + "ss" + a) (jalaksi + "in") ;
 
   dSDP : Str -> NForms = \SDP ->
-    let
-      c = case Predef.toUpper (last SDP) of {
-        "A" =>
-           <"n","ta","na","han","iden","ita","ina","issa","ihin"> ;
-        "B" | "C" | "D" | "E" | "G" | "P" | "T" | "V" | "W" =>
-           <"n","tä","nä","hen","iden","itä","inä","issä","ihin"> ;
-        "F" | "L" | "M" | "N" | "R" | "S" | "X" =>
-           <"n","ää","nä","ään","ien","iä","inä","issä","iin"> ;
-        "H" | "K" | "O" | "Å" =>
-           <"n","ta","na","hon","iden","ita","ina","issa","ihin"> ;
-        "I" | "J" =>
-           <"n","tä","nä","hin","iden","itä","inä","issä","ihin"> ;
-        "Q" | "U" =>
-           <"n","ta","na","hun","iden","ita","ina","issa","ihin"> ;
-        "Z" =>
-           <"n","aa","na","aan","ojen","oja","oina","oissa","oihin"> ;
-        "Ä" =>
-           <"n","tä","nä","hän","iden","itä","inä","issä","ihin"> ;
-        "Ö" =>
-           <"n","tä","nä","hön","iden","itä","inä","issä","ihin"> ;
-        "Y" =>
-           <"n","tä","nä","hyn","iden","itä","inä","issä","ihin"> ;
-        _ => Predef.error (["illegal abbreviation"] ++ SDP)
-        } ;
+    let c : Str*Str*Str*Str*Str*Str*Str*Str*Str = case SDP of {
+          _ + P@? + (")"|"]"|"!"|"?"|"-") -- ignore punctuation after vowel, e.g. Poly(A):n
+                  => getCases P SDP ;
+          _ + P@? => getCases P SDP } ;
     in nForms10
       SDP (SDP + ":" + c.p1) (SDP + ":" + c.p2) (SDP + ":" + c.p3)
       (SDP + ":" + c.p4) (SDP + ":" + c.p5) (SDP + ":" + c.p6)
       (SDP + ":" + c.p7) (SDP + ":" + c.p8) (SDP + ":" + c.p9) ;
+
+    -- Helper function for dSDP
+    getCases : Str -> Str -> Str*Str*Str*Str*Str*Str*Str*Str*Str ;
+    getCases c errorMsg = case Predef.toUpper c of {
+      "A" =>
+          <"n","ta","na","han","iden","ita","ina","issa","ihin"> ;
+      "B" | "C" | "D" | "E" | "G" | "P" | "T" | "V" | "W" =>
+          <"n","tä","nä","hen","iden","itä","inä","issä","ihin"> ;
+      "F" | "L" | "M" | "N" | "R" | "S" | "X" =>
+          <"n","ää","nä","ään","ien","iä","inä","issä","iin"> ;
+      "H" | "K" | "O" | "Å" =>
+          <"n","ta","na","hon","iden","ita","ina","issa","ihin"> ;
+      "I" | "J" =>
+          <"n","tä","nä","hin","iden","itä","inä","issä","ihin"> ;
+      "Q" | "U" =>
+          <"n","ta","na","hun","iden","ita","ina","issa","ihin"> ;
+      "Z" =>
+          <"n","aa","na","aan","ojen","oja","oina","oissa","oihin"> ;
+      "Ä" =>
+          <"n","tä","nä","hän","iden","itä","inä","issä","ihin"> ;
+      "Ö" =>
+          <"n","tä","nä","hön","iden","itä","inä","issä","ihin"> ;
+      "Y" =>
+          <"n","tä","nä","hyn","iden","itä","inä","issä","ihin"> ;
+      _ => Predef.error (["illegal abbreviation"] ++ errorMsg) } ;
+
 
 -- for adjective comparison
 

--- a/src/finnish/ParadigmsFin.gf
+++ b/src/finnish/ParadigmsFin.gf
@@ -699,9 +699,15 @@ mkVS = overload {
               <_ + "e",         _ + "en"> => dNukke sydan sydamen ;
               <_ + "ut",        _ + "een"> => dOttanut sydan ;  -- kuollut, kuolleen
               <_ + "ut",        _ + "en"> => dRae sydan sydamen ; -- olut, oluen
-              _ => regSydan  -- TODO: see what cases still fail and if SgGen helps
+              <_,               _ + ":n"> => dSDP sydan ;
+              <_ + #consonant,  _ + #consonant + "in"> => dUnix sydan ;
+              _ => table { -- TODO: see what cases still fail and if SgGen helps
+                1 => sydamen ;
+                x => regSydan ! x }
            }
       } ;
+
+  consonant : pattern Str = #("b"|"c"|"d"|"f"|"g"|"h"|"j"|"k"|"l"|"m"|"n"|"p"|"q"|"r"|"s"|"t"|"v"|"w"|"x"|"z") ;
 
   -- like nForms2, but 2nd argument is Sg Partitive
   nForms2sgPar : (sydan,sydanta : Str) -> NForms = \sydan,sydanta ->
@@ -718,6 +724,7 @@ mkVS = overload {
       -- then we form a full paradigm with a genitive guessed from the SgNom+SgPar
       guessedSydan : NForms = case <sydan,sydanta> of {
         <_ + "i", _ + ("ea"|"eä")> => dArpi sydan oven ;
+        <_ + "e", _ + ("ea"|"eä")> => dNukke sydan (sydan + "n") ;
         <_ + "nsi", _ + "ntt" + ("a"|"ä")> => dArpi sydan kynnen ;
         <_ + ("psi"|"tsi"), _ + ("sta"|"stä")> => dArpi sydan oven ; -- laps|i|->|en|,  veits|i|->|en|
         <_ + "i", _ + ("nta"|"ntä")> => dArpi sydan oven ;
@@ -728,6 +735,8 @@ mkVS = overload {
         <_ + ("us"|"ys"), ("tta"|"ttä")> => dLujuus sydan ; -- can't distinguish between dLujuus and dKaunis from Sg Par only
         <_ + "s"        , ("tta"|"ttä")> => dKaunis sydan ;
         <_ + "t"        , ("tta"|"ttä")> => dRae sydan oven ; -- olu|t| -> |en| — can't distinguish between kuollut and olut
+        <_ + #consonant, _ + #consonant + ("ia"|"iä")> => dUnix sydan ;
+        <_, _ + ":" + ("ta"|"tä"|"aa"|"ää")> => dSDP sydan ;
         _ => nForms1 sydan }
       } ;
 
@@ -758,6 +767,10 @@ mkVS = overload {
         <_ + "s",  _ + "teen"> => dLujuus sydan ;
         <_ + "s",  _ + "seen"> => dKaunis sydan ;
         <_ + "s",  _ + "heen"> => d42 sydan ;
+        <_ + "mpi", _ + ("mpaan"|"mpään")> => dSuurempi sydan ;
+        <_ + #consonant, _ + #consonant + "iin"> => dUnix sydan ;
+        <_, _ + ":" + ("han"|"hen"|"hin"|"hon"|"hun"|"hyn"|"hän"|"hön"|"aan"|"ään")> => dSDP sydan ;
+
         _ => nForms1 sydan }
     } ;
 


### PR DESCRIPTION
A few more pattern matches in the alternative 2-argument paradigms, and allowing punctuation to follow an abbreviation.