### PR TITLE
Check in CI that building the RGL succeeds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Check that the RGL can successfully build
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GF_VERSION: 3.11
+      DEST: gf-rgl
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download GF
+      uses: dsaltares/fetch-gh-release-asset@1.1.1
+      with:
+        repo: 'GrammaticalFramework/gf-core'
+        version: 'tags/${{ env.GF_VERSION }}'
+        file: 'gf-${{ env.GF_VERSION }}-ubuntu-20.04.deb'
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install GF
+      run: |
+        sudo dpkg -i gf-${GF_VERSION}-ubuntu-20.04.deb'
+
+    - name: Build RGL
+      run: |
+        mkdir -p ${DEST}
+        bash Setup.sh --dest=${DEST} --gf=gf --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install GF
       run: |
-        sudo dpkg -i gf-${GF_VERSION}-ubuntu-20.04.deb'
+        sudo dpkg -i gf-${GF_VERSION}-ubuntu-20.04.deb
 
     - name: Build RGL
       run: |


### PR DESCRIPTION
This should warn about build failures. 

Here's an example of a successful run: https://github.com/anka-213/gf-rgl/actions/runs/5867073985
And here's an example of a build failure: https://github.com/anka-213/gf-rgl/actions/runs/5867108591