### PR TITLE
(Ger) ordinal endings of Digits fixed

### DIFF
--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -84,7 +84,7 @@ concrete CatGer of Cat =
 -- Numeral
 
     Numeral = {s : CardOrd => Str ; n : Number } ;
-    Digits = {s : CardOrd => Str ; n : Number } ;
+    Digits = {s : CardOrd => Str ; n : Number ; isDig, tail1to19 : Bool} ;
     Decimal = {s : CardOrd => Str ; n : Number ; hasDot : Bool} ;
 
 -- Structural


### PR DESCRIPTION
Digits d- in {0,...,9}+ get endings as follows

NOrd (AMod gennum case)

1.   Nom: d-ter,d-te,d-tes,         for 0 and d ending in 1 =< d =< 19,

2.   Nom: d-ster, d-ste, d-stes, else.

NOrd APred: 

1. am 0ten, ..., am 19ten, 
2. am 20sten,...,am 99sten, am 100sten, 
3. am 101ten,...,am 119ten, 
4. am 120sten,...,am 199sten, am 200sten

etc.