### PR TITLE
(Ger) Determiners and DetQuant, DetQuantOrd improved; gender in plural removed; Extend extended

### DIFF
--- a/src/german/AdjectiveGer.gf
+++ b/src/german/AdjectiveGer.gf
@@ -41,7 +41,7 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
 -- $SuperlA$ belongs to determiner syntax in $Noun$.
 
     ComplA2 a np =
-      let CExt = case a.c2.isPrep of {
+      let CExt = case a.c2.t of {
             isCase => <appPrepNP a.c2 np, []> ;
 	    _ => <[], appPrepNP a.c2 np> }
       in {
@@ -54,7 +54,7 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
     ReflA2 a = 
       let
 	compl = appPrep a.c2 (reflPron ! agrP3 Sg) ;
-	CExt = case a.c2.isPrep of
+	CExt = case a.c2.t of
 		{isCase => <compl, []> ; _ => <[], compl> }
       in {
         s = a.s ! Posit ;

--- a/src/german/AllGer.gf
+++ b/src/german/AllGer.gf
@@ -3,7 +3,6 @@
 concrete AllGer of AllGerAbs =
   LangGer,
   IrregGer,
-----  ExtendGer, ---- to replace ExtraGer
-  ExtraGer
-  ** open ExtendGer in {} ---- to force compilation
+  ExtendGer
+  ** open ExtraGer in {} ---- to force compilation
   ;

--- a/src/german/AllGerAbs.gf
+++ b/src/german/AllGerAbs.gf
@@ -1,8 +1,7 @@
---# -path=.:../abstract:../common:prelude
+--# -path=.:../abstract:../common:../prelude
 
 abstract AllGerAbs = 
   Lang,
   IrregGerAbs,
-----  Extend,
-  ExtraGerAbs
+  Extend
   ** {} ;

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -29,7 +29,7 @@ concrete CatGer of Cat =
     IP = {s : Case => Str ; n : Number} ;
     IComp = {s : Agr => Str ; ext : Str} ; 
     IDet = {s : Gender => Case => Str ; n : Number} ;
-    IQuant = {s : Number => Gender => Case => Str} ;
+    IQuant = {s : GenNum => Case => Str} ;
 
 -- Relative
 
@@ -59,17 +59,16 @@ concrete CatGer of Cat =
       g : Gender
       } ;
     NP = ResGer.NP ;
-    Pron = {s : NPForm => Str ; a : Agr} ;
+    Pron = {s : NPForm => Str ; a : Agr ; sp : PossForm => Str} ;
     Det = {s,sp : Bool => Gender => Case => Str ; -- True if DefArt is dropped, HL 8/22
            n : Number ; a : Adjf ; isDef, hasDefArt : Bool} ;
     DAP = {s,sp : Gender => Case => Str ; n : Number ; a : Adjf ; isDef,hasDefArt : Bool} ;
-    -- HL 7/2022: first Bool = True if used to glue in Sg with preposition
-    -- second Bool is True if a cardinal number is present
+
     Quant = {
-      s, sp : Bool => Bool => Number => Gender => Case => Str ;
-      a   : Adjf ;
-      aPl : Adjf ;  --- to distinguish "meine guten Freunde" / "gute Freunde"
-      hasDefArt : Bool
+      s,sp : GenNum => Case => Str ;
+      a : Adjf ;
+      hasDefArt : Bool ;
+      delCardOne : Bool -- delete following cardinal 1 (IndefArt and no_Quant)
       } ;
     Predet = {
       s : Number => Gender => Case => Str ;
@@ -77,8 +76,8 @@ concrete CatGer of Cat =
       a : PredetAgr -- if an agr is forced, e.g. jeder von uns ist ...
       } ;
 
-    Num = {s : Gender => Case => Str ; n : Number ; isNum : Bool} ;
-    Card = {s : Gender => Case => Str ; n : Number} ;
+    Num = {s,sp : AForm => Str ; n : Number ; isNum : Bool} ; -- Num,Card.s AForm HL 12/23
+    Card = {s : AForm => Str ; n : Number} ; -- inflection mainly for: einer,eine,eines
     Ord = {s : AForm => Str} ;
 
 -- Numeral
@@ -140,7 +139,7 @@ concrete CatGer of Cat =
     Conj = \c -> c.s1 ++ c.s2 ;
 
     Det = \det -> det.s ! False ! Masc ! Nom ;
-    Prep = \prep -> case prep.isPrep of {isPrepDefArt => prep.s ! GSg Masc ;
-                                         _ => prep.s ! GPl } ;
+    Prep = \prep -> case prep.t of {isPrepDefArt => prep.s ! GSg Masc ;
+                                    _ => prep.s ! GPl } ;
 
 }

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -119,7 +119,7 @@ concrete CatGer of Cat =
 
   linref
     NP = \np -> np.s ! False ! Nom ++ np.ext ++ np.rc ; -- HL 7/2022 Bool added
-    CN = \cn -> cn.s ! Strong ! Pl ! Nom ++ cn.adv ++ cn.ext ++ cn.rc ! Pl ;
+    CN = \cn -> cn.s ! Strong ! Sg ! Nom ++ cn.adv ++ cn.ext ++ cn.rc ! Sg ;
 
     SSlash = \ss -> ss.s ! Main ++ ss.c2.s ! GPl ;
     ClSlash = \cls -> cls.s ! MIndic ! Pres ! Simul ! Pos ! Main ++ cls.c2.s ! GPl ;

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -67,7 +67,7 @@ concrete CatGer of Cat =
     Quant = {
       s,sp : GenNum => Case => Str ;
       a : Adjf ;
-      hasDefArt : Bool ;
+      isDefArt : Bool ;
       delCardOne : Bool -- delete following cardinal 1 (IndefArt and no_Quant)
       } ;
     Predet = {
@@ -94,18 +94,19 @@ concrete CatGer of Cat =
 
 -- Open lexical classes, e.g. Lexicon
 
-    V, VA, VS, VQ = ResGer.Verb ; -- = {s : VForm => Str} ;
+    V, VA, VS, VQ = Verb ; -- = {s : VForm => Str} ;
     VV = Verb ** {isAux : Bool} ;
     V2, V2A, V2S, V2Q = Verb ** {c2 : Preposition} ;
     V2V = Verb ** {c2 : Preposition ; isAux : Bool ; objCtrl : Bool} ;
     V3 = Verb ** {c2, c3 : Preposition} ;
 
-    A  = {s : Degree => AForm => Str} ;
-    A2 = {s : Degree => AForm => Str ; c2 : Preposition} ;
+    A  = Adjective ; -- = {s : Degree => AForm => Str} ;
+    A2 = Adjective ** {c2 : Preposition} ;
 
-    N  = ResGer.Noun ;
-    N2 = ResGer.Noun ** {c2 : Preposition} ;
-    N3 = ResGer.Noun ** {c2,c3 : Preposition} ;
+    N  = Noun ; -- {s : Number => Case => Str ; co : Str ;
+                --  uncap : {s: Number => Case => Str ; co : Str} ; g : Gender}
+    N2 = Noun ** {c2 : Preposition} ;
+    N3 = Noun ** {c2,c3 : Preposition} ;
     GN = {s : Case => Str; g : Sex} ;
     SN = {s : Sex => Case => Str} ;
     PN = {s : Case => Str; g : Gender; n : Number} ;

--- a/src/german/ConstructionGer.gf
+++ b/src/german/ConstructionGer.gf
@@ -2,7 +2,7 @@
 
 concrete ConstructionGer of Construction = CatGer **
   open SyntaxGer, SymbolicGer, (P = ParadigmsGer),
-       (L = LexiconGer), (E = ExtraGer), (G = GrammarGer), (I = IrregGer), (R = ResGer), (N = NounGer), Prelude in {
+       (L = LexiconGer), (E = ExtendGer), (G = GrammarGer), (I = IrregGer), (R = ResGer), (N = NounGer), Prelude in {
 flags coding=utf8 ;
 
 oper

--- a/src/german/ConstructionGer.gf
+++ b/src/german/ConstructionGer.gf
@@ -89,7 +89,7 @@ lin
       in  SyntaxGer.mkAdv (for_Prep | accPrep) n_hours_NP ;
 
     timeunitRange l u time =
-      {s = l.s ! R.Masc ! R.Nom ++ "bis" ++ u.s ! R.Masc ! R.Nom ++ time.s ! R.Pl ! R.Nom} ;
+      {s = l.s ! R.AMod (R.gennum R.Masc l.n) R.Nom ++ "bis" ++ u.s ! R.AMod (R.gennum R.Masc u.n) R.Nom ++ time.s ! R.Pl ! R.Nom} ;
 
   oper
     mkHour : Str -> Str -> Str -> Hour

--- a/src/german/ExtendGer.gf
+++ b/src/german/ExtendGer.gf
@@ -249,7 +249,7 @@ lin CompoundN a x =
       in {
         s = adj.s ! Posit ;
         isPre = True ;
-        c = case adj.c2.isPrep of {False => <compl, []> ; True => <[], compl>} ;
+        c = case adj.c2.t of {False => <compl, []> ; True => <[], compl>} ;
         ext = rnp.ext ++ rnp.rc
       } ;
 
@@ -294,7 +294,7 @@ lin CompoundN a x =
       in vp ** {
         nn = \\a =>
           let vpnn = vp.nn ! a in
-          case <prep.isPrep, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
+          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
             <False,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
             <False,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
             <False,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal

--- a/src/german/ExtendGer.gf
+++ b/src/german/ExtendGer.gf
@@ -2,15 +2,19 @@
 
 concrete ExtendGer of Extend =
   CatGer ** ExtendFunctor
-   - [
-    InOrderToVP,
-    VPS, ListVPS, VPI, ListVPI, RNP, RNPList,
-    MkVPS, BaseVPS, ConsVPS, ConjVPS, PredVPS, 
-    MkVPI, BaseVPI, ConsVPI, ConjVPI, ComplVPIVV,
-    ComplSlashPartLast,
-    Base_nr_RNP, Base_rn_RNP, Base_rr_RNP, Conj_RNP,
-    CardCNCard, CompoundN,
-    PassVPSlash, PassAgentVPSlash, PastPartAP, PastPartAgentAP
+  - [ -- remove the default implementations of:
+      GenNP, EmptyRelSlash,
+      VPS, ListVPS, MkVPS, BaseVPS, ConsVPS, ConjVPS, PredVPS,
+      VPI, ListVPI, MkVPI, BaseVPI, ConsVPI, ConjVPI, ComplVPIVV,
+      ICompAP, IAdvAdv, CompIQuant, PrepCN,
+      PastPartAP, PastPartAgentAP,
+      PassVPSlash, PassAgentVPSlash,
+      AdvIsNP,
+      RNP, RNPList, Base_rr_RNP, Base_nr_RNP, Base_rn_RNP, Cons_rr_RNP, Cons_nr_RNP, Conj_RNP,
+      ReflRNP, ReflPron, ReflPoss, PredetRNP, AdvRNP, ReflA2RNP, PossPronRNP,
+      CompoundN, DetNPMasc, DetNPFem, UseDAP, UseDAPMasc, UseDAPFem,
+      CardCNCard,
+      InOrderToVP
     ]
   with
     (Grammar = GrammarGer) **
@@ -19,7 +23,22 @@ concrete ExtendGer of Extend =
     ResGer,
     Coordination,
     Prelude,
-    ParadigmsGer in {
+    (P = ParadigmsGer) in {
+
+  lin
+    GenNP np = {
+      s,sp = \\gn,c => np.s ! False ! Gen ++ np.ext ++ np.rc ;
+      a = Strong ;
+      isDefArt = False ;
+      delCardOne = False
+      } ;
+
+    EmptyRelSlash slash = {
+      s = \\m,t,a,p,gn =>
+        appPrep slash.c2 (relPron ! gn) ++ slash.s ! m ! t ! a ! p ! Sub ;
+      c = slash.c2.c
+      } ;
+
 
   lincat
     VPI   = {s : Bool => Str} ;
@@ -27,36 +46,12 @@ concrete ExtendGer of Extend =
     VPS   = {s : Order => Agr => Str} ;
     [VPS] = {s1,s2 : Order => Agr => Str} ;
 
-lin
-
-  InOrderToVP vp = {s = "um" ++ useInfVP False vp} ;
-
+  lin
     BaseVPI = twoTable Bool ;
     ConsVPI = consrTable Bool comma ;
 
-    MkVPI vp = {s = \\b => useInfVP b vp} ;
-    ConjVPI = conjunctDistrTable Bool ;
-
-    ComplVPIVV v vpi = 
-      insertInf {inpl = <\\_ => [], (vpi.s ! v.isAux)> ; extr = \\_ => []}  -- HL 3/22
-        (predVGen v.isAux v) ;
-
     BaseVPS = twoTable2 Order Agr ;
     ConsVPS = consrTable2 Order Agr comma ;
-
-    PredVPS np vpi = 
-      let
-        subj = np.s ! False ! Nom ++ bigNP np ;
-        agr  = np.a ;
-      in {
-        s = \\o => 
-          let verb = vpi.s ! o ! agr 
-          in case o of {
-            Main => subj ++ verb ;
-            Inv  => verb ++ subj ;   ---- älskar henne och sover jag
-            Sub  => subj ++ verb 
-            }
-        } ;
 
     MkVPS tm p vp = 
       let vps = useVP vp in {
@@ -115,7 +110,251 @@ lin
     } ;
 
     ConjVPS = conjunctDistrTable2 Order Agr ;
+
+    PredVPS np vpi =
+      let
+        subj = np.s ! False ! Nom ++ bigNP np ;
+        agr  = np.a ;
+      in {
+        s = \\o =>
+          let verb = vpi.s ! o ! agr
+          in case o of {
+            Main => subj ++ verb ;
+            Inv  => verb ++ subj ;   ---- älskar henne och sover jag
+            Sub  => subj ++ verb
+            }
+        } ;
+
+-- existentials that work in the absence of Cl
     
+    MkVPI vp = {s = \\b => useInfVP b vp} ;
+
+    ConjVPI = conjunctDistrTable Bool ;
+
+    ComplVPIVV v vpi =
+      insertInf {inpl = <\\_ => [], (vpi.s ! v.isAux)> ; extr = \\_ => []}  -- HL 3/22
+        (predVGen v.isAux v) ;
+
+-- the same for VPSlash, taking a complement with shared V2 verbs
+
+-- Conjunction of copula complements
+
+-- Conjunction of imperatives
+
+    ICompAP ap = {
+      s = \\_ => "wie" ++ ap.s ! APred ;
+      ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext
+      } ;
+
+    IAdvAdv adv = {s = "wie" ++ adv.s} ;
+
+    CompIQuant iq = {
+      s = \\a => iq.s ! (gennum (genderAgr a) (numberAgr a))! Nom ;
+      ext = ""
+      } ;
+
+    PrepCN prep cn = {
+      s = prep.s ! GPl ++ cn.s ! Strong ! Sg ! prep.c ++ cn.adv ++ cn.rc ! Sg ++ cn.ext} ;
+
+  -- fronted/focal constructions, only for main clauses
+
+  -- participle constructions
+
+    PastPartAP vp =
+      let a = agrP3 Sg in {
+        s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3 ++ vp.a2 ++ vp.adj
+                    ++ vp.inf.inpl.p2 ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+        isPre = True ;
+        c = <[],[]> ;
+        ext = vp.ext
+      } ;
+
+    PastPartAgentAP vp np =
+      let a = agrP3 Sg ;
+          agent = appPrepNP P.von_Prep np
+      in {
+      s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3
+                  ++ vp.a2 ++ agent ++ vp.adj ++ vp.inf.inpl.p2
+                  ++ vp.c2.s ! GPl                     -- junk if not TV
+                  ++ vp.ext ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+      isPre = True ;
+      c = <[],[]> ;
+      ext = []
+      } ;
+
+-- this is a generalization of Verb.PassV2 and should replace it in the future.
+
+    PassVPSlash vp =
+      insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
+          { c1 = subjPrep vp.c2 } ;
+    -- this also gives "mit dir wird gerechnet" ;
+    -- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
+
+    PassAgentVPSlash vp np = ---- "von" here, "durch" in StructuralGer
+      insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
+
+-- publishing of the document
+
+-- counterpart to ProgrVP, for VPSlash
+
+-- construct VPSlash from A2 and N2
+
+-- existential for mathematics
+
+-- existentials with a/no variation
+
+-- generalisation of existential, with adverb as an argument
+
+    AdvIsNP adv np = let comp : Agr => Str = \\agr => np.s ! False ! Nom ++ np.rc ++ np.ext in
+      mkClause adv.s np.a (insertObj comp (predV sein_V)) ; -- HL 12/2023, prelim, wrong order
+
+-- infinitive for purpose AR 21/8/2013
+
+-- object S without "that"
+
+-- front the extraposed part
+
+-- proper structure of "it is AP to VP"
+
+-- to use an AP as CN or NP without CN
+
+-- infinitive complement for IAdv
+
+-- alternative to EmbedQS. For English, EmbedQS happens to work,
+
+-- Reflexive noun phrases -- (HL 5/2022: improved and completed, RNPList added)
+
+  lincat
+    RNP = {s : Agr => Case => Str ; rc,ext : Str ; isPron : Bool} ;
+    RNPList = {s1,s2 : Agr => Case => Str} ;
+
+  linref
+    RNP = \rnp -> rnp.s ! AgSgP3 Masc ! Acc ++ rnp.ext ++ rnp.rc ;
+
+  lin
+    ReflRNP vps rnp =
+      insertObjReflNP (lin RNP rnp) vps ;
+
+    ReflPron = { -- with personal pronoun nominative
+      s = ResGer.reflPron ; rc,ext = [] ; isPron = True } ;
+
+    -- To distinguish personal pronoun from reflexive pronoun:
+    --   du kennst mich vs. ich kenne mich selbst
+    --   er kennt ihn   vs. er kennt sich (selbst)
+    --   sie kennen sich (selbst) =/= sie kennen einander
+    -- we might define ReflPron by the stronger
+    -- oper
+    --   reflPronSelf : Agr => Case => Str =
+    --   \\a => \\c => reflPron ! a ! c ++ "selbst" ;
+
+  lin
+    ReflPoss num cn =
+      {s = \\a,c => let adjf = case num.n of {Sg => Strong ; Pl => Weak} -- Duden 477, HL 5/2022
+         in possPron a num.n cn.g c
+            ++ num.s ! AMod (gennum cn.g num.n) c -- HL 5/2022: meine wenigstens 3 cn,
+            ++ cn.s ! adjfCase adjf c ! num.n ! c --       not: wenigstens 3 meine cn
+            ++ cn.adv ;
+       ext = cn.ext ; rc = cn.rc ! num.n ;
+       isPron = False} ;
+
+    -- To distinguish possessive pronoun from reflexive possessive pronoun:
+    --   du kennst meine Fehler vs. ich kenne meine eigenen Fehler
+    --   er|sie|es kennt seine|ihre Fehler  vs. er|sie|es kennt seine|ihre|seine eigenen Fehler
+    -- we might define ReflPoss by the stronger
+    -- oper
+    --   reflPossPron : Agr -> Number -> Gender -> Case -> Str =
+    --   let eigen = adjForms "eigen" "eigen" in
+    --     \a,n,g,c -> possPron a n g c ++ (eigen ! (AMod (gennum g n) c)) ;
+
+    PredetRNP pred rnp = rnp ** {                        -- HL 5/2022
+      s = \\a,c => let n : Number = case pred.a of {PAg n => n ; _ => numberAgr a} ;
+                       g : Gender = genderAgr a ;
+                       d = case pred.c.k of {NoCase => c ; PredCase k => k} ;
+        in case rnp.isPron of {
+          True => pred.s ! Pl ! Masc ! c ++ "von" ++ rnp.s ! a ! Dat ;
+          _ => pred.s ! n ! genderAgr a ! c ++ pred.c.p ++ rnp.s ! a ! d} ;
+      ext = rnp.ext ; rc = rnp.rc ;
+      isPron = False} ;
+      -- ok: alle von uns; die meisten von uns ; wrong: *nur von uns =/= nur wir
+
+    AdvRNP np prep rnp = {s = \\a,c => np.s ! False ! c
+                            ++ appPrep prep (rnp.s ! a) ++ rnp.ext ++ rnp.rc ;
+                          ext = np.ext ; rc = np.rc ; isPron = False} ;
+
+    AdvRAP ap prep rnp =
+      let                                         -- ? adv ++ ap.s ! af
+        adv = appPrep prep (rnp.s ! agrP3 Sg) ;   -- bug: fixed agreement
+      in ap ** { s = \\af => ap.s ! af ++ adv } ; -- e.g. unknown in one's youth
+
+    ReflA2RNP adj rnp = -- would need AP.c : Agr => Str*Str, not AP.c : Str*Str
+      let                                            -- as we have no reflexive AP,
+        compl = appPrep adj.c2 (rnp.s ! agrP3 Sg) ; -- we use a fixed agreement
+      in {
+        s = adj.s ! Posit ;
+        isPre = True ;
+        c = case adj.c2.t of {isCase => <compl, []> ; _ => <[], compl>} ;
+        ext = rnp.ext ++ rnp.rc
+      } ;
+
+    PossPronRNP pron num cn rnp =
+      GrammarGer.DetCN (GrammarGer.DetQuant (GrammarGer.PossPron pron) num)
+      (GrammarGer.PossNP cn (lin NP {s = \\_,c => rnp.s ! pron.a ! c ;
+                            a = pron.a ;
+                            w = WLight ;
+                            ext = rnp.ext ;
+                            rc = rnp.rc})) ;
+
+    -- AdvRVP : VP -> Prep -> RNP -> VP not implemented, as the reflexive adverb (Prep + RNP): Agr => Str
+    -- could only be added to vp.a2:Str with fixed agreement, but can depend on nominal subject or object,
+    -- e.g. "er spricht mit ihr über sein Kind" vs. "er spricht mit ihr über ihr Kind".
+
+    ConjRNP conj rnps = conjunctDistrTable2 Agr Case conj rnps
+      ** {isPron = False ; ext,rc = []} ;
+
+    Base_rr_RNP x y = twoTable2 Agr Case x y ;
+    Base_nr_RNP x y = twoTable2 Agr Case {s = \\_,c => x.s ! False ! c ++ x.ext ++ x.rc} y ;
+    Base_rn_RNP x y = twoTable2 Agr Case x {s = \\_,c => y.s ! False ! c ++ y.ext ++ y.rc} ;
+
+    Cons_rr_RNP x xs = consrTable2 Agr Case comma x xs ;
+    Cons_nr_RNP x xs = consrTable2 Agr Case comma {s = \\_,c => x.s ! False ! c ++ x.ext ++ x.rc} xs ;
+
+-- reflexive possessive on its own right, like in Swedish, Czech, Slovak
+
+--- from Extensions
+
+    CompoundN a x =
+      let s = a.co in lin N {
+        s  = \\n,c => s ++ Predef.BIND ++ x.uncap.s ! n ! c ;
+        co = s ++ Predef.BIND ++ x.uncap.co ;
+        uncap = {
+          s  = \\n,c => a.uncap.co  ++ Predef.BIND ++ x.uncap.s ! n ! c ;
+          co = a.uncap.co  ++ Predef.BIND ++ x.uncap.co ;
+          } ;
+        g = x.g
+      } ;
+
+-- very language-specific things
+
+-- Romance
+
+    DetNPMasc det = {
+      s = \\b,c => det.sp ! b ! Masc ! c ;
+      a = agrgP3 Masc det.n ;
+      w = case det.isDef of {True => WLight ; _ => WHeavy} ;
+      ext, rc = []
+      } ;
+
+    DetNPFem det = {
+      s = \\b,c => det.sp ! b ! Fem ! c ;
+      a = agrgP3 Fem det.n ;
+      w = case det.isDef of {True => WLight ; _ => WHeavy} ;--WLight ;
+      ext, rc = []
+      } ;
+
+-- German
+
+-- UseDAP replaces DetNP from the RGL which is more limited.
+
     UseDAP det = {
       s = \\b,c => det.sp ! Neutr ! c ;
       a = agrP3 det.n ;
@@ -137,168 +376,32 @@ lin
       rc, ext = []
       } ;
 
-lin
-  CardCNCard card cn = {
-    s = \\g,c =>
-      (Grammar.DetCN (Grammar.DetQuant Grammar.IndefArt (Grammar.NumCard card)) cn).s ! False ! c ;
-    n = Pl
-    } ;
-
-lin PassVPSlash vp = 
-      insertObj (\\_ => (PastPartAP vp).s ! APred) (predV werdenPass) **
-          { c1 = subjPrep vp.c2 } ;
-    -- this also gives "mit dir wird gerechnet" ;
-    -- the alternative linearisation ("es wird mit dir gerechnet") is not implemented
-
-lin PassAgentVPSlash vp np = ---- "von" here, "durch" in StructuralGer
-      insertObj (\\_ => (PastPartAgentAP (lin VPSlash vp) (lin NP np)).s ! APred) (predV werdenPass) ;
-
-lin PastPartAP vp =
-      let a = agrP3 Sg in {
-        s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3 ++ vp.a2 ++ vp.adj
-                    ++ vp.inf.inpl.p2 ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
-        isPre = True ;
-        c = <[],[]> ;
-        ext = vp.ext
+    CardCNCard card cn = {
+      s = let det = (Grammar.DetQuant Grammar.IndefArt (Grammar.NumCard card)) ;
+              np = (Grammar.DetCN det cn).s ! False
+        in table{APred => np ! Nom ; AMod gn c => np ! c} ; -- HL 12/2023
+      n = Pl
       } ;
 
-lin PastPartAgentAP vp np =
-      let a = agrP3 Sg ;
-          agent = appPrepNP von_Prep np
-      in {
-      s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3
-                  ++ vp.a2 ++ agent ++ vp.adj ++ vp.inf.inpl.p2
-                  ++ vp.c2.s ! GPl                     -- junk if not TV
-                  ++ vp.ext ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
-      isPre = True ;
-      c = <[],[]> ;
-      ext = []
-      } ;
 
-lin CompoundN a x =
-       let s = a.co in
-       lin N {
-          s  = \\n,c => s ++ Predef.BIND ++ x.uncap.s ! n ! c ; 
-          co = s ++ Predef.BIND ++ x.uncap.co ;
-          uncap = {
-            s  = \\n,c => a.uncap.co  ++ Predef.BIND ++ x.uncap.s ! n ! c ; 
-            co = a.uncap.co  ++ Predef.BIND ++ x.uncap.co ;
-            } ;
-          g = x.g
-          } ;
+    InOrderToVP vp = {s = "um" ++ useInfVP False vp} ;
 
-
--- Reflexive noun phrases -- (HL 5/2022: improved and completed, RNPList added)
-
-  lincat
-    RNP = {s : Agr => Case => Str ; rc,ext : Str ; isPron : Bool} ;  -- Case, not PCase !!!
-    RNPList = {s1,s2 : Agr => Case => Str} ;
-
-  linref
-    RNP = \rnp -> rnp.s ! AgSgP3 Masc ! Acc ++ rnp.ext ++ rnp.rc ;
-
-  lin
-    ReflRNP vps rnp =
-      insertObjReflNP rnp vps ;
-
-    ReflPron = { -- with personal pronoun nominative
-      s = ResGer.reflPron ; rc,ext = [] ; isPron = True } ;
-
-    -- We might define ReflPron by the stronger reflPronSelf below, using "selbst"
-    -- to distinguish personal pronoun from reflexive pronoun:
-    --   du kennst mich vs. ich kenne mich selbst
-    --   er kennt ihn   vs. er kennt sich (selbst)
-    --   sie kennen sich (selbst) =/= sie kennen einander
-
-    ReflPoss num cn =
-      {s = \\a,c => let adjf = case num.n of {Sg => Strong ; Pl => Weak} -- Duden 477, HL 5/2022
-         in possPron a num.n cn.g c ++ num.s ! cn.g ! c -- HL 5/2022: meine wenigstens 3 cn,
-            ++ cn.s ! adjfCase adjf c ! num.n ! c       --       not: wenigstens 3 meine cn
-            ++ cn.adv ;
-       ext = cn.ext ; rc = cn.rc ! num.n ;
-       isPron = False} ;
-
-    -- We might define ReflPoss by the stronger reflPossPron below, using "eigen(er)"
-    -- to distinguish possessive pronoun from reflexive possessive pronoun:
-    --   du kennst meine Fehler vs. ich kenne meine eigenen Fehler
-    --   er|sie|es kennt seine|ihre Fehler  vs. er|sie|es kennt seine|ihre|seine eigenen Fehler
-
-    PredetRNP pred rnp = rnp ** {                        -- HL 5/2022
-      s = \\a,c => let n : Number = case pred.a of {PAg n => n ; _ => numberAgr a} ;
-                       g : Gender = genderAgr a ;
-                       d = case pred.c.k of {NoCase => c ; PredCase k => (prepC k).c} ;
-        in case rnp.isPron of {
-          True => pred.s ! Pl ! Masc ! c ++ "von" ++ rnp.s ! a ! Dat ;
-          _ => pred.s ! n ! genderAgr a ! c ++ pred.c.p ++ rnp.s ! a ! d} ;
-      ext = rnp.ext ; rc = rnp.rc ;
-      isPron = False} ;
-      -- ok: alle von uns; die meisten von uns ; wrong: *nur von uns =/= nur wir
-{-
-    AdvRNP np prep rnp = {s = \\a,c => np.s ! c
-                            ++ appPrep prep (rnp.s ! a) ++ rnp.ext ++ rnp.rc ;
-                          ext = np.ext ; rc = np.rc ; isPron = False} ;
-
-    AdvRAP ap prep rnp =
-      let                                         -- ? adv ++ ap.s ! af
-        adv = appPrep prep (rnp.s ! agrP3 Sg) ;   -- bug: fixed agreement
-      in ap ** { s = \\af => ap.s ! af ++ adv } ; -- e.g. unknown in one's youth
-
-    ReflA2RNP adj rnp = -- would need AP.c : Agr => Str*Str, not AP.c : Str*Str
-      let                                            -- as we have no reflexive AP,
-        compl = appPrep adj.c2 (rnp.s ! agrP3 Sg) ; -- we use a fixed agreement
-      in {
-        s = adj.s ! Posit ;
-        isPre = True ;
-        c = case adj.c2.t of {False => <compl, []> ; True => <[], compl>} ;
-        ext = rnp.ext ++ rnp.rc
-      } ;
-
-    PossPronRNP pron num cn rnp =
-      GrammarGer.DetCN (GrammarGer.DetQuant (GrammarGer.PossPron pron) num)
-      (GrammarGer.PossNP cn (lin NP {s = \\pc => -- usePrepC pc (\c -> rnp.s ! pron.a ! c) ;
-                                                    rnp.s ! pron.a ! pc ;
-                            a = pron.a ;
-                            w = WLight ;
-                            ext = rnp.ext ;
-                            rc = rnp.rc})) ;
-
-    -- AdvRVP : VP -> Prep -> RNP -> VP not implemented, as the reflexive adverb (Prep + RNP): Agr => Str
-    -- could only be added to vp.a2:Str with fixed agreement, but can depend on nominal subject or object,
-    -- e.g. "er spricht mit ihr über sein Kind" vs. "er spricht mit ihr über ihr Kind".
--}
-    ConjRNP conj rnps = conjunctDistrTable2 Agr Case conj rnps
-      ** {isPron = False ; ext,rc = []} ;
-
-    Base_rr_RNP x y = twoTable2 Agr Case x y ;
-    Base_nr_RNP x y = twoTable2 Agr Case {s = \\_,c => x.s ! False ! c ++ x.ext ++ x.rc} y ;
-    Base_rn_RNP x y = twoTable2 Agr Case x {s = \\_,c => y.s ! False ! c ++ y.ext ++ y.rc} ;
-
-    Cons_rr_RNP x xs = consrTable2 Agr Case comma x xs ;
-    Cons_nr_RNP x xs = consrTable2 Agr Case comma {s = \\_,c => x.s ! False ! c ++ x.ext ++ x.rc} xs ;
-{-
   oper
---    reflPronSelf : Agr => Case => Str = \\a => \\c => reflPron ! a ! c ++ "selbst" ;
-
-    -- reflPossPron : Agr -> Number -> Gender -> Case -> Str =
-    --   let eigen = adjForms "eigen" "eigen" in
-    --      \a,n,g,c -> possPron a n g c ++ (eigen ! (AMod (gennum g n) c)) ;
-
     insertObjReflNP : RNP -> ResGer.VPSlash -> ResGer.VP = -- HL 5/2022
       \rnp,vp -> insertObjRNP rnp vp.c2 vp ;
 
     insertObjRNP : RNP -> Preposition -> ResGer.VPSlash -> ResGer.VP = -- HL 5/2022
       \rnp,prep,vp ->                                           -- generalize ResGer.insertObjRefl
-      let -- prep = vp.c2 ;
-          c = case prep.c of { NPC cc => cc ; _ => Acc } ; -- put rnp.ext ++ rnp.rc to vp.ext ?
-          obj : Agr => Str = \\a => prep.s ++ rnp.s ! a ! c ++ rnp.ext ++ rnp.rc
+      let
+        obj : Agr => Str = \\a => prep.s ! GPl ++ rnp.s ! a ! prep.c ++ rnp.ext ++ rnp.rc
       in vp ** {
         nn = \\a =>
           let vpnn = vp.nn ! a in
-          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
-            <False,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
-            <False,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
-            <False,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal
-            <True,_,_>       => <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4> } --   or prepositional
+          case <prep.t, rnp.isPron, prep.c> of {   -- consider non-pron rnp as light, add to vpnn.p2
+            <isCase,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
+            <isCase,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
+            <isCase,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal
+            <_,_,_>           => <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4> } --   or prepositional
       } ;
--}
+
 }

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -29,7 +29,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
     ICompAP ap = {s = \\_ => "wie" ++ ap.s ! APred ;
                   ext = ap.c.p1 ++ ap.c.p2 ++ ap.ext} ;
 
-    CompIQuant iq = {s = table {a => iq.s ! numberAgr a ! genderAgr a ! Nom} ; ext = ""} ;
+    CompIQuant iq = {s = table {a => iq.s ! (gennum (genderAgr a) (numberAgr a))! Nom} ; ext = ""} ;
 
     IAdvAdv adv = {s = "wie" ++ adv.s} ;
 
@@ -194,7 +194,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
     ReflPoss num cn =
       {s = \\a,c => let adjf = case num.n of {Sg => Strong ; Pl => Weak} -- Duden 477, HL 5/2022
-         in possPron a num.n cn.g c ++ num.s ! cn.g ! c -- HL 5/2022: meine wenigstens 3 cn,
+         in possPron a num.n cn.g c ++ num.s ! AMod (gennum cn.g num.n) c -- HL 5/2022: meine wenigstens 3 cn,
             ++ cn.s ! adjfCase adjf c ! num.n ! c       --       not: wenigstens 3 meine cn
             ++ cn.adv ;
        ext = cn.ext ; rc = cn.rc ! num.n ;
@@ -231,7 +231,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       in {
         s = adj.s ! Posit ;
         isPre = True ;
-        c = case adj.c2.isPrep of {isCase => <compl, []> ; _ => <[], compl>} ;
+        c = case adj.c2.t of {isCase => <compl, []> ; _ => <[], compl>} ;
         ext = rnp.ext ++ rnp.rc
       } ;
 
@@ -275,7 +275,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       in vp ** {
         nn = \\a =>
           let vpnn = vp.nn ! a in
-          case <prep.isPrep, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
+          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
             <isCase,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
             <isCase,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
             <isCase,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal
@@ -288,7 +288,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       in vp ** {
         nn = \\a =>
           let vpnn = vp.nn ! a in
-          case <prep.isPrep, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
+          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
             <False,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
             <False,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
             <False,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -269,32 +269,18 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
 
     insertObjRNP : RNP -> Preposition -> ResGer.VPSlash -> ResGer.VP = -- HL 5/2022
       \rnp,prep,vp ->                                           -- generalize ResGer.insertObjRefl
-      let -- prep = vp.c2 ;
-          c : Case = case prep.c of { cc => cc ; _ => Acc } ; -- put rnp.ext ++ rnp.rc to vp.ext ?
-          obj : Agr => Str = \\a => prep.s ! GPl ++ rnp.s ! a ! c ++ rnp.ext ++ rnp.rc
+      let
+        obj : Agr => Str = \\a => prep.s ! GPl ++ rnp.s ! a ! prep.c ++ rnp.ext ++ rnp.rc
       in vp ** {
         nn = \\a =>
           let vpnn = vp.nn ! a in
-          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
+          case <prep.t, rnp.isPron, prep.c> of {      -- consider non-pron rnp as light, add to vpnn.p2
             <isCase,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
             <isCase,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
             <isCase,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal
             <_,_,_>           => <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4> } --   or prepositional
       } ;
-{-    insertObjRNP : RNP -> Preposition -> ResGer.VPSlash -> ResGer.VPSlash = -- HL 8/2023
-      \rnp,prep,vp ->                                              -- generalize ResGer.insertObjNP
-      let c = case prep.c of { NPC cc => cc ; _ => Acc } ;
-          obj : Agr => Str = \\a => prep.s ++ rnp.s ! a ! c ++ rnp.ext ++ rnp.rc
-      in vp ** {
-        nn = \\a =>
-          let vpnn = vp.nn ! a in
-          case <prep.t, rnp.isPron, c> of {           -- consider non-pron rnp as light, add to vpnn.p2
-            <False,True,Acc> => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ; -- pronoun switch:
-            <False,True,_>   => <vpnn.p1 ++ obj ! a, vpnn.p2, vpnn.p3, vpnn.p4> ; -- accPron < pron
-            <False,False,_>  => <vpnn.p1, vpnn.p2 ++ obj ! a, vpnn.p3, vpnn.p4> ; -- < non-pron nominal
-            <True,_,_>       => <vpnn.p1, vpnn.p2, vpnn.p3 ++ obj ! a, vpnn.p4> } --   or prepositional
-      } ;
--}
+
 -- SS: implementation of some of the relevant Foc rules from Extra
 
   lincat 

--- a/src/german/ExtraGerAbs.gf
+++ b/src/german/ExtraGerAbs.gf
@@ -3,6 +3,7 @@ abstract ExtraGerAbs = Extra [
   VPS,ListVPS,BaseVPS,ConsVPS,ConjVPS,MkVPS,PredVPS,EmptyRelSlash,
   VPSlash, PassVPSlash, PassAgentVPSlash, CompIQuant, PastPartAP, PastPartAgentAP,
   Temp,Tense,Pol,S,NP,VV,VP,Conj,IAdv,IQuant,IComp,ICompAP,IAdvAdv,Adv,AP,
+  Cl, Num, CN, Utt, Predet,
   Foc,FocObj,FocAdv,FocAP,UseFoc,
     RNP,ReflRNP,ReflPron,ReflPoss,PredetRNP
     ,RNPList,ConjRNP,Base_rr_RNP,Base_nr_RNP,Base_rn_RNP,Cons_rr_RNP,Cons_nr_RNP

--- a/src/german/MakeStructuralGer.gf
+++ b/src/german/MakeStructuralGer.gf
@@ -8,7 +8,7 @@ oper
   mkSubj : Str -> Subj = \x -> 
     {s = x ; lock_Subj = <>} ;
   mkIQuant : Str -> IQuant = \s ->
-    {s = \\_,_,_ => s ; lock_IQuant = <>} ;
+    {s = \\_,_ => s ; lock_IQuant = <>} ;
 
   mkPredet = overload {
     mkPredet : A -> Predet = \a ->
@@ -27,11 +27,11 @@ oper
 
  -- e.g. das selbe
  mmkQuant : Quant -> A -> Quant = \q,a -> q ** {
-   s,sp = \\b,x,n,g,c => q.s ! b ! x ! n ! g ! c ++ a.s ! Posit ! agrAdj g q.a n c
+   s,sp = \\gn,c => q.s ! gn ! c ++ a.s ! Posit ! agrAdj q.a gn c
    } ;
  -- e.g. derjenige
  mmbQuant : Quant -> A -> Quant = \q,a -> q ** {
-   s,sp = \\b,x,n,g,c => q.s ! b ! x ! n ! g ! c + a.s ! Posit ! agrAdj g q.a n c
+   s,sp = \\gn,c => q.s ! gn ! c + a.s ! Posit ! agrAdj q.a gn c
    } ;
 
 }

--- a/src/german/MorphoGer.gf
+++ b/src/german/MorphoGer.gf
@@ -1,4 +1,4 @@
---# -path=.:../common:../../prelude
+--# -path=.:../common:../prelude:
 --
 ----1 A Simple German Resource Morphology
 ----
@@ -18,7 +18,7 @@ oper
 -- For $StructuralGer$.
 
   mkPrep : Str -> Case -> Preposition = \s,c ->
-    {s = \\_ => s ; s2 = [] ; c = c ; isPrep = isPrep} ;
+    {s = \\_ => s ; s2 = [] ; c = c ; t = isPrep} ;
 
   nameNounPhrase : Gender -> {s : Case => Str} -> {s : Bool => Case => Str ;
                                                    a : Agr ;
@@ -83,7 +83,7 @@ oper
 
   cardOrd : Str -> Str -> CardOrd => Str = \drei,dritte ->
     table {
-      NCard _ _ => drei ;
+      NCard _ => drei ;
       NOrd a => (regA (init dritte)).s ! Posit ! a
       } ;
 
@@ -102,7 +102,7 @@ oper
   regDigit : Str -> LinDigit = \vier -> 
     mkDigit vier (vier + "zehn") (vier + "zig") (vier + "te") ;
 
-  invNum : CardOrd = NCard Masc Nom ;
+  invNum : CardOrd = NCard (AMod (GSg Masc) Nom) ;
 
 } ;
 

--- a/src/german/NamesGer.gf
+++ b/src/german/NamesGer.gf
@@ -79,7 +79,7 @@ lin InLN ln = {
 lin AdjLN ap ln = ln ** {
       s = \\a,c =>
                preOrPost ap.isPre
-                 (ap.c.p1 ++ ap.c.p2 ++ ap.s ! agrAdj ln.g a ln.n c ++ ap.ext)
+                 (ap.c.p1 ++ ap.c.p2 ++ ap.s ! agrAdj a (gennum ln.g ln.n) c ++ ap.ext)
                  (ln.s ! a ! c) ;
       } ;
 

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -113,20 +113,26 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
     NumSg = {s = \\g,c => []; n = Sg ; isNum = False} ; 
 
     NumDigits numeral = {s = \\g,c => numeral.s ! NCard g c; n = numeral.n } ;
-    OrdDigits numeral = {s = \\af => numeral.s ! NOrd af} ;
+    OrdDigits numeral = {s = table{APred => "am" ++ numeral.s ! NOrd APred ++ BIND ++ "en" ;
+                                   af => numeral.s ! NOrd af}} ;
 
     NumFloat dig1 dig2 = {s = \\g,c => dig1.s ! invNum ++ BIND ++ "." ++ BIND ++ dig2.s ! NCard g c ; n = Pl } ;
     NumDecimal numeral = {s = \\g,c => numeral.s ! NCard g c; n = numeral.n } ;
 
     NumNumeral numeral = {s = \\g,c => numeral.s ! NCard g c; n = numeral.n } ;
-    OrdNumeral numeral = {s = \\af => numeral.s ! NOrd af} ;
+    OrdNumeral numeral = {s = table{APred => "am" ++ numeral.s ! NOrd APred ++ BIND ++ "en" ;
+                                    af => numeral.s ! NOrd af}} ;
 
     AdNum adn num = {s = \\g,c => adn.s ++ num.s!g!c; n = num.n } ;
 
-    OrdSuperl a = {s = a.s ! Superl} ;
+    OrdSuperl a = {s = table {APred => "am" ++ a.s ! Superl ! APred ++ BIND ++ "en" ;
+                              af => a.s ! Superl ! af}} ;
 
-    OrdNumeralSuperl n a = {s = \\af => n.s ! NOrd APred ++ Predef.BIND ++ a.s ! Superl ! af} ; -- drittbeste
-
+    OrdNumeralSuperl n a =
+      {s = table {APred => "am" ++ n.s ! NOrd APred ++ Predef.BIND
+                           ++ a.s ! Superl ! APred ++ BIND ++ "en" ;      -- am drittbesten
+                  af => n.s ! NOrd APred ++ Predef.BIND ++ a.s ! Superl ! af} -- drittbeste
+      } ;
     DefArt = {
       s = table{True => \\_,n,g,c => [] ; -- definite article dropped
                 False => \\_,n,g,c => artDef ! (gennum g n) ! c} ;

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -154,13 +154,12 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
 
     AdNum adn num = {s = \\af => adn.s ++ num.s ! af ; n = num.n } ;
 
-    OrdSuperl a = {s = table {APred => "am" ++ a.s ! Superl ! APred ++ BIND ++ "en" ;
+    OrdSuperl a = {s = table {APred => "am" ++ a.s ! Superl ! APred ;
                               af => a.s ! Superl ! af}} ;
 
     OrdNumeralSuperl n a =
-      {s = table {APred => "am" ++ n.s ! NOrd APred ++ Predef.BIND
-                           ++ a.s ! Superl ! APred ++ BIND ++ "en" ;      -- am drittbesten
-                  af => n.s ! NOrd APred ++ Predef.BIND ++ a.s ! Superl ! af} -- drittbeste
+      {s = table {APred => "am" ++ n.s ! NOrd APred ++ BIND ++ a.s ! Superl ! APred ; -- am drittbesten
+                  af => n.s ! NOrd APred ++ BIND ++ a.s ! Superl ! af}                -- drittbeste
       } ;
     DefArt = {
       s = \\gn,c => artDef ! gn ! c ;

--- a/src/german/NumeralGer.gf
+++ b/src/german/NumeralGer.gf
@@ -88,7 +88,8 @@ oper
                      NOrd af => d.s ! invNum ++ BIND ++ i'.s ! NOrd af} ;
           n = Pl ;
           isDig = False ;
-          tail1to19 = case i.isDig of {True => notB isPld ; False => i.tail1to19}
+          tail1to19 = case i.isDig of {True => notB isPld ; False => i.tail1to19} ;
+          lock_Digits = <>
       } ;
 
     D_0 = mkDig "0" ** {isZero = True} ;

--- a/src/german/NumeralGer.gf
+++ b/src/german/NumeralGer.gf
@@ -40,22 +40,22 @@ lin
   pot1as2 n = n ;
 
   pot2 d = {s = \\g => 
-    multiple (d.s ! DUnit) d.n ++ cardOrd "hundert" "hunderte" ! g ; n = Pl} ;
+    multiple (d.s ! DUnit) d.n ++ cardOrd "hundert" "hundertste" ! g ; n = Pl} ;
   pot2plus d e = {s = \\g => 
     multiple (d.s ! DUnit) d.n ++ "hundert" ++ BIND ++ e.s ! g ; n = Pl} ;
   pot2as3 n = n ;
 
   pot3 n = {s = \\g => 
-    multiple n.s n.n ++ cardOrd "tausend" "tausendte" ! g ; n = Pl} ; ----
+    multiple n.s n.n ++ cardOrd "tausend" "tausendste" ! g ; n = Pl} ;
   pot3plus n m = {s = \\g => 
     multiple n.s n.n ++ "tausend" ++ m.s ! g ; n = Pl} ;
   pot3as4 n = n ;
   pot3decimal d = {s = \\g =>
-    d.s ! invNum ++ cardOrd "tausend" "tausendte" ! g ; n = Pl} ; ----
+    d.s ! invNum ++ cardOrd "tausend" "tausendste" ! g ; n = Pl} ;
 
   pot4as5 n = n ;
   pot4decimal d = {s = \\g =>
-    d.s ! invNum ++ cardOrd "Millionen" "Millionte" ! g ; n = Pl} ; ----
+    d.s ! invNum ++ cardOrd "Millionen" "Millionste" ! g ; n = Pl} ; -- * 1 Million
 
   pot51 = {s = \\g => "einer Milliarde"; n = Pl} ;  -- KA: case inflection missing
 
@@ -70,15 +70,14 @@ oper
 
   lin
     IDig d = {s = table{NCard g c => d.s ! NCard g c ;
-                        NOrd APred => "am" ++ d.s ! invNum ++ BIND ++ "ten";
                         NOrd amod  => d.s ! NOrd amod} ;
               n = d.n ;
               isDig = True ;
               tail1to19 = notB d.isZero} ;
 
-    -- HL 11/2023 added case endings or ordinals to digits
+    -- HL 11/2023 added case endings of ordinals to digits
     -- NCard Masc Nom (= invNum):       0,1,     19,    20,21,...
-    -- NOrd (AMid (GSg Masc) Nom): 0ter,1ter,...,19ter, 20ster,21ster,...,99ster, 100ster
+    -- NOrd (AMod (GSg Masc) Nom): 0ter,1ter,...,19ter, 20ster,21ster,...,99ster, 100ster
     --                                101ter,...,119ter,120ster,...             , 200ster
     IIDig d i =
       let isPld : Bool = case d.n of {Sg => False ; _ => True} ;
@@ -86,15 +85,14 @@ oper
           i' : Digits = case b of {True => IDig (mkDig (i.s ! invNum ++ BIND ++ "s")) ;
                                    _  => i }
       in {s = table {NCard g c => d.s ! invNum ++ BIND ++ i.s ! NCard g c ;
-                     NOrd APred => "am" ++ d.s ! invNum ++ BIND ++ i'.s ! invNum ++ BIND ++ "ten" ;
                      NOrd af => d.s ! invNum ++ BIND ++ i'.s ! NOrd af} ;
           n = Pl ;
           isDig = False ;
           tail1to19 = case i.isDig of {True => notB isPld ; False => i.tail1to19}
       } ;
 
-    D_0 = mk2Dig "0" Sg ** {isZero = True} ;
-    D_1 = mk2Dig "1" Sg ;
+    D_0 = mkDig "0" ** {isZero = True} ;
+    D_1 = mk2Dig "1" ; -- with cardinal inflection and number Sg
     D_2 = mkDig "2" ;
     D_3 = mkDig "3" ;
     D_4 = mkDig "4" ;
@@ -106,30 +104,33 @@ oper
 
     PosDecimal d = d ** {hasDot=False} ;
     NegDecimal d = {
-      s = \\o => case o of {
-        NOrd APred => "am" ++ "-" ++ BIND ++ d.s ! NOrd (AMod GPl Dat) ;
-        _ => "-" ++ BIND ++ d.s ! o} ;
+      s = \\o => "-" ++ BIND ++ d.s ! o ;
       n = Pl ;
       hasDot=False
     } ;
     IFrac d i = {
-      s=\\o=>d.s ! invNum ++
-             if_then_Str d.hasDot BIND (BIND++"."++BIND) ++
-             i.s ! o;
+      s = \\o => d.s ! invNum ++
+        if_then_Str d.hasDot BIND (BIND ++ "." ++ BIND) ++
+        i.s ! o;
       n = Pl;
       hasDot=True
     } ;
 
   oper
-    mkDig : Str -> TDigit = \c -> mk2Dig c Pl ;
-
-    mk2Dig : Str -> Number -> TDigit = \c,n -> mk3Dig c (c + "t") n ; -- like Duden 464 (4.Auflage)
+    mkDig : Str -> TDigit = \c -> mk3Dig c (c + "t") Pl ; -- like Duden 464 (4.Auflage)
 
     mk3Dig : Str -> Str -> Number -> TDigit = \c,o,n -> {
       s = table {NCard _ _ => c ;                      -- 0,...,9
                  NOrd af => (regA o).s ! Posit ! af} ; -- (ein) 0ter .. 9ter | (der) 0te ... 9te
       n = n ;                                          -- NOrd APred: "0",... or "am 0ten",... ?
       isZero = False
+      } ;
+
+    mk2Dig : Str -> TDigit = \crd ->
+      {s = table {NCard g c => crd ;
+                  NOrd af => (regA (crd + "t")).s ! Posit ! af} ;
+       n = Sg ;
+       isZero = False
       } ;
 
     TDigit = {

--- a/src/german/NumeralGer.gf
+++ b/src/german/NumeralGer.gf
@@ -23,7 +23,8 @@ lin
 
   pot01 = {
     s = \\f => table {
-          NCard g c => "ein" + pronEnding ! GSg g ! c ;
+          NCard (AMod gn c) => "ein" + pronEnding ! gn ! c ;
+          NCard APred => "ein" ;
           NOrd af => (regA "erst").s ! Posit ! af
           } ; 
     n = Sg
@@ -69,8 +70,7 @@ oper
     Dig = TDigit ;
 
   lin
-    IDig d = {s = table{NCard g c => d.s ! NCard g c ;
-                        NOrd amod  => d.s ! NOrd amod} ;
+    IDig d = {s = d.s ;
               n = d.n ;
               isDig = True ;
               tail1to19 = notB d.isZero} ;
@@ -84,7 +84,7 @@ oper
           b : Bool = case i.isDig of {True => isPld ; _ => notB i.tail1to19} ;
           i' : Digits = case b of {True => IDig (mkDig (i.s ! invNum ++ BIND ++ "s")) ;
                                    _  => i }
-      in {s = table {NCard g c => d.s ! invNum ++ BIND ++ i.s ! NCard g c ;
+      in {s = table {NCard af => d.s ! invNum ++ BIND ++ i.s ! NCard af ;
                      NOrd af => d.s ! invNum ++ BIND ++ i'.s ! NOrd af} ;
           n = Pl ;
           isDig = False ;
@@ -120,14 +120,14 @@ oper
     mkDig : Str -> TDigit = \c -> mk3Dig c (c + "t") Pl ; -- like Duden 464 (4.Auflage)
 
     mk3Dig : Str -> Str -> Number -> TDigit = \c,o,n -> {
-      s = table {NCard _ _ => c ;                      -- 0,...,9
+      s = table {NCard _ => c ;                        -- 0,...,9
                  NOrd af => (regA o).s ! Posit ! af} ; -- (ein) 0ter .. 9ter | (der) 0te ... 9te
       n = n ;                                          -- NOrd APred: "0",... or "am 0ten",... ?
       isZero = False
       } ;
 
     mk2Dig : Str -> TDigit = \crd ->
-      {s = table {NCard g c => crd ;
+      {s = table {NCard af => crd ;
                   NOrd af => (regA (crd + "t")).s ! Posit ! af} ;
        n = Sg ;
        isZero = False

--- a/src/german/ParadigmsGer.gf
+++ b/src/german/ParadigmsGer.gf
@@ -579,16 +579,16 @@ mkV2 : overload {
 
   mkPrep = overload {
     mkPrep : Str -> Case -> Prep = \s,c ->
-      {s = \\_ => s ; s2 = [] ; c = c ; isPrep = isPrep ; lock_Prep = <>} ;
+      {s = \\_ => s ; s2 = [] ; c = c ; t = isPrep ; lock_Prep = <>} ;
     mkPrep : Case -> Str -> Prep = \c,s ->
-      {s = \\_ => [] ; s2 = s ; c = c ; isPrep = isPrep ; lock_Prep = <>} ;
+      {s = \\_ => [] ; s2 = s ; c = c ; t = isPrep ; lock_Prep = <>} ;
     mkPrep : Str -> Case -> Str -> Prep = \s,c,t ->
-      {s = \\_ => s ; s2 = t ; c = c ; isPrep = isPrep ; lock_Prep = <>} ;
+      {s = \\_ => s ; s2 = t ; c = c ; t = isPrep ; lock_Prep = <>} ;
     mkPrep : Str -> Str -> Str -> Str -> Case -> Prep = \s,masc,fem,neutr,c ->
       {s = table{GPl => s ; GSg Masc => masc ; GSg Fem => fem ; GSg Neutr => neutr} ;
-       s2 = [] ; c = c ; isPrep = isPrepDefArt ; lock_Prep = <>} ;
+       s2 = [] ; c = c ; t = isPrepDefArt ; lock_Prep = <>} ;
     mkPrep : Case -> Prep = \c ->
-      {s = \\_ => [] ; s2 = [] ; c = c ; isPrep = isCase ; lock_Prep = <>}
+      {s = \\_ => [] ; s2 = [] ; c = c ; t = isCase ; lock_Prep = <>}
     } ;
 
   accPrep = mkPrep accusative ;
@@ -672,7 +672,7 @@ mkV2 : overload {
       = \v,c,d -> lin V3 (v ** {c2 = c ; c3 = d}) ;
     } ;
 
-  dirV3 v p = mkV3 v accPrep p ;        -- accPrep sets isPrep=False
+  dirV3 v p = mkV3 v accPrep p ;        -- accPrep, datPrep have t=isCase
   accdatV3 v = mkV3 v datPrep accPrep ; -- to fit to Eng ditransitives (no preposition): 
                                         -- give sb(indir) sth(dir) = geben jmdm(dat) etwas(acc)
   mkVS v = v ** {lock_VS = <>} ;

--- a/src/german/PhraseGer.gf
+++ b/src/german/PhraseGer.gf
@@ -17,7 +17,7 @@ concrete PhraseGer of Phrase = CatGer ** open Prelude, ResGer in {
     UttVP vp = {s = useInfVP True vp} ;  -- without zu
     UttAdv adv = adv ;
     UttCN n = {s = n.s ! Strong ! Sg ! Nom ++ n.adv ++ n.ext ++ n.rc ! Sg} ;
-    UttCard n = {s = n.s ! Neutr ! Nom} ;
+    UttCard n = {s = n.s ! AMod (GSg Neutr) Nom} ;
     UttAP ap = {s = ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ++ ap.ext} ;
     UttInterj i = i ;
 

--- a/src/german/QuestionGer.gf
+++ b/src/german/QuestionGer.gf
@@ -90,7 +90,7 @@ concrete QuestionGer of Question = CatGer ** open ResGer in {
       let 
         n = num.n
       in {
-      s = \\g,c => idet.s ! n ! g ! c ++ num.s!g!c  ; 
+      s = \\g,c => idet.s ! (gennum g n) ! c ++ num.s ! AMod (gennum g n) c ;
       n = n
       } ;
 

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -319,8 +319,8 @@ resource ResGer = ParamX ** open Prelude in {
     {s = table {
        Posit  => adjForms gut gute ; 
        Compar => adjForms besser besser ; 
-       Superl => adjForms best best -- HL 12/2023: build ("am" ++ besten) via (OrdSuperl a)
-       }                            -- to get zweitbeste, am zweitbesten; *zweit am besten
+       Superl => adjForms besten best -- HL 12/2023: build ("am" ++ besten) via (OrdSuperl a)
+       }                              -- to get zweitbeste, am zweitbesten; *zweit am besten
     } ;
 
 -- Verbs need as many as 12 forms, to cover the variations with

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -28,7 +28,7 @@ resource ResGer = ParamX ** open Prelude in {
 
 -- Complex $CN$s, like adjectives, have strong and weak forms.
 
-    Adjf = Strong | Weak ;
+    Adjf = Strong | Weak | Mixed | MixedStrong ;
 
 -- Gender distinctions are only made in the singular. 
 
@@ -74,6 +74,10 @@ resource ResGer = ParamX ** open Prelude in {
 -- and possessive forms.
 
   param NPForm = NPCase Case | NPPoss GenNum Case ;
+
+-- Possessive pronouns have special forms for stand-alone usage as NP (mein.sp = meiner).
+
+  param PossForm = PossF GenNum Case ;
 
 -- Predeterminers sometimes require a case ("ausser mir"), sometimes not ("nur ich").
 -- A number is sometimes inherited ("alle Menschen"), sometimes forced ("jeder von
@@ -147,7 +151,7 @@ resource ResGer = ParamX ** open Prelude in {
 
 --2 For $Numeral$
 
-    CardOrd = NCard Gender Case | NOrd AForm ;
+    CardOrd = NCard AForm | NOrd AForm ;
     DForm = DUnit  | DTeen  | DTen ;
 
 --2 Transformations between parameter types
@@ -166,7 +170,7 @@ resource ResGer = ParamX ** open Prelude in {
         Pl => GPl
         } ;
 
--- Needed in $RelativeGer$.
+-- Needed in $RelativeGer$ and $NounGer$.
 
     numGenNum : GenNum -> Number = \gn -> 
       case gn of {
@@ -174,23 +178,31 @@ resource ResGer = ParamX ** open Prelude in {
         GPl   => Pl
         } ;
 
+    genGenNum : GenNum -> Gender = \gn ->
+      case gn of {GSg g => g ; GPl => Masc} ;
+
 -- Used in $NounGer$.
 
-    agrAdj : Gender -> Adjf -> Number -> Case -> AForm = \g,a,n,c ->
+    agrAdj : Adjf -> GenNum -> Case -> AForm = \a,gn,c ->
       let
-        gn = gennum g n ;
         e  = AMod (GSg Fem) Nom ;
         en = AMod (GSg Masc) Acc ;
       in
       case a of {
         Strong => AMod gn c ;
-        _ => case <gn,c> of {
+        Weak => case <gn,c> of {
           <GSg _,   Nom> => e ;
           <GSg Masc,Acc> => en ;
           <GSg _,   Acc> => e ;
-          _              => en 
-        }
+          _              => en } ;
+        Mixed => case <gn,c> of {
+          <GSg g, Nom|Acc> => AMod gn c ;
+          _ => en } ;
+        MixedStrong => case <gn,c> of {
+          <GSg _, Dat|Gen> => en ;
+          _                => AMod gn c }
       } ;
+
 
 -- This is used twice in NounGer.
 
@@ -437,11 +449,11 @@ resource ResGer = ParamX ** open Prelude in {
     PrepType = isCase | isPrep | isPrepDefArt ;                  -- HL 7/2022
 
   oper
-    Preposition : Type = {s : GenNum => Str ; s2:Str ; c : Case ; isPrep : PrepType} ;
+    Preposition : Type = {s : GenNum => Str ; s2:Str ; c : Case ; t : PrepType} ;
 
-  isaCase : Preposition -> Bool = \p -> case p.isPrep of {isCase => True ; _ => False} ;
-  isaPrep : Preposition -> Bool = \p -> case p.isPrep of {isPrep => True ; _ => False} ;
-  isaPrepDefArt : Preposition -> Bool = \p -> case p.isPrep of {isPrepDefArt => True ; _ => False} ;
+  isaCase : Preposition -> Bool = \p -> case p.t of {isCase => True ; _ => False} ;
+  isaPrep : Preposition -> Bool = \p -> case p.t of {isPrep => True ; _ => False} ;
+  isaPrepDefArt : Preposition -> Bool = \p -> case p.t of {isPrepDefArt => True ; _ => False} ;
 
 -- To apply a preposition to a complement.
 
@@ -452,7 +464,7 @@ resource ResGer = ParamX ** open Prelude in {
     let
       g : Gender = genderAgr np.a ;
       n : Number = numberAgr np.a ;
-      glues = case <prep.isPrep,n> of {<isPrepDefArt,Sg> => True ; _ => False} ;
+      glues = case <prep.t,n> of {<isPrepDefArt,Sg> => True ; _ => False} ;
       nps = np.s ! glues ! prep.c
     in
     case <glues, np.w> of {
@@ -476,19 +488,19 @@ resource ResGer = ParamX ** open Prelude in {
 -- To build a preposition from just a case.  -- HL 9/19: no longer used in RGL
 
   noPreposition : Case -> Preposition = \c -> 
-    {s = \\_ => [] ; s2 = [] ; c = c ; isPrep = isCase} ;
+    {s = \\_ => [] ; s2 = [] ; c = c ; t = isCase} ;
 
 -- To build a preposition from just a case.  -- HL 9/19: moved to mkPrep in ParadigmsGer
 
-  PrepNom : Preposition = {s = \\_ => []; isPrep = isCase ; c = Nom ; s2 = []} ;
+  PrepNom : Preposition = {s = \\_ => [] ; t = isCase ; c = Nom ; s2 = []} ;
 
   vonDat  : Preposition = {s=table{GPl => "von" ; GSg Fem => "von der"; _ => "vom"};
-                           s2=[]; c=Dat; isPrep=isPrepDefArt} ;
+                           s2=[]; c=Dat; t=isPrepDefArt} ;
 
 -- To build passive: accusative object -> nom subject; others -> same case or prep
 
   subjPrep : Preposition -> Preposition = \prep ->
-    case <prep.c,prep.isPrep> of {
+    case <prep.c,prep.t> of {
       <Acc,isCase> => prep ** {c = Nom} ;
       _ => prep
     } ;
@@ -498,7 +510,7 @@ resource ResGer = ParamX ** open Prelude in {
 -- All personal pronouns, except "ihr", conform to the simple pattern $mkPronPers$.
 
    mkPronPers : (x1,_,_,_,x5 : Str) -> Gender -> Number -> Person ->
-                {s : NPForm => Str ; a : Agr} =
+                {s : NPForm => Str ; a : Agr ; sp : PossForm => Str} =
     \ich,mich,mir,meiner,mein,g,n,p -> {
       s = table {
         NPCase c    => caselist ich mich mir meiner ! c ;
@@ -515,13 +527,16 @@ resource ResGer = ParamX ** open Prelude in {
             <g,Sg,P3> => AgSgP3 g ;
             <_,Sg,P1> => AgSgP1 ;
             <_,Sg,P2> => AgSgP2 -- for "man", "Sie", set in StructuralGer  HL
-            }
+        } ;
+      sp = table {PossF (GSg Masc) Nom => mein + "er" ;             -- HL 12/23
+                  PossF (GSg Neutr) (Nom|Acc) => mein + "es" ;
+                  PossF gn c  => mein + (pronEnding ! gn ! c)} ;
       } ;
 
   pronEnding : GenNum => Case => Str = table {
     GSg Masc => caselist ""  "en" "em" "es" ;
     GSg Fem  => caselist "e" "e"  "er" "er" ;
-    GSg Neutr => caselist ""  ""   "em" "es" ;
+    GSg Neutr => caselist ""  ""  "em" "es" ;
     GPl      => caselist "e"  "e" "en" "er"
     } ;
 
@@ -544,16 +559,16 @@ resource ResGer = ParamX ** open Prelude in {
 -- This auxiliary gives the forms in each degree of adjectives. 
 
   adjForms : (x1,x2 : Str) -> AForm => Str = \teuer,teur ->
-   table {
-    APred => teuer ;
-    AMod (GSg Masc) c => 
-      caselist (teur+"er") (teur+"en") (teur+"em") (teur+"en") ! c ;
-    AMod (GSg Fem) c => 
-      caselist (teur+"e") (teur+"e") (teur+"er") (teur+"er") ! c ;
-    AMod (GSg Neutr) c => 
-      caselist (teur+"es") (teur+"es") (teur+"em") (teur+"en") ! c ;
-    AMod GPl c => 
-      caselist (teur+"e") (teur+"e") (teur+"en") (teur+"er") ! c
+    table {
+      APred => teuer ;
+      AMod gn c => teur + adjEnding ! gn ! c  -- Strong Adjf
+    } ;
+
+  adjEnding : GenNum => Case => Str = table {
+    GSg Masc  => caselist "er" "en" "em" "en" ;
+    GSg Fem   => caselist "e"  "e"  "er" "er" ;
+    GSg Neutr => caselist "es" "es" "em" "en" ;
+    GPl       => caselist "e"  "e"  "en" "er"
     } ;
 
   -- for some determiners, Gen form -es rather than -en
@@ -564,6 +579,13 @@ resource ResGer = ParamX ** open Prelude in {
      AMod (GSg Masc| GSg Neutr) Gen => teur + "es" ;
      a => adj ! a
      } ;
+
+  detEnding : GenNum => Case => Str = table {
+    GSg Masc  => caselist "er" "en" "em" "es" ;
+    GSg Fem   => caselist "e"  "e"  "er" "er" ;
+    GSg Neutr => caselist "es" "es" "em" "es" ;
+    GPl       => caselist "e"  "e"  "en" "er"
+    } ;
 
 --------------------------------------------
 --VP CONSTRUCTION
@@ -744,7 +766,7 @@ resource ResGer = ParamX ** open Prelude in {
 
   insertObjNP : NP -> Preposition -> VPSlash -> VPSlash = \np,prep,vp ->
     let obj = appPrepNP prep np ;
-        b : Bool = case prep.isPrep of {isPrep | isPrepDefArt => True ; _ => False} ;
+        b : Bool = case prep.t of {isPrep | isPrepDefArt => True ; _ => False} ;
         w = np.w ;
         c = prep.c
     in insertObj' obj b w c vp ;
@@ -779,7 +801,7 @@ resource ResGer = ParamX ** open Prelude in {
     in vp ** {
       nn = \\a =>
         let vpnn = vp.nn ! a in
-        case prep.isPrep of {
+        case prep.t of {
           isCase => <obj ! a ++ vpnn.p1, vpnn.p2, vpnn.p3, vpnn.p4> ;
           _      => <vpnn.p1, obj ! a ++ vpnn.p2, vpnn.p3, vpnn.p4> }
     } ;

--- a/src/german/ResGer.gf
+++ b/src/german/ResGer.gf
@@ -307,8 +307,8 @@ resource ResGer = ParamX ** open Prelude in {
     {s = table {
        Posit  => adjForms gut gute ; 
        Compar => adjForms besser besser ; 
-       Superl => adjForms ("am" ++ besten) best
-       }
+       Superl => adjForms best best -- HL 12/2023: build ("am" ++ besten) via (OrdSuperl a)
+       }                            -- to get zweitbeste, am zweitbesten; *zweit am besten
     } ;
 
 -- Verbs need as many as 12 forms, to cover the variations with

--- a/src/german/StructuralGer.gf
+++ b/src/german/StructuralGer.gf
@@ -40,7 +40,7 @@ concrete StructuralGer of Structural = CatGer **
   everywhere_Adv = ss "überall" ;
   few_Det = {
     s,sp = \\_,g,c => "wenig" + adjEnding ! (gennum g Pl) ! c ;
-    n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
+    n = Pl ; a = Strong ; isDef = False ; hasDefArt = False} ;
 ----  first_Ord = {s = (regA "erst").s ! Posit} ;
   for_Prep = mkPrep "für" P.accusative ;
   from_Prep = mkPrep "aus" P.dative ;
@@ -59,7 +59,7 @@ concrete StructuralGer of Structural = CatGer **
   less_CAdv = X.mkCAdv "weniger" "als" ;
   many_Det = {
     s,sp = \\_,g,c => "viel" + adjEnding ! (gennum g Pl) ! c ;
-    n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
+    n = Pl ; a = Strong ; isDef = False ; hasDefArt = False} ;
   more_CAdv = X.mkCAdv "mehr" "als" ;
 --  most_Predet = {s = appAdj (regA "meist") ; c = noCase ; a = PAgNone} ;
   most_Predet = {                                                           -- HL 5/2022
@@ -70,8 +70,9 @@ concrete StructuralGer of Structural = CatGer **
     c = {p = [] ; k = PredCase Gen} ;
     a = PAg Pl} ;
   much_Det = {
-    s = \\_,_,_ => "viel" ; sp = \\_,_,_ => "vieles" ;
-    n = Sg ; a = Weak ; isDef = False ; hasDefArt = False} ;
+    s = \\_,g,c => "viel" ;
+    sp = \\_,g,c => "viel" + detEnding ! (gennum g Sg) ! c ;  ---- (GSg _ Sg) ! Gen ?
+    n = Sg ; a = Strong ; isDef = False ; hasDefArt = False} ;
   must_VV = auxVV 
       (mkV 
         "müssen" "muss" "musst" "muss" "müsst" "müss" 
@@ -94,16 +95,16 @@ concrete StructuralGer of Structural = CatGer **
   somebody_NP = nameNounPhrase Masc {s = caselist "jemand" "jemanden" "jemandem" "jemands"} ;
   somePl_Det = {
     s,sp = \\_,g,c => "einig" + adjEnding ! (gennum g Pl) ! c ;
-    n = Pl ; a = Weak ; isDef = True ; hasDefArt = False} ;
+    n = Pl ; a = Strong ; isDef = True ; hasDefArt = False} ;
   someSg_Det = {
-      s = \\_,g,c => "ein" + pronEnding ! GSg g ! c ;  -- ein, eine, ein
-      sp = \\_,g,c => "ein" + detEnding ! GSg g ! c ;  -- einer, eine, eines
-      n = Sg ; a = Strong ; hasNum = True ; isDef = False ; hasDefArt = False
-      } ;
+    s = \\_,g,c => "ein" + pronEnding ! GSg g ! c ;  -- ein, eine, ein
+    sp = \\_,g,c => "ein" + detEnding ! GSg g ! c ;  -- einer, eine, eines
+    n = Sg ; a = Mixed ; isDef = False ; hasDefArt = False
+    } ;
   something_NP = nameNounPhrase Neutr {s = \\_ => "etwas"} ;
   somewhere_Adv = ss "irgendwo" ;
   that_Quant = {
-    s,sp = \\gn,c => "jen" + detEnding ! gn ! c ; a = Weak ; hasDefArt,delCardOne = False} ;
+    s,sp = \\gn,c => "jen" + detEnding ! gn ! c ; a = Weak ; isDefArt,delCardOne = False} ;
 ---b  that_NP = nameNounPhrase Neutr {s = caselist "das" "das" "dem" "dessen"} ; ----
   there_Adv = ss "da" ; --- no variants in the rgl | ss "dort" ;
   there7to_Adv = ss "dahin" ;
@@ -112,7 +113,7 @@ concrete StructuralGer of Structural = CatGer **
 ---b  these_NP = {s = caselist "diese" "diese" "diesen" "dieser" ; a = agrP3 Pl} ;
   they_Pron = mkPronPers "sie" "sie" "ihnen" "ihrer" "ihr" Fem Pl P3 ;
   this_Quant = {
-    s,sp = \\gn,c => "dies" + detEnding ! gn ! c ; a = Weak ; hasDefArt, delCardOne = False} ;
+    s,sp = \\gn,c => "dies" + detEnding ! gn ! c ; a = Weak ; isDefArt, delCardOne = False} ;
 ---b  this_NP = nameNounPhrase Neutr {s = caselist "dies" "dies" "diesem" "dieses"} ; ----
 ---b  those_NP = {s = caselist "jene" "jene" "jenen" "jener" ; a = agrP3 Pl} ;
   through_Prep = mkPrep "durch" P.accusative ;
@@ -150,7 +151,7 @@ concrete StructuralGer of Structural = CatGer **
     s = table {GSg g => \\c => "kein" + pronEnding ! GSg g ! c ;
                GPl   => \\c => "kein" + detEnding ! GPl ! c} ;
     sp = \\gn,c => "kein" + detEnding ! gn ! c ;
-    a = Mixed ; hasDefArt = False ; delCardOne = True} ; -- HL kein+ein(er) => kein(er)
+    a = Mixed ; isDefArt = False ; delCardOne = True} ; -- HL kein+ein(er) => kein(er)
   if_then_Conj = {s1 = "wenn" ; s2 = "dann" ; n = Sg ; lock_Conj = <>} ;
   nobody_NP = 
     nameNounPhrase Masc {s = caselist "niemand" "niemanden" "niemandem" "niemands"} ;

--- a/src/german/StructuralGer.gf
+++ b/src/german/StructuralGer.gf
@@ -33,12 +33,14 @@ concrete StructuralGer of Structural = CatGer **
   during_Prep = mkPrep "während" P.genitive ; --- no variants in the rgl | P.mkPrep P.accusative "über" ; 
   either7or_DConj = sd2 "entweder" "oder" ** {n = Sg} ;
   everybody_NP = nameNounPhrase Masc {s = caselist "jeder" "jeden" "jedem" "jedes"} ;
-  every_Det = let tab = (detUnlikeAdj False Sg "jed").s
-    in {s,sp = asQuant tab ; n = Sg ; a = Weak ; isDef = False ; hasDefArt = False} ;
+  every_Det = {
+    s,sp = \\_,g,c => "jed" + detEnding ! (gennum g Sg) ! c ;
+    n = Sg ; a = Weak ; isDef = False ; hasDefArt = False} ;
   everything_NP = nameNounPhrase Neutr {s = caselist "alles" "alles" "allem" "alles"} ;
   everywhere_Adv = ss "überall" ;
-  few_Det = let tab = (detLikeAdj False Pl "wenig").s
-    in {s,sp = asQuant tab ; n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
+  few_Det = {
+    s,sp = \\_,g,c => "wenig" + adjEnding ! (gennum g Pl) ! c ;
+    n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
 ----  first_Ord = {s = (regA "erst").s ! Posit} ;
   for_Prep = mkPrep "für" P.accusative ;
   from_Prep = mkPrep "aus" P.dative ;
@@ -48,25 +50,27 @@ concrete StructuralGer of Structural = CatGer **
   here_Adv = ss "hier" ;
   how_IAdv = ss "wie" ;
   how8much_IAdv = ss "wieviel" ;
-  how8many_IDet = {s = \\g,c => (detUnlikeAdj False Pl "wie viel").s ! g ! c ; n = Pl} ;
+  how8many_IDet = {s = \\g,c => "wie viel" + detEnding ! (gennum g Pl) ! c ; n = Pl} ;
   if_Subj = ss "wenn" ; --- no variants in the RGL! | ss "falls" ;
   in8front_Prep = mkPrep "vor" P.dative ;
   i_Pron = mkPronPers "ich" "mich" "mir" "meiner" "mein" Masc Sg P1 ;
   in_Prep = P.inDat_Prep ; 
   it_Pron = mkPronPers "es" "es" "ihm" "seiner" "sein"  Neutr Sg P3 ;
   less_CAdv = X.mkCAdv "weniger" "als" ;
-  many_Det = let tab = (detLikeAdj False Pl "viel").s
-    in {s,sp = asQuant tab ; n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
+  many_Det = {
+    s,sp = \\_,g,c => "viel" + adjEnding ! (gennum g Pl) ! c ;
+    n = Pl ; a = Weak ; isDef = False ; hasDefArt = False} ;
   more_CAdv = X.mkCAdv "mehr" "als" ;
 --  most_Predet = {s = appAdj (regA "meist") ; c = noCase ; a = PAgNone} ;
   most_Predet = {                                                           -- HL 5/2022
     s = \\n,g,c => let gn = R.gennum g n ;
                       adj = (P.mkA "viel" "mehr" "meiste").s ! Superl
                    in
-                      R.artDef ! gn ! c ++ adj ! (agrAdj g Weak n c) ;
+                      R.artDef ! gn ! c ++ adj ! (agrAdj Weak gn c) ;
     c = {p = [] ; k = PredCase Gen} ;
     a = PAg Pl} ;
-  much_Det = {s = asQuant (\\_,_ => "viel") ; sp = asQuant (\\_,_ => "vieles") ;
+  much_Det = {
+    s = \\_,_,_ => "viel" ; sp = \\_,_,_ => "vieles" ;
     n = Sg ; a = Weak ; isDef = False ; hasDefArt = False} ;
   must_VV = auxVV 
       (mkV 
@@ -88,21 +92,18 @@ concrete StructuralGer of Structural = CatGer **
   she_Pron = mkPronPers "sie" "sie" "ihr" "ihrer" "ihr" Fem Sg P3 ;
   so_AdA = ss "so" ;
   somebody_NP = nameNounPhrase Masc {s = caselist "jemand" "jemanden" "jemandem" "jemands"} ;
-  somePl_Det = let tab = (detLikeAdj True Pl "einig").s
-    in {s,sp = asQuant tab ; n = Pl ; a = Weak ; isDef = True ; hasDefArt = False} ;
+  somePl_Det = {
+    s,sp = \\_,g,c => "einig" + adjEnding ! (gennum g Pl) ! c ;
+    n = Pl ; a = Weak ; isDef = True ; hasDefArt = False} ;
   someSg_Det = {
-      s,sp = asQuant (\\g,c => "ein" + pronEnding ! GSg g ! c) ;  ---- einer,eines
-      n = Sg ;
-      a = Strong ;
-      hasNum = True ;
-      isDef = False ;
-      hasDefArt = False 
+      s = \\_,g,c => "ein" + pronEnding ! GSg g ! c ;  -- ein, eine, ein
+      sp = \\_,g,c => "ein" + detEnding ! GSg g ! c ;  -- einer, eine, eines
+      n = Sg ; a = Strong ; hasNum = True ; isDef = False ; hasDefArt = False
       } ;
   something_NP = nameNounPhrase Neutr {s = \\_ => "etwas"} ;
   somewhere_Adv = ss "irgendwo" ;
-  that_Quant = let 
-     jener : Number => Gender => Case => Str = \\n => (detUnlikeAdj True n "jen").s in
-     {s,sp = \\_,_ => jener ; a,aPl = Weak ; hasDefArt = False} ;
+  that_Quant = {
+    s,sp = \\gn,c => "jen" + detEnding ! gn ! c ; a = Weak ; hasDefArt,delCardOne = False} ;
 ---b  that_NP = nameNounPhrase Neutr {s = caselist "das" "das" "dem" "dessen"} ; ----
   there_Adv = ss "da" ; --- no variants in the rgl | ss "dort" ;
   there7to_Adv = ss "dahin" ;
@@ -110,9 +111,8 @@ concrete StructuralGer of Structural = CatGer **
   therefore_PConj = ss "deshalb" ;
 ---b  these_NP = {s = caselist "diese" "diese" "diesen" "dieser" ; a = agrP3 Pl} ;
   they_Pron = mkPronPers "sie" "sie" "ihnen" "ihrer" "ihr" Fem Pl P3 ;
-  this_Quant = let 
-     dieser : Number => Gender => Case => Str = \\n => (detUnlikeAdj True n "dies").s in
-     {s,sp = \\_,_ => dieser ; a,aPl = Weak ; hasDefArt = False} ;
+  this_Quant = {
+    s,sp = \\gn,c => "dies" + detEnding ! gn ! c ; a = Weak ; hasDefArt, delCardOne = False} ;
 ---b  this_NP = nameNounPhrase Neutr {s = caselist "dies" "dies" "diesem" "dieses"} ; ----
 ---b  those_NP = {s = caselist "jene" "jene" "jenen" "jener" ; a = agrP3 Pl} ;
   through_Prep = mkPrep "durch" P.accusative ;
@@ -134,8 +134,7 @@ concrete StructuralGer of Structural = CatGer **
   when_IAdv = ss "wann" ;
   when_Subj = ss "wenn" ;
   where_IAdv = ss "wo" ;
-  which_IQuant = {s = \\n,g,c => (detUnlikeAdj True n "welch").s ! g ! c} ;
-
+  which_IQuant = {s = \\gn,c => "welch" + detEnding ! gn ! c} ;
   whoSg_IP = {s = caselist "wer" "wen" "wem" "wessen" ; n = Sg} ;
   whoPl_IP = {s = caselist "wer" "wen" "wem" "wessen" ; n = Sg} ; -- HL 6/2016
   why_IAdv = ss "warum" ;
@@ -147,13 +146,11 @@ concrete StructuralGer of Structural = CatGer **
   yes_Utt = ss "ja" ;
 
   not_Predet = {s = \\_,_,_ => "nicht" ; c = noCase ; a = PAgNone} ;
-  no_Quant = let 
-     keiner : Number => Gender => Case => Str = table {
-       Sg => \\g,c => "kein" + pronEnding ! GSg g ! c ;
-       Pl => (detUnlikeAdj False Pl "kein").s
-       }
-     in 
-     {s,sp = \\_,_ => keiner ; a = Strong ; aPl = Weak ; hasDefArt = False} ;   ---- sp
+  no_Quant = {
+    s = table {GSg g => \\c => "kein" + pronEnding ! GSg g ! c ;
+               GPl   => \\c => "kein" + detEnding ! GPl ! c} ;
+    sp = \\gn,c => "kein" + detEnding ! gn ! c ;
+    a = Mixed ; hasDefArt = False ; delCardOne = True} ; -- HL kein+ein(er) => kein(er)
   if_then_Conj = {s1 = "wenn" ; s2 = "dann" ; n = Sg ; lock_Conj = <>} ;
   nobody_NP = 
     nameNounPhrase Masc {s = caselist "niemand" "niemanden" "niemandem" "niemands"} ;
@@ -171,12 +168,14 @@ concrete StructuralGer of Structural = CatGer **
 
 oper
   asQuant : (Gender => Case => Str) -> (Bool => Gender => Case => Str) =
-    \tab -> \\_,g,c => tab ! g ! c ; 
+    \tab -> \\_,g,c => tab ! g ! c ;
   asNum : (Gender => Case => Str) -> (Gender => Case => {quant,num:Str}) =
     \tab -> \\g,c => {quant = []; num = tab ! g ! c} ;
   pairTable : (Gender => Case => Str) -> (Gender => Case => Str) -> (Gender => Case => {quant,num:Str})
     = \qt,nt -> \\g,c => {quant = qt ! g ! c; num = nt ! g ! c} ;
-  appAdjDegAdjf : Adjective -> Degree -> Adjf -> Number => Gender => Case => Str =
-    \adj,deg,adjf -> \\n,g,c => adj.s ! deg ! (agrAdj g adjf n c) ;
+  appAdjDegAdjf : Adjective -> Degree -> Adjf -> GenNum => Case => Str =
+    \adj,deg,adjf -> \\gn,c => adj.s ! deg ! (agrAdj adjf gn c) ;
 
+  -- (detLikeAdj b n str).s   = \\g,c => str + adjEnding ! (gennum g n) ! c
+  -- (detUnLikeAdj b n str).s = \\g,c => str + detEnding ! (gennum g n) ! c
 }

--- a/src/german/StructuralGer.gf
+++ b/src/german/StructuralGer.gf
@@ -167,8 +167,6 @@ concrete StructuralGer of Structural = CatGer **
   lin language_title_Utt = ss "Deutsch" ;
 
 oper
-  asQuant : (Gender => Case => Str) -> (Bool => Gender => Case => Str) =
-    \tab -> \\_,g,c => tab ! g ! c ;
   asNum : (Gender => Case => Str) -> (Gender => Case => {quant,num:Str}) =
     \tab -> \\g,c => {quant = []; num = tab ! g ! c} ;
   pairTable : (Gender => Case => Str) -> (Gender => Case => Str) -> (Gender => Case => {quant,num:Str})

--- a/src/german/SymbolGer.gf
+++ b/src/german/SymbolGer.gf
@@ -6,32 +6,32 @@ lin
   SymbPN i = {s = \\c => i.s ; g = Neutr ; n = Sg} ; --- c
   IntPN i  = {s = \\c => i.s ; g = Neutr ; n = Sg} ; --- c
   FloatPN i  = {s = \\c => i.s ; g = Neutr ; n = Sg} ; --- c
-  NumPN i  = {s = i.s ! Neutr ; g = Neutr ; n = Sg} ; --- c
+  NumPN i  = {s = \\c => i.s ! APred ; g = Neutr ; n = Sg} ; --- c  -- HL
 
   CNIntNP cn i = {
     s = \\_,c => cn.s ! Weak ! Sg ! Nom ++ i.s ;
     a = agrP3 Sg ;
     w = WLight ;
-    ext,rc = [] -- added
+    ext,rc = []
     } ;
   CNSymbNP det cn xs = let g = cn.g in {
     s = \\b,c => det.s ! b ! g ! c ++ cn.s ! adjfCase det.a c ! det.n ! c ++ xs.s ; 
     a = agrP3 det.n ;
     w = WLight ;
-    ext,rc = [] -- added
+    ext,rc = []
     } ;
   CNNumNP cn i = {
     s = \\b,c => case b of {True => [] ; False => artDef ! (GSg cn.g) ! c}
-                 ++ cn.s ! Weak ! Sg ! Nom ++ i.s ! Neutr ! c ;
+                 ++ cn.s ! Weak ! Sg ! Nom ++ i.s ! AMod (GSg Neutr) c ;
     a = agrgP3 cn.g Sg ;  -- HL 27.9.2023
     w = WDefArt ;         -- im Haus 14
-    ext,rc = [] -- added
+    ext,rc = []
     } ;
 
   SymbS sy = {s = \\_ => sy.s} ;
 
-  SymbNum n = {s = \\_,_ => n.s ; n = Pl ; isNum = True} ;
-  SymbOrd n = {s = \\_   => glue n.s "."} ;
+  SymbNum n = {s = \\_ => n.s ; n = Pl ; isNum = True} ;
+  SymbOrd n = {s = \\_ => glue n.s "."} ;
 
 
 lincat 

--- a/src/german/TerminologyGer.gf
+++ b/src/german/TerminologyGer.gf
@@ -1,7 +1,7 @@
 --# -path=.:../abstract:../common
 
 concrete TerminologyGer of Terminology = CatGer ** open 
-  ResGer,
+  (R = ResGer),
   ParadigmsGer,
   (G = GrammarGer),
   (S = SyntaxGer),
@@ -59,7 +59,7 @@ lin
   superlative_Parameter = mkN "Superlativ" ;
   predicative_Parameter = mkN "Prädikativ" ;
 
-  nounHeading n = ss (n.s ! Sg ! Nom) ;
+  nounHeading n = ss (n.s ! R.Sg ! R.Nom) ;
 
   exampleGr_N = mkN "Beispiel" "Beispiele" neuter ;
 

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -95,7 +95,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
    --     insertObjNP np v.c2 (ComplVV v vp ** {c2 = vp.c2 ; objCtrl = vp.objCtrl}) ;
      let prep = v.c2 ;
          obj = appPrep prep (np.s!False) ; -- simplify: no glueing of prep+DefArt, HL 8/22
-         b : Bool = case prep.isPrep of {isPrep | isPrepDefArt => True ; _ => False} ;
+         b : Bool = case prep.t of {isPrep | isPrepDefArt => True ; _ => False} ;
          c = prep.c ;
          w = np.w ;
          vps = (ComplVV v vp ** {c2 = vp.c2 ; objCtrl = vp.objCtrl})
@@ -132,7 +132,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
     ReflVP vp = insertObjRefl vp ; -- HL, 19/06/2019
 
     PassV2 v = -- acc object -> nom subject; all others: same PCase
-      let c = case <v.c2.c, v.c2.isPrep> of {
+      let c = case <v.c2.c, v.c2.t> of {
             <Acc, isCase> => Nom ; _ => v.c2.c}
       in insertObj (\\_ => v.s ! VPastPart APred) (predV werdenPass) ** { c1 = v.c2 ** {c = c} } ;
 


### PR DESCRIPTION
1. Changed some types .. => Number => Gender => .. to .. => GenNum => to get rid of gender in plural 
2. Reduced the paradigm of Quant and reimplemented DetQuant and DetQuantOrd to handle the dependence on num.isNum there (and add special treatment of num = cardinal 1)
3. Corrected the sp-paradigm and adjective inflection type of several determiners in Structural
4. Increased Extend and use in in AllGer instead of Extra

Some inflection of small cardinals needs to be implemented, e.g. "wir erklaeren euch drei-en die Loesung zwei-er Probleme". So far, Card.s : AForm => Str is used only for cardinal 1, "der ein-e", "mein ein-er" etc.