### PR TITLE
(Ger) AP is now a split phrase with separable comparison NP

### DIFF
--- a/src/german/AdjectiveGer.gf
+++ b/src/german/AdjectiveGer.gf
@@ -3,29 +3,28 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
   flags optimize=all_subs ;
 
   lin
-
     PositA  a = {
       s = a.s ! Posit ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
       } ;
-    ComparA a np =
-      let nps = np.s ! False ! Nom ++ bigNP np
-      in {
-      s = \\af => a.s ! Compar ! af ++ conjThan ++ nps ;
+    ComparA a np = {
+      s = \\af => a.s ! Compar ! af ;
+      s2 = \\c => conjThan ++ np.s ! False ! c ++ np.ext ++ np.rc ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
       } ;
-    CAdvAP ad ap np =
-      let nps = np.s ! False ! Nom ++ bigNP np in
-      ap ** {
-      s = \\af => ad.s ++ ap.s ! af ++ ad.p ++ nps ;
-      isPre = False 
+    CAdvAP adv ap np = ap ** {
+      s = \\af => adv.s ++ ap.s ! af ;
+      s2 = \\c => adv.p ++ np.s ! False ! c ++ np.ext ++ np.rc ;
+      isPre = True -- HL 1/2023
       } ;
     UseComparA a = {
       s = \\af => a.s ! Compar ! af ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
@@ -33,6 +32,7 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
 
     AdjOrd a = {
       s = a.s ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
@@ -41,25 +41,24 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
 -- $SuperlA$ belongs to determiner syntax in $Noun$.
 
     ComplA2 a np =
-      let CExt = case a.c2.t of {
-            isCase => <appPrepNP a.c2 np, []> ;
-	    _ => <[], appPrepNP a.c2 np> }
+      let
+        obj = appPrepNP a.c2 np
       in {
-           s = a.s ! Posit ;
-           isPre = True ;
-           c = CExt ;
-           ext = []
+        s = a.s ! Posit ;
+        s2 = \\_ => [] ;
+        isPre = True ;
+        c = case a.c2.t of {isCase => <obj, []> ; _ => <[], obj>} ;
+        ext = []
       } ;
 
     ReflA2 a = 
       let
-	compl = appPrep a.c2 (reflPron ! agrP3 Sg) ;
-	CExt = case a.c2.t of
-		{isCase => <compl, []> ; _ => <[], compl> }
+	obj = appPrep a.c2 (reflPron ! agrP3 Sg) ;
       in {
         s = a.s ! Posit ;
+        s2 = \\_ => [] ;
         isPre = True ;
-        c = CExt ;
+        c = case a.c2.t of {isCase => <obj, []> ; _ => <[], obj>} ;
         ext = []
       } ;
 
@@ -72,9 +71,12 @@ concrete AdjectiveGer of Adjective = CatGer ** open ResGer, Prelude in {
 
     UseA2 a = {
       s = a.s ! Posit ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
       } ;
+
+    AdvAP ap adv = ap ** {s = \\a => adv.s ++ ap.s ! a} ; -- HL 1/2024
 
 }

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -68,7 +68,8 @@ concrete CatGer of Cat =
     DAP = {s,sp : Gender => Case => Str ; n : Number ; a : Adjf ; isDef,hasDefArt : Bool} ;
 
     Quant = {
-      s,sp : GenNum => Case => Str ;
+      s : Bool => GenNum => Case => Str ; -- True if leading DefArtSg is dropped
+      sp : GenNum => Case => Str ;        --     and contracted with preposition
       a : Adjf ;
       isDefArt : Bool ;
       delCardOne : Bool -- delete following cardinal 1 (IndefArt and no_Quant)

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -45,10 +45,10 @@ concrete CatGer of Cat =
 -- Adjective  (HL 7/23: we need c : Agr => Str * Str to handle reflexive objects, cf ReflA2)
 
     AP = {
-      s : AForm => Str ;
+      s : AForm => Str ; -- (strong) adjective paradigm
       s2 : Case => Str ; -- comparison np, e.g. [s kleineres] (Tier) [s2 als den Hund] HL 1/34
       isPre : Bool ; -- pre-nominal as attribute, e.g. False with sentential complement
-      c: Str * Str ; -- pp,np-complement, e.g. (ich bin) [c1 ihm] treu ; stolz [c2 auf dich]
+      c: Str * Str ; -- np,pp-complement, e.g. (ich bin) [c1 ihm] treu ; stolz [c2 auf dich]
       ext : Str      -- s,inf-complement, (du bist) so klug (gewesen) [ext ihn zu lesen]
       } ;
 

--- a/src/german/CatGer.gf
+++ b/src/german/CatGer.gf
@@ -44,10 +44,13 @@ concrete CatGer of Cat =
 
 -- Adjective  (HL 7/23: we need c : Agr => Str * Str to handle reflexive objects, cf ReflA2)
 
-    AP = {s : AForm => Str ; isPre : Bool ; c: Str * Str ; ext : Str} ; 
-    -- ich bin [c1 ihm] treu 
-	-- du bist so klug gewesen [ext ihn zu lesen]
-	-- ich bin stolz [c2 auf dich]
+    AP = {
+      s : AForm => Str ;
+      s2 : Case => Str ; -- comparison np, e.g. [s kleineres] (Tier) [s2 als den Hund] HL 1/34
+      isPre : Bool ; -- pre-nominal as attribute, e.g. False with sentential complement
+      c: Str * Str ; -- pp,np-complement, e.g. (ich bin) [c1 ihm] treu ; stolz [c2 auf dich]
+      ext : Str      -- s,inf-complement, (du bist) so klug (gewesen) [ext ihn zu lesen]
+      } ;
 
 -- Noun
 
@@ -127,7 +130,7 @@ concrete CatGer of Cat =
     VP = \vp -> useInfVP False vp ;
     VPSlash = \vps -> useInfVP False vps ++ vps.c2.s ! GPl ++ vps.ext;
 
-    AP = \ap -> ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ++ ap.ext ;
+    AP = \ap -> ap.c.p1 ++ ap.s ! APred ++ ap.c.p2 ++ ap.s2 ! Nom ++ ap.ext ;
     A2 = \a2 -> a2.s ! Posit ! APred ++ a2.c2.s ! GPl ;
 
     V, VS, VQ, VA = \v -> useInfVP False (predV v) ;

--- a/src/german/ConjunctionGer.gf
+++ b/src/german/ConjunctionGer.gf
@@ -20,6 +20,7 @@ concrete ConjunctionGer of Conjunction =
          in (conjAgr agr ss.a) }) ;
 
     ConjAP conj ss = conjunctDistrTable AForm conj ss ** {
+      s2 = \\c => [] ; -- comparison np of ap = {s:AForm => Str; s2:Case => Str} HL 1/23
       isPre = ss.isPre ; c = ss.c ; ext = ss.ext} ;
 
     ConjRS conj ss = conjunctDistrTable RelGenNum conj ss ** {
@@ -87,8 +88,8 @@ concrete ConjunctionGer of Conjunction =
     [CN] = {s1,s2 : Adjf => Number => Case => Str ; g : Gender} ;
 
   oper
-    bigAP : AP -> AForm => Str = \ap ->
-		\\a => ap.c.p1 ++ ap.s ! a ++ ap.c.p2 ++ ap.ext;
+    bigAP : AP -> AForm => Str = \ap ->                                         -- HL 1/23: not always ok:
+		\\a => ap.c.p1 ++ ap.s ! a ++ ap.c.p2 ++ ap.ext ++ ap.s2 ! Nom ; -- comparison np in Nom
     bigCN : CN -> Adjf => Number => Case => Str = \cn ->
 		\\a,n,c => cn.s ! a ! n ! c ++ cn.adv ++ cn.ext ++ cn.rc ! n ;
 		

--- a/src/german/ExtendGer.gf
+++ b/src/german/ExtendGer.gf
@@ -164,6 +164,7 @@ concrete ExtendGer of Extend =
       let a = agrP3 Sg in {
         s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3 ++ vp.a2 ++ vp.adj
                     ++ vp.inf.inpl.p2 ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+        s2 = \\_ => [] ;
         isPre = True ;
         c = <[],[]> ;
         ext = vp.ext
@@ -177,6 +178,7 @@ concrete ExtendGer of Extend =
                   ++ vp.a2 ++ agent ++ vp.adj ++ vp.inf.inpl.p2
                   ++ vp.c2.s ! GPl                     -- junk if not TV
                   ++ vp.ext ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = []
@@ -291,6 +293,7 @@ concrete ExtendGer of Extend =
         compl = appPrep adj.c2 (rnp.s ! agrP3 Sg) ; -- we use a fixed agreement
       in {
         s = adj.s ! Posit ;
+        s2 = \\_ => [] ;
         isPre = True ;
         c = case adj.c2.t of {isCase => <compl, []> ; _ => <[], compl>} ;
         ext = rnp.ext ++ rnp.rc

--- a/src/german/ExtendGer.gf
+++ b/src/german/ExtendGer.gf
@@ -26,11 +26,14 @@ concrete ExtendGer of Extend =
     (P = ParadigmsGer) in {
 
   lin
-    GenNP np = {
-      s,sp = \\gn,c => np.s ! False ! Gen ++ np.ext ++ np.rc ;
-      a = Strong ;
-      isDefArt = False ;
-      delCardOne = False
+    GenNP np =
+      let tab : GenNum => Case => Str =
+            \\gn,c => np.s ! False ! Gen ++ np.ext ++ np.rc
+      in {s = \\_ => tab ;
+          sp = tab ;
+          a = Strong ;
+          isDefArt = False ;
+          delCardOne = False
       } ;
 
     EmptyRelSlash slash = {

--- a/src/german/ExtraGer.gf
+++ b/src/german/ExtraGer.gf
@@ -71,6 +71,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
       let a = agrP3 Sg in {
         s = \\af => (vp.nn ! a).p1 ++ (vp.nn ! a).p2 ++ (vp.nn ! a).p3 ++ vp.a2 ++ vp.adj
                     ++ vp.inf.inpl.p2 ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+        s2 = \\_ => [] ;
         isPre = True ;
         c = <[],[]> ;
         ext = vp.ext
@@ -84,6 +85,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
                   ++ vp.a2 ++ agent ++ vp.adj ++ vp.inf.inpl.p2
                   ++ vp.c2.s ! GPl                      -- junk if not TV
                   ++ vp.ext ++ (vp.inf.extr ! a) ++ vp.s.s ! VPastPart af ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       ext = [] 
@@ -230,6 +232,7 @@ concrete ExtraGer of ExtraGerAbs = CatGer **
         compl = appPrep adj.c2 (rnp.s ! agrP3 Sg) ;  -- we use a fixed agreement
       in {
         s = adj.s ! Posit ;
+        s2 = \\_ => [] ;
         isPre = True ;
         c = case adj.c2.t of {isCase => <compl, []> ; _ => <[], compl>} ;
         ext = rnp.ext ++ rnp.rc

--- a/src/german/MakeStructuralGer.gf
+++ b/src/german/MakeStructuralGer.gf
@@ -27,11 +27,13 @@ oper
 
  -- e.g. das selbe
  mmkQuant : Quant -> A -> Quant = \q,a -> q ** {
-   s,sp = \\gn,c => q.s ! gn ! c ++ a.s ! Posit ! agrAdj q.a gn c
+   s = \\b,gn,c => q.s ! b ! gn ! c ++ a.s ! Posit ! agrAdj q.a gn c ;
+   sp = \\gn,c => q.s ! False ! gn ! c ++ a.s ! Posit ! agrAdj q.a gn c
    } ;
  -- e.g. derjenige
  mmbQuant : Quant -> A -> Quant = \q,a -> q ** {
-   s,sp = \\gn,c => q.s ! gn ! c + a.s ! Posit ! agrAdj q.a gn c
+   s = \\b,gn,c => q.s ! b ! gn ! c + a.s ! Posit ! agrAdj q.a gn c ;
+   sp = \\gn,c => q.s ! False ! gn ! c + a.s ! Posit ! agrAdj q.a gn c
    } ;
 
 }

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -71,11 +71,6 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       } ;
 
   oper
-    dropDefArtSg : Number -> Bool -> (GenNum => Case => Str) -> (Bool => GenNum => Case => Str) =
-      \n,isDefArt,qnt -> case <n,isDefArt> of {
-        <Sg,True> => table{True => \\gn,c => [] ; False => qnt} ;
-        _ => \\b => qnt
-      } ;
     einziger : AForm => Str = table{AMod gn c => "einzig" + adjEnding ! gn ! c ; _ => "einziges"} ;
 
   lin
@@ -85,7 +80,6 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
         a = quant.a ;
         d = quant.isDefArt ;
         isCardOne = case n of {Sg => num.isNum ; _ => False} ;
-        qunt : Bool => GenNum => Case => Str = dropDefArtSg n d quant.s ;
         nums : AForm => Str = \\af => case af of {
           AMod (GSg g) c => case <quant.delCardOne,isCardOne> of {
             <True,True> =>  einziger ! af ;  -- (ein,kein) einziger
@@ -94,7 +88,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
           _ => num.s ! APred}
       in {
         s,sp = \\b,g,c => let gn = gennum g n in
-          qunt ! b ! gn ! c ++ nums ! agrAdj a gn c ++ ord.s ! agrAdj a gn c ;
+          quant.s ! b ! gn ! c ++ nums ! agrAdj a gn c ++ ord.s ! agrAdj a gn c ;
         n = n ;
         a = a ;
         isDef = case a of {Strong => False ; _ => True} ;
@@ -107,9 +101,8 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
         a = quant.a ;
         d = quant.isDefArt ;
         isCardOne = case n of {Sg => num.isNum ; _ => False} ;
-        quants = dropDefArtSg n d quant.s ;
         quantsp : Bool => GenNum => Case => Str =
-          dropDefArtSg n d (case num.isNum of {True => quant.s ; False => quant.sp}) ;
+          case num.isNum of {True => quant.s ; False => \\b => quant.sp} ;
         nums : AForm => Str = \\af => case af of {
           AMod (GSg g) c => case <quant.delCardOne,isCardOne> of {
             <True,True> =>  einziger ! af ;  -- (k)ein einziger, drop cardinal "ein" of num
@@ -119,7 +112,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
           APred => num.s ! APred}
       in {
         s = \\b,g,c => let gn = gennum g n in
-          quants ! b ! gn ! c ++ nums ! agrAdj a gn c ;
+          quant.s ! b ! gn ! c ++ nums ! agrAdj a gn c ;
         sp = \\b,g,c => let gn = gennum g n in
           quantsp ! b ! gn ! c ++ nums ! agrAdj a gn c ;
         n = n ;
@@ -129,8 +122,8 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       } ;
 
     PossPron p = {
-      s  = \\gn,c => p.s ! NPPoss gn c ; -- mein (dritter)
-      sp = \\gn,c => p.sp ! PossF gn c ; -- meiner
+      s  = \\_,gn,c => p.s ! NPPoss gn c ; -- mein (dritter)
+      sp = \\gn,c => p.sp ! PossF gn c ;   -- meiner
       a = Mixed ;
       isDefArt = False ;
       delCardOne = False ;
@@ -166,7 +159,7 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
                   af => n.s ! NOrd APred ++ BIND ++ a.s ! Superl ! af}                -- drittbeste
       } ;
     DefArt = {
-      s = \\gn,c => artDef ! gn ! c ;
+      s = \\b,gn,c => case <b,gn> of {<True,GSg _> => [] ; _ => artDef ! gn ! c} ;
       sp = \\gn,c  => case <gn,c> of {
                             <GSg Masc,Gen> => "dessen" ;
                             <GSg Fem, Gen> => "derer" ;
@@ -180,8 +173,8 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       } ;
 
     IndefArt = {
-      s = table {GSg g => \\c => "ein" + pronEnding ! (GSg g) ! c ;
-                 GPl => \\c => []} ;
+      s = \\_ => table {GSg g => \\c => "ein" + pronEnding ! (GSg g) ! c ;
+                        GPl => \\c => []} ;
       sp = table {GSg g => \\c => "ein" + detEnding ! (GSg g) ! c ;
                   GPl => caselist "einige" "einige" "einigen" "einiger"} ;
       a = MixedStrong ; -- Sg Mixed, Pl Strong

--- a/src/german/NounGer.gf
+++ b/src/german/NounGer.gf
@@ -233,10 +233,12 @@ concrete NounGer of Noun = CatGer ** open ResGer, MorphoGer, Prelude in {
       let 
         g = cn.g 
       in cn ** {
-        s = \\a,n,c => 
-               preOrPost ap.isPre
+        s = case ap.isPre of { -- HL 1/2023 False only for ap = SentAP ap' sc
+          True => \\a,n,c =>   -- besserer cn als a.s2 [instead: cn, besser als a.s2,]
                  (ap.c.p1 ++ ap.c.p2 ++ ap.s ! agrAdj a (gennum g n) c)
-                 (cn.s ! a ! n ! c) ++ ap.ext ; -- comparison part of ap HL 11/2023;
+            ++   (cn.s ! a ! n ! c) ++ ap.s2 ! c ++ ap.ext ;
+          False => \\a,n,c => cn.s ! a ! n ! c ++ -- postnominal ap with sc
+            embedInCommas (ap.c.p1 ++ ap.c.p2 ++ ap.s ! APred ++ ap.s2 ! c ++ ap.ext)} ;
         g = g
         } ;
 

--- a/src/german/StructuralGer.gf
+++ b/src/german/StructuralGer.gf
@@ -103,17 +103,18 @@ concrete StructuralGer of Structural = CatGer **
     } ;
   something_NP = nameNounPhrase Neutr {s = \\_ => "etwas"} ;
   somewhere_Adv = ss "irgendwo" ;
-  that_Quant = {
-    s,sp = \\gn,c => "jen" + detEnding ! gn ! c ; a = Weak ; isDefArt,delCardOne = False} ;
+  that_Quant = let jener : GenNum => Case => Str = \\gn,c => "jen" + detEnding ! gn ! c
+    in {s = \\_ => jener ; sp = jener ; a = Weak ; isDefArt,delCardOne = False} ;
 ---b  that_NP = nameNounPhrase Neutr {s = caselist "das" "das" "dem" "dessen"} ; ----
   there_Adv = ss "da" ; --- no variants in the rgl | ss "dort" ;
   there7to_Adv = ss "dahin" ;
   there7from_Adv = ss ["daher"] ;
   therefore_PConj = ss "deshalb" ;
 ---b  these_NP = {s = caselist "diese" "diese" "diesen" "dieser" ; a = agrP3 Pl} ;
+
   they_Pron = mkPronPers "sie" "sie" "ihnen" "ihrer" "ihr" Fem Pl P3 ;
-  this_Quant = {
-    s,sp = \\gn,c => "dies" + detEnding ! gn ! c ; a = Weak ; isDefArt, delCardOne = False} ;
+  this_Quant = let dieser : GenNum => Case => Str = \\gn,c => "dies" + detEnding ! gn ! c
+    in {s = \\_ => dieser ; sp = dieser ; a = Weak ; isDefArt, delCardOne = False} ;
 ---b  this_NP = nameNounPhrase Neutr {s = caselist "dies" "dies" "diesem" "dieses"} ; ----
 ---b  those_NP = {s = caselist "jene" "jene" "jenen" "jener" ; a = agrP3 Pl} ;
   through_Prep = mkPrep "durch" P.accusative ;
@@ -148,8 +149,8 @@ concrete StructuralGer of Structural = CatGer **
 
   not_Predet = {s = \\_,_,_ => "nicht" ; c = noCase ; a = PAgNone} ;
   no_Quant = {
-    s = table {GSg g => \\c => "kein" + pronEnding ! GSg g ! c ;
-               GPl   => \\c => "kein" + detEnding ! GPl ! c} ;
+    s = \\_ => table {GSg g => \\c => "kein" + pronEnding ! GSg g ! c ;
+                      GPl   => \\c => "kein" + detEnding ! GPl ! c} ;
     sp = \\gn,c => "kein" + detEnding ! gn ! c ;
     a = Mixed ; isDefArt = False ; delCardOne = True} ; -- HL kein+ein(er) => kein(er)
   if_then_Conj = {s1 = "wenn" ; s2 = "dann" ; n = Sg ; lock_Conj = <>} ;

--- a/src/german/VerbGer.gf
+++ b/src/german/VerbGer.gf
@@ -37,7 +37,7 @@ concrete VerbGer of Verb = CatGer ** open Prelude, ResGer, Coordination in {
         insertInf inf vps) ** {c2 = v.c2 ; objCtrl = v.objCtrl} ;
 
     SlashV2A v ap =
-      insertAdj (ap.s ! APred) ap.c ap.ext (predV v) ** {c2 = v.c2; objCtrl = False} ;
+      insertAdj (ap.s ! APred ++ ap.s2 ! Nom) ap.c ap.ext (predV v) ** {c2 = v.c2; objCtrl = False} ;
 
     ComplSlash vps np =
       -- IL 24/04/2018 force reflexive in the VPSlash to take the agreement of np.

--- a/tests/german/TestLangGer.gf
+++ b/tests/german/TestLangGer.gf
@@ -69,6 +69,7 @@ concrete TestLangGer of TestLang =
       s = \\af => (vp.nn ! agrP3 Sg).p1 ++ (vp.nn ! agrP3 Sg).p2 ++
         (vp.nn ! agrP3 Sg).p3 ++ (vp.nn ! agrP3 Sg).p4 ++ vp.adj ++ vp.a2 
         ++ vp.inf.inpl.p2 ++ vp.s.s ! VPastPart af ;
+      s2 = \\_ => [] ;
       isPre = True ;
       c = <[],[]> ;
       adj = [] ;
@@ -183,7 +184,7 @@ gr -tr (PredVP (UsePron ?) (ComplSlash (SlashV2V lassen_V2V (ReflVP (SlashV2a wa
       s = \\m,t,a,p => 
             let 
               cls = slash.s ! m ! t ! a ! p ;
-              who = appPrepC slash.c2 ip.s ;
+              who = appPrep slash.c2 ip.s ;
             in table {
               QDir   => who ++ cls ! Inv ! (RGenNum gn);
               QIndir => who ++ cls ! Sub ! (RGenNum gn)
@@ -201,10 +202,10 @@ gr -tr (PredVP (UsePron ?) (ComplSlash (SlashV2V lassen_V2V (ReflVP (SlashV2a wa
       } ;
 
     SlashVS np vs slash =
-      let subj = mkSubj np PrepNom ;
+      let subj = mkSubject np PrepNom ;
           vps = insertExtrapos (conjThat ++ slash.s ! Sub) (predV vs)
                    ** {c2 = slash.c2 ; objCtrl = False}  -- default objCtrl guessed
-      in mkClSlash subj.p1 subj.p2 vps ;
+      in mkClSlash subj.s subj.a vps ;
 
     UseSlash t p cl = {
       s = \\o => t.s ++ p.s ++ cl.s ! t.m ! t.t ! t.a ! p.p ! o ! RSentence ;
@@ -213,9 +214,9 @@ gr -tr (PredVP (UsePron ?) (ComplSlash (SlashV2V lassen_V2V (ReflVP (SlashV2a wa
 
   oper
     gnToAgr : RelGenNum -> Agr = \gn ->
-       case gn of {RGenNum (GSg g) => Ag g Sg P3 ;
-                   RGenNum GPl     => Ag Neutr Pl P3 ;
-                   RSentence       => Ag Neutr Sg P3} ;
+       case gn of {RGenNum (GSg g) => AgSgP3 g ;
+                   RGenNum GPl     => AgPl P3 ;
+                   RSentence       => AgSgP3 Neutr} ;
 
 
     mkClSlash : Str -> Agr -> ResGer.VPSlash -> ClauseSlash = \subj,agr,vp ->
@@ -227,7 +228,8 @@ gr -tr (PredVP (UsePron ?) (ComplSlash (SlashV2V lassen_V2V (ReflVP (SlashV2a wa
             Sub => True ;  -- glue prefix to verb
             _ => False
             } ;
-          verb  = vps.s  ! ord ! agr ! VPFinite m t a ;
+          vagr = agr2vagr agr ;
+          verb  = vps.s  ! ord ! vagr ! VPFinite m t a ;
           haben = verb.inf2 ;
           neg = negation ! b ;
           ag : Agr = case vp.objCtrl of {True => gnToAgr gn ; _ => agr} ;

--- a/tests/german/TestLexiconEng.gf
+++ b/tests/german/TestLexiconEng.gf
@@ -51,8 +51,6 @@ lin
   kaufen_bei_fuer_V4 = dirV4 (irregV "buy" "bought" "bought") (mkPrep "from") (mkPrep "for") ;
   mieten_von_fuer_V4 = dirV4 (regV "rent") (mkPrep "from") (mkPrep "for") ;
 
-  neugierig_auf_A2 = mkA2 (regA "curious") (mkPrep "about") ;
-
   wagen_VV = mkVV (regV "dare") ;                       -- typ=VVInf
   versuchen_VV = mkVV (irregV "try" "tried" "tried") ;  -- typ=VVInf
   helfen_V2V = defaultV2V (regV "help") ;
@@ -62,4 +60,10 @@ lin
   -- aci verb:
   sehen_V2V  = mkV2V (I.see_V) ;
   hoeren_V2V = mkV2V (I.hear_V) ;
+
+  -- Adjectives
+
+  neugierig_auf_A2 = mkA2 (regA "curious") (mkPrep "about") ;
+  treu_A2 = mkA2 (compoundA (mkA "faithful")) (mkPrep "to") ;
+  stolz_A2 = mkA2 (mkA "proud" "prouder") (mkPrep "of") ;
 }

--- a/tests/german/TestLexiconGer.gf
+++ b/tests/german/TestLexiconGer.gf
@@ -55,8 +55,6 @@ lin
   kaufen_bei_fuer_V4 = dirV4 (regV "kaufen") bei_Prep fuer_Prep ;
   mieten_von_fuer_V4 = dirV4 (regV "mieten") von_Prep fuer_Prep ;
 
-  neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
-  
   -- verbs with infinitival object (non-modal):
   wagen_VV = mkVV (regV "wagen")  ;
   versuchen_VV = mkVV (irregV "versuchen" "versucht" "versuchte" "versuchte" "versucht") ;
@@ -72,4 +70,11 @@ lin
   -- aci verb:
   sehen_V2V  = auxV2V (irregV "sehen" "sieht" "sah" "sähe" "gesehen") accPrep ;
   hoeren_V2V = auxV2V (regV "hören") accPrep ;
+
+  -- Adjectives
+
+  neugierig_auf_A2 = mkA2 (mk3A "neugierig" "neugieriger" "neugierigste") (mkPrep "auf" accusative) ;
+  treu_A2 = mkA2 (mk3A "treu" "treuer" "treueste") datPrep ;
+  stolz_A2 = mkA2 (mk3A "stolz" "stolzer" "stolzeste") (mkPrep "auf" accusative) ;
+
 }

--- a/tests/german/TestLexiconGerAbs.gf
+++ b/tests/german/TestLexiconGerAbs.gf
@@ -24,8 +24,6 @@ fun
   entschuldigen_bei_fuer_rV3 : V3 ;
   raechen_am_fuer_rV3 : V3 ;
 
-  neugierig_auf_A2 : A2 ;
-
   wagen_VV : VV ;
   versuchen_VV : VV ;
 
@@ -42,5 +40,11 @@ cat
 fun
   kaufen_bei_fuer_V4 : V4 ;
   mieten_von_fuer_V4 : V4 ;
+
+  -- Adjectives
+
+  neugierig_auf_A2 : A2 ;
+  treu_A2 : A2 ;  -- Ger: dative complement
+  stolz_A2 : A2 ;
 
 }


### PR DESCRIPTION
In German, an attributive AP is wrapped around a N : the adjective precedes, but the comparison NP follows the N:

- (ein) ebenso grosses (Tier) wie dieser Hund   [an animal as big as this dog]
- (ein) kleineres (Tier) als dieser Hund                [an animal smaller than this dog]

Attributive AP containing a sentential complement are post-nominal (uninflected) modifiers:

- (ein) Student, froh [darüber], das Examen bestanden zu haben, [a student glad to have passed the exam]
- instead of:  (ein) [darüber,] das Examen bestanden zu haben, froher Student

I also changed Quant to remove a recently used bug that raised a metavariable when parsing contracted defArt+pronoun