### PR TITLE
Fix AdjCN to include comparative NP (ComparA)

### DIFF
--- a/src/somali/NounSom.gf
+++ b/src/somali/NounSom.gf
@@ -250,7 +250,7 @@ concrete NounSom of Noun = CatSom ** open ResSom, Prelude in {
     mod = \\st,n,c =>
             cn.mod ! st ! n ! Abs -- If there was something before, it is now in Abs
          ++ andConj st cn.modtype -- If the sentence is already modified, any new modifier needs to be introduced with conjunction
-         ++ ap.s ! AF n c ;
+         ++ ap.s ! AF n c ++ " " ++ ap.compar ;
     modtype = AMod
     } ;
 

--- a/src/somali/unittest/ap.gftest
+++ b/src/somali/unittest/ap.gftest
@@ -23,6 +23,10 @@ Lang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQ
 LangSom: bisad BIND daasi bisad BIND dan waa ka weyn tahay
 Lang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant that_Quant NumSg) (UseN cat_N)) (UseComp (CompAP (ComparA big_A (DetCN (DetQuant this_Quant NumSg) (UseN cat_N)))))))) NoVoc
 
+-- LangEng: house bigger than car
+LangSom: guri ka weyn baabuur
+Lang: PhrUtt NoPConj (UttNP (AdjCN (ComparA big_A (MassNP (UseN car_N))) (UseN house_N))) NoVoc
+
 -- LangEng: that cat is biggest
 LangSom: bisad BIND daasi waa ugu weyn tahay
 Lang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQuant that_Quant NumSg) (UseN cat_N)) (UseComp (CompAP (AdjOrd (OrdSuperl big_A))))))) NoVoc


### PR DESCRIPTION
AdjCN currently ignores the 'compar' field from AP, causing the NP in comparative constructions (ComparA) to be dropped.

Example:
- Expected: "guri ka weyn baabuur"
- Actual:   "guri ka weyn"

This change appends ap.compar in AdjCN, preserving the comparison NP.

A corresponding test has been added to src/somali/unittest/ap.gftest.