### PR TITLE
(Som) Add full forms of the pronoun into the s field in UsePron…

### DIFF
--- a/src/somali/NounSom.gf
+++ b/src/somali/NounSom.gf
@@ -64,7 +64,10 @@ concrete NounSom of Noun = CatSom ** open ResSom, Prelude in {
     } ;
 
   -- : Pron -> NP ;
-  UsePron pron = pron ** {st = Definite} ;
+  UsePron pron = pron ** {
+    s = pron.sp ;
+    st = Definite
+    } ;
 
   -- : Predet -> NP -> NP ; -- only the man
   PredetNP predet np =

--- a/src/somali/unittest/ap.gftest
+++ b/src/somali/unittest/ap.gftest
@@ -25,7 +25,15 @@ Lang: PhrUtt NoPConj (UttS (UseCl (TTAnt TPres ASimul) PPos (PredVP (DetCN (DetQ
 
 -- LangEng: house bigger than car
 LangSom: guri ka weyn baabuur
-Lang: PhrUtt NoPConj (UttNP (AdjCN (ComparA big_A (MassNP (UseN car_N))) (UseN house_N))) NoVoc
+Lang: PhrUtt NoPConj (UttCN (AdjCN (ComparA big_A (MassNP (UseN car_N))) (UseN house_N))) NoVoc
+
+-- LangEng: house bigger than he
+Lang> l PhrUtt NoPConj (UttCN (AdjCN (ComparA big_A (UsePron he_Pron)) (UseN house_N))) NoVoc
+guri ka weyn isaga
+
+-- LangEng: house bigger than I
+Lang> l PhrUtt NoPConj (UttCN (AdjCN (ComparA big_A (UsePron i_Pron)) (UseN house_N))) NoVoc
+guri ka weyn aniga
 
 -- LangEng: that cat is biggest
 LangSom: bisad BIND daasi waa ugu weyn tahay


### PR DESCRIPTION
Fixes the same issue as #468 but more generally.

This is the intended behaviour for ComparA, but how about ComplN2?

```haskell
Lang> l -bind ComplN2 father_N2 (UsePron she_Pron)
iyada aabbeheed
```
Is this correct? (If word order is wrong we can always fix that!)

(The clitic forms used in VPs and Cls are syncategorematic, so those constructions did not break. It's still "waan ku arkay", not "iyada waan ku arkay".)

Future work: determine rules for stuff like

> **After prepositions**
> 
> isaga la jooga → with him
> iyada u keen → bring it to her
> aniga ka fog → far from me
> iyaga dhexdooda → between them
> 
> **Adjective complements / fixed expressions**
> 
> la mid ah isaga → similar to him
> ka duwan iyaga → different from them
> u dhow aniga → close to me
>